### PR TITLE
Dogun mossk rework

### DIFF
--- a/TGX Files/Data/ModInfo.ini
+++ b/TGX Files/Data/ModInfo.ini
@@ -1,6 +1,6 @@
 [ModInfo]
 TwoCharacterIdentifier=KG
-Version=0.3.0
+Version=0.3.1
 Author=KohanCitadel
 Author_www=https://discord.gg/U4K4vPS
 Author_email=

--- a/TGX Files/Data/ObjectData/Heroes/DOGUN_MOSSK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DOGUN_MOSSK.INI
@@ -4,7 +4,7 @@ Class                                                   =   2
 Sprite                                                  =   units\Engineer.tgr
 BoundingRadius                                          =   0.25
 RotTime                                                 =   30
-MaxHitPoints                                            =   600
+MaxHitPoints                                            =   625
 CostGold                                                =   0
 BuildTime                                               =   5
 DetectionRadius                                         =   100
@@ -53,7 +53,7 @@ DamagePoint                                             =   0.7
 ReloadTime                                              =   0
 AttackRange                                             =   .75
 AttackType                                              =   BUILD
-Damage                                                  =   5
+Damage                                                  =   8
 
 [ElementBonus]
 DAMAGE_TAKEN_FROM_RANGED                                =   .5
@@ -74,7 +74,7 @@ Defense                                                 =   11
 Damage                                                  =   50
 
 [Attack1Data1]
-Damage                                                  =   7
+Damage                                                  =   12
 
 [ElementBonus1]
 DAMAGE_TAKEN_FROM_RANGED                                =   .5
@@ -84,6 +84,7 @@ ATTACK_BONUS_TO_BUILDING                                =   8
 ENTRENCHMENT_RATE_BONUS                                 =   .6
 VISUAL_RANGE_BONUS                                      =   1.3
 ZONE_OF_CONTROL_BONUS                                   =   1.2
+MORALE_CHECK_BONUS                                      =   2
 
 [Level2]
 MaxHitPoints                                            =   1100
@@ -93,7 +94,7 @@ Defense                                                 =   12
 Damage                                                  =   54
 
 [Attack1Data2]
-Damage                                                  =   9
+Damage                                                  =   17
 
 [ElementBonus2]
 DAMAGE_TAKEN_FROM_RANGED                                =   .5
@@ -103,7 +104,7 @@ ATTACK_BONUS_TO_BUILDING                                =   10
 ENTRENCHMENT_RATE_BONUS                                 =   .5
 VISUAL_RANGE_BONUS                                      =   1.35
 ZONE_OF_CONTROL_BONUS                                   =   1.3
-MORALE_CHECK_BONUS                                      =   2
+MORALE_CHECK_BONUS                                      =   3
 
 [Level3]
 MaxHitPoints                                            =   1325
@@ -114,17 +115,17 @@ Damage                                                  =   60
 DamageType                                              =   Khaldunite
 
 [Attack1Data3]
-Damage                                                  =   10
+Damage                                                  =   20
 
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_RANGED                                =   .5
 
 [SupportBonus3]
 ATTACK_BONUS_TO_BUILDING                                =   12
-ENTRENCHMENT_RATE_BONUS                                 =   .6
+ENTRENCHMENT_RATE_BONUS                                 =   .5
 VISUAL_RANGE_BONUS                                      =   1.4
 ZONE_OF_CONTROL_BONUS                                   =   1.3
-MORALE_CHECK_BONUS                                      =   3
+MORALE_CHECK_BONUS                                      =   4
 
 [HeroData]
 AwakenCost                                              =   50

--- a/TGX Files/Data/ObjectData/Heroes/DOGUN_MOSSK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DOGUN_MOSSK.INI
@@ -18,10 +18,12 @@ Land                                                    =   1
 Water                                                   =   0
 
 DeathSound1                                             =   Game\engineer_death.wav
-SelectionSound1                                         =   Game\m_hero4_select1.wav
-SelectionSound2                                         =   Game\m_hero4_select_good.wav
-CommandSound1                                           =   Game\m_hero4_command1.wav
-CommandSound2                                           =   Game\m_hero4_command_good.wav
+SelectionSound1                                         =   Game\agm_hero4_select1.wav
+SelectionSound2                                         =   Game\agm_hero4_select2.wav
+SelectionSound3                                         =   Game\agm_hero4_select3.wav
+CommandSound1                                           =   Game\agm_hero4_command1.wav
+CommandSound2                                           =   Game\agm_hero4_command2.wav
+CommandSound3                                           =   Game\agm_hero4_command3.wav
 
 [UnitData]
 Type                                                    =   HERO


### PR DESCRIPTION
Changes had already been largely implemented in the initial files put into the repository, but there were a few touch-ups needed. Note this is not his full stat sheet, just the things that were changed. To see his full stat sheet, go have a look on the discord forum.

### **Changes from 1.3.10:**

Dogun's voiceset changed from m_hero4 to agm_hero4.
Dogun now builds when on settler or engineer companies.

### Awakened:
HP increased from 550 to 625
DV increased from 8 to 10
AV increased from 44 to 46
Build Speed increased from 5 to 8

Entrenchment bonus increased from 80% to 75% (Provided)
Visual range bonus increased from 110% to 120% (Provided)
Added Dominion 110% (Provided)

### Enlightened:
DV increased from 9 to 11
Build Speed increased from 7 to 12

Siege bonus reduced from 10 to 8 (Provided)
Entrenchment bonus increased from 80% to 60% (Provided)
Visual Range bonus increased from 115% to 130% (Provided)
Added Dominion 120% (Provided)
Added Valor 2 (Provided)

### Restored:
DV increased from 10 to 12
AV decreased from 58 to 54
Build Speed increased from 9 to 17

Siege bonus reduced from 14 to 10 (Provided)
Entrenchment bonus increased from 70% to 50% (Provided)
Visual Range bonus increased from 120% to 135% (Provided)
Added Dominion 130% (Provided)
Added Valor 3 (Provided)

### Ascended:
HP decreased from 1375 to 1325
DV increased from 11 to 14
AV increased from 58 to 60 (Khaldunite damage type)
Build Speed increased from 10 to 20

Siege bonus reduced from 20 to 12 (Provided)
Entrenchment bonus increased from 60% to 50% (Provided)
Visual Range bonus increased from 125% to 140% (Provided)
Added Dominion 130% (Provided)
Added Valor 4 (Provided)
