### PR TITLE
Maghnus rework

### DIFF
--- a/TGX Files/Data/ModInfo.ini
+++ b/TGX Files/Data/ModInfo.ini
@@ -1,6 +1,6 @@
 [ModInfo]
 TwoCharacterIdentifier=KG
-Version=0.3.1
+Version=0.3.2
 Author=KohanCitadel
 Author_www=https://discord.gg/U4K4vPS
 Author_email=

--- a/TGX Files/Data/ModInfo.ini
+++ b/TGX Files/Data/ModInfo.ini
@@ -1,6 +1,6 @@
 [ModInfo]
 TwoCharacterIdentifier=KG
-Version=0.3.0
+Version=0.3.1
 Author=KohanCitadel
 Author_www=https://discord.gg/U4K4vPS
 Author_email=

--- a/TGX Files/Data/ObjectData/Heroes/DOGUN_MOSSK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DOGUN_MOSSK.INI
@@ -4,7 +4,7 @@ Class                                                   =   2
 Sprite                                                  =   units\Engineer.tgr
 BoundingRadius                                          =   0.25
 RotTime                                                 =   30
-MaxHitPoints                                            =   600
+MaxHitPoints                                            =   625
 CostGold                                                =   0
 BuildTime                                               =   5
 DetectionRadius                                         =   100
@@ -53,7 +53,7 @@ DamagePoint                                             =   0.7
 ReloadTime                                              =   0
 AttackRange                                             =   .75
 AttackType                                              =   BUILD
-Damage                                                  =   5
+Damage                                                  =   8
 
 [ElementBonus]
 DAMAGE_TAKEN_FROM_RANGED                                =   .5
@@ -74,7 +74,7 @@ Defense                                                 =   11
 Damage                                                  =   50
 
 [Attack1Data1]
-Damage                                                  =   7
+Damage                                                  =   12
 
 [ElementBonus1]
 DAMAGE_TAKEN_FROM_RANGED                                =   .5
@@ -84,6 +84,7 @@ ATTACK_BONUS_TO_BUILDING                                =   8
 ENTRENCHMENT_RATE_BONUS                                 =   .6
 VISUAL_RANGE_BONUS                                      =   1.3
 ZONE_OF_CONTROL_BONUS                                   =   1.2
+MORALE_CHECK_BONUS                                      =   2
 
 [Level2]
 MaxHitPoints                                            =   1100
@@ -93,7 +94,7 @@ Defense                                                 =   12
 Damage                                                  =   54
 
 [Attack1Data2]
-Damage                                                  =   9
+Damage                                                  =   17
 
 [ElementBonus2]
 DAMAGE_TAKEN_FROM_RANGED                                =   .5
@@ -103,7 +104,7 @@ ATTACK_BONUS_TO_BUILDING                                =   10
 ENTRENCHMENT_RATE_BONUS                                 =   .5
 VISUAL_RANGE_BONUS                                      =   1.35
 ZONE_OF_CONTROL_BONUS                                   =   1.3
-MORALE_CHECK_BONUS                                      =   2
+MORALE_CHECK_BONUS                                      =   3
 
 [Level3]
 MaxHitPoints                                            =   1325
@@ -114,17 +115,17 @@ Damage                                                  =   60
 DamageType                                              =   Khaldunite
 
 [Attack1Data3]
-Damage                                                  =   10
+Damage                                                  =   20
 
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_RANGED                                =   .5
 
 [SupportBonus3]
 ATTACK_BONUS_TO_BUILDING                                =   12
-ENTRENCHMENT_RATE_BONUS                                 =   .6
+ENTRENCHMENT_RATE_BONUS                                 =   .5
 VISUAL_RANGE_BONUS                                      =   1.4
 ZONE_OF_CONTROL_BONUS                                   =   1.3
-MORALE_CHECK_BONUS                                      =   3
+MORALE_CHECK_BONUS                                      =   4
 
 [HeroData]
 AwakenCost                                              =   50

--- a/TGX Files/Data/ObjectData/Heroes/DOGUN_MOSSK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DOGUN_MOSSK.INI
@@ -18,10 +18,12 @@ Land                                                    =   1
 Water                                                   =   0
 
 DeathSound1                                             =   Game\engineer_death.wav
-SelectionSound1                                         =   Game\m_hero4_select1.wav
-SelectionSound2                                         =   Game\m_hero4_select_good.wav
-CommandSound1                                           =   Game\m_hero4_command1.wav
-CommandSound2                                           =   Game\m_hero4_command_good.wav
+SelectionSound1                                         =   Game\agm_hero4_select1.wav
+SelectionSound2                                         =   Game\agm_hero4_select2.wav
+SelectionSound3                                         =   Game\agm_hero4_select3.wav
+CommandSound1                                           =   Game\agm_hero4_command1.wav
+CommandSound2                                           =   Game\agm_hero4_command2.wav
+CommandSound3                                           =   Game\agm_hero4_command3.wav
 
 [UnitData]
 Type                                                    =   HERO

--- a/TGX Files/Data/ObjectData/Heroes/MAGHNUS.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MAGHNUS.INI
@@ -8,7 +8,7 @@ MaxHitPoints            =   560
 CostGold                =   0
 BuildTime               =   5
 DetectionRadius         =   100
-Defense                 =   10
+Defense                 =   8
 Faction                 =   Ceyah
 
 Moveable                =   1
@@ -45,7 +45,7 @@ DamagePoint             =   0.5
 ReloadTime              =   0.5
 AttackRange             =   0.75
 AttackType              =   MELEE
-Damage                  =   38
+Damage                  =   50
 DamageType              =   NORMAL
 
 [Attack2]
@@ -55,66 +55,72 @@ DamagePoint             =   0.7
 ReloadTime              =   0
 AttackRange             =   .75
 AttackType              =   BUILD
-Damage                  =   4
+Damage                  =   7
 
 [ElementBonus]
-ATTACK_BONUS_TO_BUILDING    =   4
+ATTACK_BONUS_TO_BUILDING    =   16
 DAMAGE_TAKEN_FROM_RANGED    =   .5
 
 [SupportBonus]
-ATTACK_BONUS_TO_BUILDING    =   2
+ATTACK_BONUS_TO_BUILDING    =   4
 ENTRENCHMENT_RATE_BONUS     =   .8
+MORALE_BONUS                =   2
 
 [Level1]
 MaxHitPoints            =   730
 
 [Attack0Data1]
-Damage                  =   44
+Damage                  =   54
 
 [Attack1Data1]
-Damage                  =   6
+Damage                  =   11
 
 [ElementBonus1]
-ATTACK_BONUS_TO_BUILDING    =   8
+ATTACK_BONUS_TO_BUILDING    =   24
 DAMAGE_TAKEN_FROM_RANGED    =   .5
 
 [SupportBonus1]
-ATTACK_BONUS_TO_BUILDING    =   4
-ENTRENCHMENT_RATE_BONUS     =   .7
+ATTACK_BONUS_TO_BUILDING    =   6
+ENTRENCHMENT_RATE_BONUS     =   .75
+MORALE_BONUS                =   2
 
 [Level2]
 MaxHitPoints            =   920
-Defense                 =   12
+Defense                 =   10
 
 [Attack0Data2]
-Damage                  =   50
+Damage                  =   58
 
 [Attack1Data2]
-Damage                  =   8
+Damage                  =   15
 
 [ElementBonus2]
-ATTACK_BONUS_TO_BUILDING    =   14
+ATTACK_BONUS_TO_BUILDING    =   32
 DAMAGE_TAKEN_FROM_RANGED    =   .5
 
 [SupportBonus2]
-ATTACK_BONUS_TO_BUILDING    =   6
+ATTACK_BONUS_TO_BUILDING    =   8
 ENTRENCHMENT_RATE_BONUS     =   .6
+MORALE_BONUS                =   4
 
 [Level3]
 MaxHitPoints            =   1140
+Defense                 =   12
 
 [Attack0Data3]
+Damage                  =   64
 
 [Attack1Data3]
-Damage                  =   10
+Damage                  =   18
 
 [ElementBonus3]
-ATTACK_BONUS_TO_BUILDING    =   22
+ATTACK_BONUS_TO_BUILDING    =   40
 DAMAGE_TAKEN_FROM_RANGED    =   .5
 
 [SupportBonus3]
-ATTACK_BONUS_TO_BUILDING    =   8
-ENTRENCHMENT_RATE_BONUS     =   .5
+ATTACK_BONUS_TO_BUILDING    =   10
+ENTRENCHMENT_RATE_BONUS     =   .6
+MORALE_BONUS                =   6
 
 [HeroData]
 AwakenCost              =   50


### PR DESCRIPTION
Rework of Maghnus. The changes make him a more offensive focused character, and he is hands down the best Kohan in the game at damaging buildings. He does not scale well defensively however, and is a bit of a glass cannon. He is also the worst builder of the three engineer Kohan, and will only lend his expertise to constructing fortifications, not homes.

Note these are the CHANGES and not the FULL STAT SHEET. Please see the Discord if you want to see his final stat sheet. Anything that has not been changed is not included here.

### **Changelog:**
Maghnus now builds alongside engineer companies.

### Awakened:
DV decreased from 10 to 8
AV increased from 38 to 50
Build speed increased from 4 to 7

Siege bonus increased from 4 to 16 (Personal)

Siege bonus increased from 2 to 4 (Provided)
Added Bravery 2 (Provided)

### Enlightened:
AV increased from 44 to 54
Build Speed increased from 6 to 11

Siege bonus increased from 8 to 24 (Personal)

Siege bonus increased from 4 to 6 (Provided)
Entrenchment bonus decreased from 70% to 75% (Provided)
Added Bravery 2 (Provided)

### Restored:
DV decreased from 12 to 10
AV increased from 50 to 58
Build Speed increased from 8 to 15

Siege bonus increased from 14 to 32 (Personal)

Siege bonus increased from 6 to 8 (Provided)
Added Bravery 4 (Provided)

### Ascended:
AV increased from 58 to 64
Build speed increased from 10 to 18

Siege bonus increased from 22 to 40 (Personal)

Siege bonus increased from 8 to 10 (Provided)
Added Bravery 6 (Provided)