### PR TITLE
Nationalist change

### DIFF
--- a/TGX Files/Data/ModInfo.ini
+++ b/TGX Files/Data/ModInfo.ini
@@ -1,6 +1,6 @@
 [ModInfo]
 TwoCharacterIdentifier=KG
-Version=0.3.0
+Version=0.3.4
 Author=KohanCitadel
 Author_www=https://discord.gg/U4K4vPS
 Author_email=

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_CITY.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_CITY.INI
@@ -39,7 +39,7 @@ CompanyLimit	=	3			; companies allowed per settlement
 UpgradeCost		=	350	;800
 UpgradeTime		= 120
 ComponentLimit		=	6
-ComponentsRequiredToLevel = 	6
+ComponentsRequiredToLevel = 	5
 UpgradesRequiredToLevel = 1
 GoldLimitModifier		= 700
 

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_TOWN.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_TOWN.INI
@@ -39,7 +39,7 @@ CompanyLimit	=	2			; companies allowed per settlement
 UpgradeCost		=	350
 UpgradeTime		= 90
 ComponentLimit		=	4
-ComponentsRequiredToLevel = 	4
+ComponentsRequiredToLevel = 	3
 UpgradesRequiredToLevel = 0
 GoldLimitModifier		= 600
 

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_VILLAGE.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_VILLAGE.INI
@@ -41,7 +41,7 @@ CompanyLimit	=	1			; companies allowed per settlement
 UpgradeCost		=	200 ;150
 UpgradeTime		= 	45
 ComponentLimit		=	2
-ComponentsRequiredToLevel = 	2
+ComponentsRequiredToLevel = 	1
 UpgradesRequiredToLevel = 	0
 GoldLimitModifier	= 	500
 


### PR DESCRIPTION
### Changelog:
Nationalist components required to upgrade now matches all other factions. The bonus slot is not necessary to be able to upgrade.