### PR TITLE
Ghalen mordecai rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/GHALEN_MORDECAI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/GHALEN_MORDECAI.INI
@@ -96,7 +96,7 @@ Damage			=	60
 DamageType      =   Khaldunite
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_MELEE		=   .8
+DAMAGE_TAKEN_FROM_ANY		=   .8
 DAMAGE_TAKEN_FROM_RANGED	=   .5
 
 [SupportBonus2]

--- a/TGX Files/Data/ObjectData/Heroes/GHALEN_MORDECAI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/GHALEN_MORDECAI.INI
@@ -25,14 +25,6 @@ CommandSound1		=	Game\agm_hero5_command1.wav
 CommandSound2		=	Game\agm_hero5_command2.wav
 CommandSound3		=	Game\agm_hero5_command3.wav
 
-
-[ElementBonus]
-DAMAGE_TAKEN_FROM_MELEE		= .9
-DAMAGE_TAKEN_FROM_RANGED	= .5
-
-[SupportBonus]
-ATTACK_BONUS_TO_ROUTED		= -8
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Infantry_icon.tgr
@@ -45,9 +37,7 @@ ResupplyRate		=	10			; health / second (float)
 CombatValue		= 15
 Description = STRING_2383_Ghalen_is_a_hard_man__one_who_has_dedicated_his_life_to_battle_and_the_improvement_of_his_physical_abilities__He_is_nearly_unbeatable_in_single_combat__so_well_trained_in_the_art_of_melee_as_he_is__He_awaits_the_day_he_can_get_his_revenge_on_Sijansur__the_Ceyah_whose_army_defeated_him_during_the_second_Cataclysm_
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0040_Ghalen_Mordecai
+[SpellData]
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
@@ -68,32 +58,20 @@ AttackRange		=	0		;tiles (float)
 AttackType		=	0		;enumeration list(int)	
 DamageType		=	0		;number (float)
 
+[ElementBonus]
+DAMAGE_TAKEN_FROM_MELEE		= .9
+DAMAGE_TAKEN_FROM_RANGED	= .5
+
+[SupportBonus]
+ATTACK_BONUS_TO_ROUTED		= -8
+
 [Level1]
 MaxHitPoints		=	770
 
-[Level2]
-MaxHitPoints		=	990
-Defense			=	12
-
-[Level3]
-MaxHitPoints		=	1210
-;Technology		= SampleTech
+[SpellData1]
 
 [Attack0Data1]
 Damage			=	54
-
-[Attack0Data2]
-Damage			=	58
-
-[Attack0Data3]
-Damage			=	66
-DamageType		=	MAGIC
-
-[SpellData1]
-
-[SpellData2]
-
-[SpellData3]
 
 [ElementBonus1]
 DAMAGE_TAKEN_FROM_MELEE		= .85
@@ -101,6 +79,15 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
 ATTACK_BONUS_TO_ROUTED		= -6
+
+[Level2]
+MaxHitPoints		=	990
+Defense			=	12
+
+[SpellData2]
+
+[Attack0Data2]
+Damage			=	58
 
 [ElementBonus2]
 DAMAGE_TAKEN_FROM_MELEE		= .8
@@ -110,6 +97,16 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 ATTACK_BONUS_TO_ROUTED		= -4
 DAMAGE_TAKEN_FROM_MELEE		= .9
 
+[Level3]
+MaxHitPoints		=	1210
+;Technology		= SampleTech
+
+[Attack0Data3]
+Damage			=	66
+DamageType		=	MAGIC
+
+[SpellData3]
+
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_MELEE		= .75
 DAMAGE_TAKEN_FROM_RANGED	= .5
@@ -117,3 +114,7 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 [SupportBonus3]
 ATTACK_BONUS_TO_ROUTED		= -2
 DAMAGE_TAKEN_FROM_MELEE		= .85
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0040_Ghalen_Mordecai

--- a/TGX Files/Data/ObjectData/Heroes/GHALEN_MORDECAI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/GHALEN_MORDECAI.INI
@@ -38,6 +38,8 @@ CombatValue		= 15
 Description = STRING_2383_Ghalen_is_a_hard_man__one_who_has_dedicated_his_life_to_battle_and_the_improvement_of_his_physical_abilities__He_is_nearly_unbeatable_in_single_combat__so_well_trained_in_the_art_of_melee_as_he_is__He_awaits_the_day_he_can_get_his_revenge_on_Sijansur__the_Ceyah_whose_army_defeated_him_during_the_second_Cataclysm_
 
 [SpellData]
+MaxMana 		=	20 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	1	;the amount of mana that gets regenerated sec.
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
@@ -51,69 +53,74 @@ Sound1			= 	Game\infantry_attack.wav
 Sound2			= 	Game\sword3.wav
 
 [Attack2]
-AttackTime		=	0		;seconds(float) seconds per animation cycle
-DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
-ReloadTime		=	0		;seconds(float)
-AttackRange		=	0		;tiles (float)
-AttackType		=	0		;enumeration list(int)	
-DamageType		=	0		;number (float)
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.25		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.2			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		= 	0		;animations are backwards
 
 [ElementBonus]
-DAMAGE_TAKEN_FROM_MELEE		= .9
-DAMAGE_TAKEN_FROM_RANGED	= .5
+DAMAGE_TAKEN_FROM_ANY		=   .85
+DAMAGE_TAKEN_FROM_RANGED	=   .65
 
 [SupportBonus]
-ATTACK_BONUS_TO_ROUTED		= -8
+MORALE_CHECK_BONUS          =   2
+ATTACK_BONUS_TO_ROUTED		=   -8
 
 [Level1]
 MaxHitPoints		=	770
+Defense             =   11
 
 [SpellData1]
 
 [Attack0Data1]
-Damage			=	54
+Damage			=	56
 
 [ElementBonus1]
-DAMAGE_TAKEN_FROM_MELEE		= .85
-DAMAGE_TAKEN_FROM_RANGED	= .5
+DAMAGE_TAKEN_FROM_ANY		=   .80
+DAMAGE_TAKEN_FROM_RANGED	=   .65
 
 [SupportBonus1]
-ATTACK_BONUS_TO_ROUTED		= -6
+MORALE_CHECK_BONUS          =   4
+ATTACK_BONUS_TO_ROUTED		=   -8
 
 [Level2]
 MaxHitPoints		=	990
 Defense			=	12
 
 [SpellData2]
+Spell0          =   Grit
 
 [Attack0Data2]
-Damage			=	58
+Damage			=	60
+DamageType      =   Khaldunite
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_MELEE		= .8
-DAMAGE_TAKEN_FROM_RANGED	= .5
+DAMAGE_TAKEN_FROM_MELEE		=   .8
+DAMAGE_TAKEN_FROM_RANGED	=   .5
 
 [SupportBonus2]
-ATTACK_BONUS_TO_ROUTED		= -4
-DAMAGE_TAKEN_FROM_MELEE		= .9
+MORALE_CHECK_BONUS          =   4
+ATTACK_BONUS_TO_ROUTED		=   -8
 
 [Level3]
 MaxHitPoints		=	1210
 ;Technology		= SampleTech
 
 [Attack0Data3]
-Damage			=	66
-DamageType		=	MAGIC
 
 [SpellData3]
+MaxMana                 =   30
+ManaRegenerationRate    =   2
+Spell0                  =   True Grit
 
 [ElementBonus3]
-DAMAGE_TAKEN_FROM_MELEE		= .75
+DAMAGE_TAKEN_FROM_ANY		= .75
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
-ATTACK_BONUS_TO_ROUTED		= -2
-DAMAGE_TAKEN_FROM_MELEE		= .85
+MORALE_CHECK_BONUS          =   4
+ATTACK_BONUS_TO_ROUTED		=   -8
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/Spells.ini
+++ b/TGX Files/Data/Spells.ini
@@ -467,7 +467,7 @@ REVERSE_DAMAGE_WHEN_HIT	= 20
 
 
 [25]
-Name = Shadow's Blessing
+Name = Shadow's Blessing ;'
 ProperName = STRING_1456_Shadow_s_Blessing
 Description = STRING_1457_Blesses_all_friendly_elements_by_trading_defense_for_attack_
 Mana_Cost = 30
@@ -782,7 +782,7 @@ REVERSE_DAMAGE_WHEN_HIT	= 20
 DEFENSE_BONUS_VS_ARCHER = 10
 
 [42]
-Name = Heaven's Bolt
+Name = Heaven's Bolt ;'
 ProperName = STRING_1487_Heaven_s_Bolt
 Description = STRING_1488_Launches_a_stream_of_divine_energy_at_an_evil_target__burning_it_with_holy_retribution__Only_affects_creatures_of_Shadow_
 Mana_Cost = 35

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -255,7 +255,7 @@ Sound = spells\armor_of_light.wav
 DEFENSE_BONUS_VS_ANY = 7 ;8
 
 [12]
-Name = Ahriman's Gift
+Name = Ahriman's Gift ;'
 ProperName = STRING_4487_Ahriman_s_Blessing
 Description = STRING_4488_The_Dark_Master_Ahriman_bestows_this_gift_upon_his_most_loyal_servants__increasing_their_power_dramatically_
 Mana_Cost = 45
@@ -339,7 +339,7 @@ DAMAGE_TAKEN_FROM_MELEE		= .25
 IGNORE_TERRAIN_BONUS		= 1
 
 [16]
-Name = Shadow's Hunter
+Name = Shadow's Hunter ;'
 ProperName = STRING_4495_Shadow_s_Hunter
 Description = STRING_4496_A_great_boon_from_the_Shadow__turning_those_so_blessed_into_the_hunting_dogs_of_the_Shadow_
 Mana_Cost = 30
@@ -545,7 +545,7 @@ TargetDoCastEffect0 = invigorate
 Sound = spells\light_of_heaven.wav
 
 [28]
-Name = Heaven's Grip
+Name = Heaven's Grip ;'
 ProperName = STRING_4518_Heaven_s_Grip
 Description = STRING_4519_The_caster_channels_the_strength_of_the_Creator_to_bind_his_opponents_for_a_short_time__leaving_them_defenseless_
 Offensive =	1	;DEFENSIVE or OFFENSIVE
@@ -566,7 +566,7 @@ PARALYZE_BONUS	= 1
 DEFENSE_BONUS_VS_ANY	= -4
 
 [29]
-Name = Heaven's Cage
+Name = Heaven's Cage ;'
 ProperName = STRING_4520_Heaven_s_Cage
 Description = STRING_4521_The_caster_channels_the_strength_of_the_Creator_to_bind_his_opponents_while_inflicting_intense_pain_
 Offensive =	1	;DEFENSIVE or OFFENSIVE
@@ -646,7 +646,7 @@ MOVEMENT_BONUS		= .45
 ATTACK_BONUS_TO_ANY	= -5
 
 [33]
-Name = Shadow's Sleep
+Name = Shadow's Sleep ;'
 ProperName = STRING_4528_Shadow_s_Sleep
 Description = STRING_4529_The_caster_is_able_to_temporarily_force_his_opponents_into_a_short_nightmare_filled_sleep_
 Mana_Cost = 50
@@ -768,7 +768,7 @@ DAMAGE_TAKEN_FROM_NON_MAGIC	= .8
 
 
 [40]
-Name = Berserker's Rage
+Name = Berserker's Rage ;'
 ProperName = STRING_4539_Berserker_s_Rage
 Description = STRING_4540_Mystical_energies_fill_the_minds_of_the_caster_s_troops_increasing_their_attacks_and_removing_their_fear_of_death_
 Mana_Cost = 35

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -830,3 +830,39 @@ TargetLoopEffect0 = icestorm_fade
 PARALYZE_BONUS  = 1
 DAMAGE_TAKEN_FROM_ANY = 1.15
 
+[43]
+Name            =   Grit 
+ProperName      =   Grit
+Description     = Through sheer force of will the caster is able to shrug off debilitating effects and effortlessly maneuver in difficult terrain.
+Mana_Cost       =   15
+Type            =   Personal
+Offensive       =   0
+Morale          =   0
+CasterStartEffect0 = None
+TargetDoCastEffect0 = invigorate
+TargetLoopEffect0 = invigloop
+Duration = 8
+BonusSection = GritBonuses
+Sound = spells\protection.wav
+[GritBonuses]
+IMMUNITY_TO_ENCHANTMENT     =   1
+IGNORE_TERRAIN_BONUS        =   1
+
+[44]
+Name            =  True Grit 
+ProperName      =   True Grit
+Description     = Through sheer force of will the caster is able to shrug off wounds and debilitating effects. Maneuvering in difficult terrain becomes effortless.
+Mana_Cost       =   20
+Type            =   Personal
+Offensive       =   0
+Morale          =   0
+CasterStartEffect0 = None
+TargetDoCastEffect0 = invigorate
+TargetLoopEffect0 = invigloop
+Duration = 15
+BonusSection = TrueGritBonuses
+Sound = spells\protection.wav
+[TrueGritBonuses]
+IMMUNITY_TO_ENCHANTMENT     =   1
+IGNORE_TERRAIN_BONUS        =   1
+DAMAGE_TAKEN_FROM_ANY       =   0.75


### PR DESCRIPTION
Ghalen was one of the melee heroes desperately in need of a rework, as he seemed strong on paper as a standard Kohan but severely lacked the ability to cope with enchantment effects, and overall seemed very fragile. This update is by no means perfect and will require another look at some point in the near future, but it's a good first step to fleshing the hero out properly.

### **Changelog:**

### All:
Attack 2 is now for Casting. Ghalen is a fast caster with a reload time of 0.2, to not break his stride by much as he's going into battle.
Added Maxmana of 20 and mana regen of 1.
Chivalry (Negative attack bonus to routed) is set to 8. This remains a constant provided modifier across all levels.

### Awakened:

Removed Melee Resistance (Personal)
Ranged Resist decreased from 50% to 65% (Personal)
Added Toughness (Resistance to all) 85% (Personal)
Added Valor 2 (Provided)

### Enlightened
DV increased from 10 to 11
AV increased from 54 to 56

Removed Melee Resist (Personal)
Ranged Resist decreased from 50% to 65% (Personal)
Added Toughness (Resistance to all) 80% (Personal)
Attack Bonus to Routed decreased from -6 to -8 (Provided
Added Valor 4 (Provided)

### Restored:
Added Grit spell - Enchantment Immunity & Trailblazing for 8 seconds

AV increased from 58 to 60
Damage Type changed to Khaldunite

Removed Melee Resist (Personal)
Ranged Resist decreased from 50% to 65% (Personal)
Added Toughness (Resistance to all) 75% (Personal)
Removed Melee Resist (Provided)
Attack Bonus to Routed decreased from -4 to -8 (Provided)
Added Valor 4 (Provided)

### Ascended:
Added True Grit spell - Enchantment Immunity & Trailblazing & Damage Resistance 75% for 15 seconds

Removed melee resist (Personal)
Added Toughness 75% (Personal)
Attack Bonus to Routed decreased from -2 to -8 (Provided)
Added Valor 4 (Provided)