### PR TITLE
Final Changes for 0.3

### DIFF
--- a/TGX Files/Data/ModInfo.ini
+++ b/TGX Files/Data/ModInfo.ini
@@ -1,6 +1,6 @@
 [ModInfo]
 TwoCharacterIdentifier=KG
-Version=0.3.11
+Version=0.4.0
 Author=KohanCitadel
 Author_www=https://discord.gg/U4K4vPS
 Author_email=

--- a/TGX Files/Data/ObjectData/Heroes/ISHAN'GHUL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/ISHAN'GHUL.INI
@@ -60,7 +60,7 @@ AttackType                  =   CAST
 Animation                   =   0
 
 [ElementBonus]
-DAMAGE_TAKEN_FROM_KHALDUNITE        =   1.5
+DAMAGE_TAKEN_FROM_KHALDUNITE        =   1.25
 DAMAGE_TAKEN_FROM_RANGED            =   .40
 
 [SupportBonus]
@@ -75,7 +75,7 @@ Defense                     =   12
 [Attack0Data1]
 Damage                      =   44
 [ElementBonus1]
-DAMAGE_TAKEN_FROM_KHALDUNITE        =   1.35
+DAMAGE_TAKEN_FROM_KHALDUNITE        =   1.20
 DAMAGE_TAKEN_FROM_RANGED            =   .4
 
 [SupportBonus1]
@@ -93,7 +93,7 @@ Spell0                      =   Darkfire Immolation
 Damage                      =   48
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_KHALDUNITE        =   1.2
+DAMAGE_TAKEN_FROM_KHALDUNITE        =   1.15
 DAMAGE_TAKEN_FROM_RANGED            =   .4
 
 [SupportBonus2]

--- a/TGX Files/Data/ObjectData/Heroes/KENDRA_LANGSTON.INI
+++ b/TGX Files/Data/ObjectData/Heroes/KENDRA_LANGSTON.INI
@@ -58,7 +58,7 @@ AttackType		=	CAST		; enumeration list (int)
 Animation		= 	0		;animations are backwards
 
 [ElementBonus]
-DAMAGE_TAKEN_FROM_RANGED	= .75
+DAMAGE_TAKEN_FROM_RANGED	= .80
 ATTACK_BONUS_TO_SHADOW      = 3
 
 [SupportBonus]
@@ -69,10 +69,10 @@ MaxHitPoints		=	650
 [SpellData1]
 
 [Attack0Data1]
-Damage			=	42
+Damage			=	40
 
 [ElementBonus1]
-DAMAGE_TAKEN_FROM_RANGED	= .65
+DAMAGE_TAKEN_FROM_RANGED	= .80
 ATTACK_BONUS_TO_SHADOW      = 4
 IMMUNITY_TO_ENCHANTMENT		= 1
 
@@ -86,10 +86,10 @@ MaxHitPoints		=	800
 [SpellData2]
 
 [Attack0Data2]
-Damage			=	46
+Damage			=	42
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_RANGED	= .5
+DAMAGE_TAKEN_FROM_RANGED	= .80
 ATTACK_BONUS_TO_SHADOW      = 6
 
 [SupportBonus2]
@@ -105,11 +105,11 @@ Defense			=	14
 Spell0			=	True Blessing
 
 [Attack0Data3]
-Damage			=	50
+Damage			=	46
 
 [ElementBonus3]
 IMMUNITY_TO_ENCHANTMENT		= 1
-DAMAGE_TAKEN_FROM_RANGED	= .5
+DAMAGE_TAKEN_FROM_RANGED	= .80
 ATTACK_BONUS_TO_SHADOW      = 8
 
 

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_CITY.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_CITY.INI
@@ -36,7 +36,7 @@ NextLevel		=	Nationalist_Citadel
 CompanyLimit	=	3			; companies allowed per settlement
 
 [SettlementData]
-UpgradeCost		=	350	;800
+UpgradeCost		=	300	;800
 UpgradeTime		= 120
 ComponentLimit		=	6
 ComponentsRequiredToLevel = 	5

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_TOWN.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_TOWN.INI
@@ -36,7 +36,7 @@ NextLevel		= 	Nationalist_City
 CompanyLimit	=	2			; companies allowed per settlement
 
 [SettlementData]
-UpgradeCost		=	350
+UpgradeCost		=	320
 UpgradeTime		= 90
 ComponentLimit		=	4
 ComponentsRequiredToLevel = 	3

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_VILLAGE.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_VILLAGE.INI
@@ -38,7 +38,7 @@ NextLevel		=	Nationalist_Town
 CompanyLimit	=	1			; companies allowed per settlement
 
 [SettlementData]
-UpgradeCost		=	200 ;150
+UpgradeCost		=	180 ;150
 UpgradeTime		= 	45
 ComponentLimit		=	2
 ComponentsRequiredToLevel = 	1


### PR DESCRIPTION
Final pass for changes for 0.3 in order to update to 0.4.

### _Changelog:_

Kendra's AV progression changed from 38, 42, 46, 50 to 38, 40, 42, 46
Her ranged resist is now 80% on all levels, no longer scales.
(This should still work with her blessing and true blessing spells. Will make more sense after the Dali update.)

Ishanghul's khaldunite vulnerability changed to his 1.3.10 values
125% - 120% - 115% - 110% respectively.

Nationalist Upgrade Costs have been adjusted.
(This is to correct the harsh penalties put onto Nationalists for their bonus component slot and is a follow-up to the reduction in the number of components required to upgrade. In theory this should alleviate a lot of Nats problems, especially being unable to react in a timely manner in the early game, and being strangled by company limit in the late game - without solving both problems entirely. It's still a penalty, it's just less harsh.)

Decreased cost to upgrade village to town from 200 to 180.
Decreased town to city upgrade from 350 to 320.
Removed extra cost from upgrading from city to citadel. (350 to 300)

(This may be adjusted in future if it's too powerful for Nats and causes major imbalances in matchups)