### PR TITLE
Roxanna javidan rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
@@ -4,7 +4,7 @@ Class			= 	2			;enumeration list(int)
 Sprite			=   units\sorceress.tgr
 BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	450			;health rating(float)
+MaxHitPoints		=	500			;health rating(float)
 CostGold		=	0			;int
 BuildTime		=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
@@ -48,7 +48,7 @@ DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	0.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	36		;number (float)
+Damage			=	38		;number (float)
 DamageType		=	MAGIC
 Sound1			= 	spells\magician_attack.wav
 
@@ -59,9 +59,10 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 
 [ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED    =   0.8
 
 [SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
+MORALE_BONUS                =   2
 
 [Level1]
 MaxHitPoints		=	560

--- a/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
@@ -65,17 +65,18 @@ DAMAGE_TAKEN_FROM_RANGED    =   0.8
 MORALE_BONUS                =   2
 
 [Level1]
-MaxHitPoints		=	560
+MaxHitPoints		=	610
 
 [SpellData1]
 
 [Attack0Data1]
+Damage              =   42
 
 [ElementBonus1]
+DAMAGE_TAKEN_FROM_RANGED    =   0.8
 
 [SupportBonus1]
 MORALE_BONUS		= 4
-DEFENSE_BONUS_VS_ANY = 0
 
 [Level2]
 MaxHitPoints		=	670

--- a/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
@@ -98,19 +98,24 @@ ATTACK_BONUS_TO_ANY         = 2
 DEFENSE_BONUS_VS_ANY        = 3
 
 [Level3]
+MaxHitPoints		=	830
+Defense             =   12
 ;Technology		= SampleTech
 
 [SpellData3]
-Spell0			=	True Blessing
-Spell1			=	Conflagration
+MaxMana                     =   70
+ManaRegenerationRate        =   5
 
 [Attack0Data3]
-Damage			=	48
+Damage			=	50
 
 [ElementBonus3]
+DAMAGE_TAKEN_FROM_RANGED    =   0.8
 
 [SupportBonus3]
 MORALE_BONUS		= 6
+ATTACK_BONUS_TO_ANY         = 2
+DEFENSE_BONUS_VS_ANY        = 3
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
@@ -23,11 +23,6 @@ SelectionSound2		=	Game\f_hero6_select_good.wav
 CommandSound1		=	Game\f_hero6_command.wav
 CommandSound2		=	Game\f_hero6_command_good.wav
 
-[ElementBonus]
-
-[SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Sorceress_icon.tgr
@@ -47,10 +42,6 @@ ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Immolation
 Spell1			=	Blessing
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_2387_Roxanna_Javidan
-
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
@@ -67,31 +58,17 @@ DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 
+[ElementBonus]
+
+[SupportBonus]
+DEFENSE_BONUS_VS_ANY = -1
+
 [Level1]
 MaxHitPoints		=	560
 
-[Level2]
-MaxHitPoints		=	670
-
-[Level3]
-;Technology		= SampleTech
-
-[Attack0Data1]
-
-[Attack0Data2]
-Damage			=	42
-
-[Attack0Data3]
-Damage			=	48
-
 [SpellData1]
 
-[SpellData2]
-ManaRegenerationRate 	=	5
-
-[SpellData3]
-Spell0			=	True Blessing
-Spell1			=	Conflagration
+[Attack0Data1]
 
 [ElementBonus1]
 
@@ -99,12 +76,35 @@ Spell1			=	Conflagration
 MORALE_BONUS		= 4
 DEFENSE_BONUS_VS_ANY = 0
 
+[Level2]
+MaxHitPoints		=	670
+
+[SpellData2]
+ManaRegenerationRate 	=	5
+
 [ElementBonus2]
 
 [SupportBonus2]
 MORALE_BONUS		= 6
 
+[Attack0Data2]
+Damage			=	42
+
+[Level3]
+;Technology		= SampleTech
+
+[SpellData3]
+Spell0			=	True Blessing
+Spell1			=	Conflagration
+
+[Attack0Data3]
+Damage			=	48
+
 [ElementBonus3]
 
 [SupportBonus3]
 MORALE_BONUS		= 6
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_2387_Roxanna_Javidan

--- a/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
@@ -79,21 +79,23 @@ DAMAGE_TAKEN_FROM_RANGED    =   0.8
 MORALE_BONUS		= 4
 
 [Level2]
-MaxHitPoints		=	670
+MaxHitPoints		=	720
+Defense             =   11
 
 [SpellData2]
-ManaRegenerationRate 	=	5
+Spell1			=	Conflagration
+ManaRegenerationRate 	=	4
 
 [Attack0Data2]
-Damage			=	42
+Damage			=	46
 
 [ElementBonus2]
+DAMAGE_TAKEN_FROM_RANGED    =   0.8
 
 [SupportBonus2]
 MORALE_BONUS		= 6
-
-[Attack0Data2]
-Damage			=	42
+ATTACK_BONUS_TO_ANY         = 2
+DEFENSE_BONUS_VS_ANY        = 3
 
 [Level3]
 ;Technology		= SampleTech

--- a/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JASMIN_SHAHIN.INI
@@ -84,6 +84,9 @@ MaxHitPoints		=	670
 [SpellData2]
 ManaRegenerationRate 	=	5
 
+[Attack0Data2]
+Damage			=	42
+
 [ElementBonus2]
 
 [SupportBonus2]


### PR DESCRIPTION
### _Changelog_:

_All levels:_
Added Ranged Resist 80% (Personal)


### Awakened:
Increased HP from 450 to 500
Increased AV from 36 to 38

Removed -1 DV penalty (Provided)
Added Bravery 2 (Provided)

### Enlightened:
Increased HP from 560 to 610
Increased AV from 36 to 42


### Restored:
Increased HP from 670 to 720
Increased DV from 10 to 11
Increased AV from 42 to 46

Replaced Blessing with Conflagration
Decreased mana regen from 5 to 4

Added bonus AV 2 (Provided)
Added bonus DV 3 (Provided)

> Loses Blessing but gains the bonuses permanently

### Ascended:
Increased HP from 670 to 830
Increased DV from 10 to 12
Increased AV from 48 to 50

Increased Max Mana from 60 to 70
Mana Regen 5 (Moved from Restored to Ascended)

Added bonus AV 2 (Provided)
Added bonus DV 3 (Provided)