### PR TITLE
Thora maesun rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/THORA_MAESUN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/THORA_MAESUN.INI
@@ -66,19 +66,19 @@ ATTACK_BONUS_TO_SHADOW		= 2
 [SupportBonus]
 
 [Level1]
-MaxHitPoints		=	500
+MaxHitPoints		=	540
 
 [SpellData1]
+MaxMana         =   70
 Spell1			=	Heavens Gift
 
 [Attack0Data1]
-Damage			=	34
+Damage			=	38
 
 [ElementBonus1]
+ATTACK_BONUS_TO_SHADOW		= 4
 
 [SupportBonus1]
-DEFENSE_BONUS_VS_ANY        = 0
-ATTACK_BONUS_TO_SHADOW		= 2
 
 [Level2]
 MaxHitPoints		=	580

--- a/TGX Files/Data/ObjectData/Heroes/THORA_MAESUN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/THORA_MAESUN.INI
@@ -25,12 +25,6 @@ CommandSound1		=	Game\agf_hero4_command1.wav
 CommandSound2		=	Game\agf_hero4_command2.wav
 CommandSound3		=	Game\agf_hero4_command3.wav
 
-[ElementBonus]
-
-[SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
-ATTACK_BONUS_TO_SHADOW		= 2
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Priestess_icon.tgr
@@ -49,10 +43,6 @@ ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Heal
 Spell1			=	Blessing
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_4730_Thora_Maesun
-
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
@@ -70,32 +60,20 @@ DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 
+[ElementBonus]
+
+[SupportBonus]
+DEFENSE_BONUS_VS_ANY = -1
+ATTACK_BONUS_TO_SHADOW		= 2
+
 [Level1]
 MaxHitPoints		=	500
-
-[Level2]
-MaxHitPoints		=	580
-
-[Level3]
-MaxHitPoints		=	660
-
-[Attack0Data1]
-Damage			=	34
-
-[Attack0Data2]
-
-[Attack0Data3]
-Damage			=	38
 
 [SpellData1]
 Spell1			=	Heavens Gift
 
-[SpellData2]
-MaxMana 		=	70
-ManaRegenerationRate 	=	4
-
-[SpellData3]
-Spell0			=	Restoration
+[Attack0Data1]
+Damage			=	34
 
 [ElementBonus1]
 
@@ -103,12 +81,34 @@ Spell0			=	Restoration
 DEFENSE_BONUS_VS_ANY        = 0
 ATTACK_BONUS_TO_SHADOW		= 2
 
+[Level2]
+MaxHitPoints		=	580
+
+[SpellData2]
+MaxMana 		=	70
+ManaRegenerationRate 	=	4
+
+[Attack0Data2]
+
 [ElementBonus2]
 
 [SupportBonus2]
 ATTACK_BONUS_TO_SHADOW		= 4
 
+[Level3]
+MaxHitPoints		=	660
+
+[SpellData3]
+Spell0			=	Restoration
+
+[Attack0Data3]
+Damage			=	38
+
 [ElementBonus3]
 
 [SupportBonus3]
 ATTACK_BONUS_TO_SHADOW		= 6
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_4730_Thora_Maesun

--- a/TGX Files/Data/ObjectData/Heroes/THORA_MAESUN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/THORA_MAESUN.INI
@@ -81,18 +81,18 @@ ATTACK_BONUS_TO_SHADOW		= 4
 [SupportBonus1]
 
 [Level2]
-MaxHitPoints		=	580
+MaxHitPoints		=	620
 
 [SpellData2]
-MaxMana 		=	70
-ManaRegenerationRate 	=	4
+Spell0			=	Restoration
 
 [Attack0Data2]
+Damage              =   40
 
 [ElementBonus2]
+ATTACK_BONUS_TO_SHADOW		= 6
 
 [SupportBonus2]
-ATTACK_BONUS_TO_SHADOW		= 4
 
 [Level3]
 MaxHitPoints		=	660

--- a/TGX Files/Data/ObjectData/Heroes/THORA_MAESUN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/THORA_MAESUN.INI
@@ -4,7 +4,7 @@ Class			= 	2			;enumeration list(int)
 Sprite			=   units\priestess.tgr
 BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	420			;health rating(float)
+MaxHitPoints		=	450			;health rating(float)
 CostGold		=	0			;int
 BuildTime		=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
@@ -49,7 +49,7 @@ DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	0.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)
-Damage			=	30		;number (float)
+Damage			=	34		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\battle_priest_melee.wav
 Sound2			= 	Game\club2.wav
@@ -61,10 +61,9 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 
 [ElementBonus]
+ATTACK_BONUS_TO_SHADOW		= 2
 
 [SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
-ATTACK_BONUS_TO_SHADOW		= 2
 
 [Level1]
 MaxHitPoints		=	500

--- a/TGX Files/Data/ObjectData/Heroes/THORA_MAESUN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/THORA_MAESUN.INI
@@ -95,18 +95,19 @@ ATTACK_BONUS_TO_SHADOW		= 6
 [SupportBonus2]
 
 [Level3]
-MaxHitPoints		=	660
+MaxHitPoints		=	700
+Defense             =   12
 
 [SpellData3]
-Spell0			=	Restoration
+ManaRegenerationRate        =   5
 
 [Attack0Data3]
-Damage			=	38
+Damage			=	46
 
 [ElementBonus3]
+ATTACK_BONUS_TO_SHADOW		= 6
 
 [SupportBonus3]
-ATTACK_BONUS_TO_SHADOW		= 6
 
 [HeroData]
 AwakenCost		=	50


### PR DESCRIPTION
### _Changelog_:

### Awakened:
Increased HP from 420 to 450
Increased AV from 30 to 34

Added Bonus AV to Shadow 2 (Personal)

Removed DV penalty -1 (Provided)
Removed Bonus AV to Shadow 2 (Provided)

### Enlightened:
Increased HP from 500 to 540 

Increased Max Mana from 60 to 70

Added Bonus AV to Shadow 4 (Personal)

Removed Bonus AV to Shadow 2 (Provided)

### Restored:
Increased HP from 580 to 620
Increased AV from 34 to 40

Spell: Heal replaced with Restoration.
Retains Max Mana and Mana Regeneration from Enlightened (70 and 3, respectively)

Added Bonus AV to Shadow 6 (Personal)

Removed Bonus AV to Shadow 4 (Provided)

### Ascended:
Increased HP from 660 to 700
Increased DV from 10 to 12
Increased AV from 38 to 46

Increased Mana Regen from 3 to 5

Added Bonus AV to Shadow 6 (Personal)

Removed Bonus AV to Shadow 6 (Provided)