### PR TITLE
Garadun Attack Speed Fix

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
@@ -47,12 +47,11 @@ Sound1			= 	Game\paladin_attack.wav
 Sound2			= 	Game\sword1.wav
 
 [Attack2]
-AttackTime		=	0		;seconds(float) seconds per animation cycle
+AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
-ReloadTime		=	0		;seconds(float)
-AttackRange		=	0		;tiles (float)
-AttackType		=	0		;enumeration list(int)	
-DamageType		=	0		;number (float)
+ReloadTime		=	0.2		;seconds(float)
+AttackType		=	CAST		;enumeration list(int)	
+Animation       =   0
 
 [ElementBonus]
 ATTACK_BONUS_TO_BUILDING   =   12
@@ -104,7 +103,9 @@ MaxHitPoints		=	1550
 Defense             =   14
 
 [SpellData3]
-
+MaxMana             = 60
+ManaRegenerationRate    =   1
+Spell0              =   Grit
 [Attack0Data3]
 Damage			=	80
 DamageType      =   Khaldunite

--- a/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
@@ -55,9 +55,9 @@ AttackType		=	0		;enumeration list(int)
 DamageType		=	0		;number (float)
 
 [ElementBonus]
+ATTACK_BONUS_TO_BUILDING   =   12
 DEFENSE_BONUS_VS_SHADOW		= 2
 DAMAGE_TAKEN_FROM_RANGED	= .5
-ATTACK_BONUS_TO_BUILDING   =   12
 
 [SupportBonus]
 MORALE_LOSS_RATE_BONUS      =   .80
@@ -72,13 +72,13 @@ MaxHitPoints		=	950
 Damage			=	68
 
 [ElementBonus1]
-DAMAGE_TAKEN_FROM_RANGED	= .5
-DEFENSE_BONUS_VS_SHADOW		= 3
 ATTACK_BONUS_TO_BUILDING   =   14
+DEFENSE_BONUS_VS_SHADOW		= 3
+DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
-ZONE_OF_CONTROL_BONUS		= 1.3
 MORALE_LOSS_RATE_BONUS      =   .75
+ZONE_OF_CONTROL_BONUS		= 1.3
 
 [Level2]
 MaxHitPoints		=	1250
@@ -90,14 +90,14 @@ Defense             =   13
 Damage			=	72
 
 [ElementBonus2]
+ATTACK_BONUS_TO_BUILDING   =   18
 DEFENSE_BONUS_VS_SHADOW		= 4
 DAMAGE_TAKEN_FROM_RANGED	= .5
-ATTACK_BONUS_TO_BUILDING   =   18
 
 [SupportBonus2]
-ZONE_OF_CONTROL_BONUS		= 1.3
-MORALE_LOSS_RATE_BONUS      =   .75
 MORALE_CHECK_BONUS          =   2
+MORALE_LOSS_RATE_BONUS      =   .75
+ZONE_OF_CONTROL_BONUS		= 1.3
 
 [Level3]
 MaxHitPoints		=	1550
@@ -110,14 +110,14 @@ Damage			=	80
 DamageType      =   Khaldunite
 
 [ElementBonus3]
-DAMAGE_TAKEN_FROM_RANGED	= .5
-DEFENSE_BONUS_VS_SHADOW		= 6
 ATTACK_BONUS_TO_BUILDING   =   22
+DEFENSE_BONUS_VS_SHADOW		= 6
+DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
-ZONE_OF_CONTROL_BONUS		= 1.35
-MORALE_LOSS_RATE_BONUS      =   .65
 MORALE_CHECK_BONUS          =   4
+MORALE_LOSS_RATE_BONUS      =   .65
+ZONE_OF_CONTROL_BONUS		= 1.35
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
@@ -38,7 +38,7 @@ Description = STRING_2380_Garadun_Payne_is_a_monster_of_a_man__Even_though_he_sp
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
-ReloadTime		=	1.0		;seconds(float)
+ReloadTime		=	1.3		;seconds(float)
 AttackRange		=	0.75	;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
 Damage			=	62		;number (float)


### PR DESCRIPTION
Changing Garadun's attack from 2 seconds to 2.3 seconds.

This lowers his attack rate from 75% to 65%, so we can keep him as a heavy hitter and still have it be fair.