### PR TITLE
Kyran delroba rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
@@ -62,20 +62,22 @@ VISUAL_RANGE_BONUS		= 1.2
 ZONE_OF_CONTROL_BONUS		= 1.1
 
 [Level1]
-MaxHitPoints		=	800
+MaxHitPoints		=	850
+Defense             =   12
 
 [SpellData1]
 
 [Attack0Data1]
-Damage			=	46
+Damage			=	52
 
 [ElementBonus1]
 DAMAGE_TAKEN_FROM_RANGED	= .5
+IGNORE_TERRAIN_BONUS        =   1
 
 [SupportBonus1]
 ATTACK_BONUS_TO_ARCHER		= 4
-VISUAL_RANGE_BONUS		= 1.15
-ZONE_OF_CONTROL_BONUS		= 1.1
+VISUAL_RANGE_BONUS		= 1.3
+ZONE_OF_CONTROL_BONUS		= 1.2
 
 [Level2]
 MaxHitPoints		=	1000

--- a/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
@@ -23,14 +23,6 @@ SelectionSound2		=	Game\m_hero5_select_good.wav
 CommandSound1		=	Game\m_hero5_command2.wav
 CommandSound2		=	Game\m_hero5_command_good.wav
 
-[ElementBonus]
-DAMAGE_TAKEN_FROM_RANGED	= .5
-
-[SupportBonus]
-ATTACK_BONUS_TO_ARCHER		= 3
-VISUAL_RANGE_BONUS		= 1.1
-ZONE_OF_CONTROL_BONUS		= 1.1
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Scout_icon.tgr
@@ -42,10 +34,6 @@ WalkDistance		=   	2		;tiles (float) how far does unit move in one animation cyc
 ResupplyRate		=	10			; health / second (float)
 CombatValue		= 15
 Description = STRING_2391_Kyran_is_a_very_practical_person__one_who_always_knows_his_limitations_and_works_hard_at_finding_ways_to_combat_them__He_is_well_trained_in_the_arts_of_battle__and_is_well_known_for_his_tactical_strategies_for_defeating_archers_
-
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_2392_Kyran_Delroba
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
@@ -65,28 +53,21 @@ AttackRange		=	0		;tiles (float)
 AttackType		=	0		;enumeration list(int)	
 DamageType		=	0		;number (float)
 
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .5
+
+[SupportBonus]
+ATTACK_BONUS_TO_ARCHER		= 3
+VISUAL_RANGE_BONUS		= 1.1
+ZONE_OF_CONTROL_BONUS		= 1.1
+
 [Level1]
 MaxHitPoints		=	800
 
-[Level2]
-MaxHitPoints		=	1000
-
-[Level3]
-MaxHitPoints		=	1200
+[SpellData1]
 
 [Attack0Data1]
 Damage			=	46
-
-[Attack0Data2]
-
-[Attack0Data3]
-Damage			=	50
-
-[SpellData1]
-
-[SpellData2]
-
-[SpellData3]
 
 [ElementBonus1]
 DAMAGE_TAKEN_FROM_RANGED	= .5
@@ -96,6 +77,13 @@ ATTACK_BONUS_TO_ARCHER		= 4
 VISUAL_RANGE_BONUS		= 1.15
 ZONE_OF_CONTROL_BONUS		= 1.1
 
+[Level2]
+MaxHitPoints		=	1000
+
+[SpellData2]
+
+[Attack0Data2]
+
 [ElementBonus2]
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
@@ -104,6 +92,14 @@ ATTACK_BONUS_TO_ARCHER		= 6
 VISUAL_RANGE_BONUS		= 1.25
 ZONE_OF_CONTROL_BONUS		= 1.2
 
+[Level3]
+MaxHitPoints		=	1200
+
+[SpellData3]
+
+[Attack0Data3]
+Damage			=	50
+
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
@@ -111,3 +107,7 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 ATTACK_BONUS_TO_ARCHER		= 8
 VISUAL_RANGE_BONUS		= 1.35
 ZONE_OF_CONTROL_BONUS		= 1.3
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_2392_Kyran_Delroba

--- a/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
@@ -80,19 +80,22 @@ VISUAL_RANGE_BONUS		= 1.3
 ZONE_OF_CONTROL_BONUS		= 1.2
 
 [Level2]
-MaxHitPoints		=	1000
+MaxHitPoints		=	1050
 
 [SpellData2]
 
 [Attack0Data2]
+Damage              =   54
 
 [ElementBonus2]
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus2]
 ATTACK_BONUS_TO_ARCHER		= 6
-VISUAL_RANGE_BONUS		= 1.25
-ZONE_OF_CONTROL_BONUS		= 1.2
+VISUAL_RANGE_BONUS		= 1.4
+ZONE_OF_CONTROL_BONUS		= 1.25
+IGNORE_TERRAIN_BONUS        =   1
+
 
 [Level3]
 MaxHitPoints		=	1200

--- a/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
@@ -98,12 +98,13 @@ IGNORE_TERRAIN_BONUS        =   1
 
 
 [Level3]
-MaxHitPoints		=	1200
+MaxHitPoints		=	1250
 
 [SpellData3]
 
 [Attack0Data3]
-Damage			=	50
+Damage			=	60
+DamageType      =   Khaldunite
 
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_RANGED	= .5

--- a/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
@@ -71,8 +71,8 @@ Defense             =   12
 Damage			=	52
 
 [ElementBonus1]
-DAMAGE_TAKEN_FROM_RANGED	= .5
 IGNORE_TERRAIN_BONUS        =   1
+DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
 ATTACK_BONUS_TO_ARCHER		= 4
@@ -91,10 +91,10 @@ Damage              =   54
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus2]
+IGNORE_TERRAIN_BONUS        =   1
 ATTACK_BONUS_TO_ARCHER		= 6
 VISUAL_RANGE_BONUS		= 1.4
 ZONE_OF_CONTROL_BONUS		= 1.25
-IGNORE_TERRAIN_BONUS        =   1
 
 
 [Level3]
@@ -107,9 +107,9 @@ Damage			=	60
 DamageType      =   Khaldunite
 
 [ElementBonus3]
-DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
+IGNORE_TERRAIN_BONUS        =   1
 ATTACK_BONUS_TO_ARCHER		= 8
 VISUAL_RANGE_BONUS		= 1.35
 ZONE_OF_CONTROL_BONUS		= 1.3

--- a/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/KYRAN_DELROBA.INI
@@ -4,7 +4,7 @@ Class			= 	2			;enumeration list(int)
 Sprite			=   units\Scout.tgr
 BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	600			;health rating(float)
+MaxHitPoints		=	650			;health rating(float)
 CostGold		=	0			;int
 BuildTime		=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
@@ -41,7 +41,7 @@ DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	0.75	;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	42		;number (float)
+Damage			=	48		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\spear3.wav
 
@@ -58,7 +58,7 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus]
 ATTACK_BONUS_TO_ARCHER		= 3
-VISUAL_RANGE_BONUS		= 1.1
+VISUAL_RANGE_BONUS		= 1.2
 ZONE_OF_CONTROL_BONUS		= 1.1
 
 [Level1]


### PR DESCRIPTION
### _Changelog:_

### Awakened:
	Increased HP from 600 to 650 
	Increased AV from 42 to 48

	Increased Recon from 110% to 120% (Provided)

### Enlightened:

	Increased HP from 800 to 850 
	Increased DV from 10 to 12
	Increased AV from 46 to 52 
	
	Personal
	Added Trailblazing (Personal)

	
	Provided
	Increased Dominion from 110% to 120% (Provided)
	Increased Recon from 115% to 130% (Provided)

### Restored:
	Increased HP from 1000 to 1050 
	Increased AV from 46 to 54
		
	Added Trail Blazing (Provided)
	Increased Dominion from 120% to 125% (Provided)
	Increased Recon from 125% to 140% (Provided)

### Ascended:

	Increased HP from 1200 to 1250 
	Increased AV from 50 to 60 
	Damage Type changed from Normal to Khald
	
	Increased Recon from 135% to 150%
