### PR TITLE
Mausallas bahram rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
@@ -69,16 +69,21 @@ DEFENSE_BONUS_VS_ARCHER         =   2
 MORALE_BONUS                    =   4
 
 [Level1]
-MaxHitPoints                    =   410
+MaxHitPoints                    =   560
+Defense                         =   10
 
 [SpellData1]
+MaxMana                         =   60
+Spell1                          =   Lightning
 
 [Attack0Data1]
+Damage                          =   32
 
 [ElementBonus1]
-DAMAGE_TAKEN_FROM_UNHOLY        =   .9
 
 [SupportBonus1]
+DEFENSE_BONUS_VS_ARCHER         =   2
+MORALE_BONUS                    =   5
 
 [Level2]
 MaxHitPoints                    =   500

--- a/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
@@ -86,18 +86,20 @@ DEFENSE_BONUS_VS_ARCHER         =   2
 MORALE_BONUS                    =   5
 
 [Level2]
-MaxHitPoints                    =   500
+MaxHitPoints                    =   700
 
 [SpellData2]
-Spell0                          =   Valor
+Spell1                          =   Lightning Vestments
+ManaRegenerationRate            =   3
 
 [Attack0Data2]
-Damage                          =   28
+Damage                          =   38
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_UNHOLY        =   .8
 
 [SupportBonus2]
+DEFENSE_BONUS_VS_ARCHER         =   3
+MORALE_BONUS                    =   6
 
 [Level3]
 MaxHitPoints                    =   590

--- a/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
@@ -41,7 +41,7 @@ ManaRegenerationRate            =   2
 Spell0                          =   Storm Shield
 
 [Attack1]
-Sound1                          =   spells\necro_attack.wav
+Sound1                          =   Game\ranger_attack.wav
 AttackTime                      =   1
 DamagePoint                     =   0.5
 ReloadTime                      =   1
@@ -52,6 +52,7 @@ DamageType                      =   Vorpal
 Animation                       =   1
 MoraleDamage                    =   0
 MoraleDamageType                =   Normal
+
 [Attack2]
 AttackTime                      =   1
 DamagePoint                     =   0.5

--- a/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
@@ -4,7 +4,7 @@ Class                           =   2
 Sprite                          =   units\sorceress.tgr
 BoundingRadius                  =   0.25
 RotTime                         =   30
-MaxHitPoints                    =   320
+MaxHitPoints                    =   440
 CostGold                        =   0
 BuildTime                       =   0
 Defense                         =   8
@@ -36,10 +36,9 @@ CombatValue                     =   15
 Description                     =   Mausallas Bahram possesses an unusual beauty, her unkempt shock of reddish-blonde hair and prominent nose conflicting with her serene brown eyes and ruby-red lips. Her beauty belies her intense intelligence and commanding grasp of the realm of magic. She is an accomplished warrior-mage, often found leading the charge against the forces of the Shadow, as well as wreaking havoc with her command of lightning. In melee, Mausallas wields a blackened longblade called Sta'archan that slices through the armor of her enemies with frightening ease. ;'
 
 [SpellData]
-MaxMana                         =   60
-ManaRegenerationRate            =   3
-Spell0                          =   Courage
-Spell1                          =   Lightning
+MaxMana                         =   50
+ManaRegenerationRate            =   2
+Spell0                          =   Storm Shield
 
 [Attack1]
 Sound1                          =   spells\necro_attack.wav
@@ -64,8 +63,10 @@ MoraleDamage                    =   0
 MoraleDamageType                =   Normal
 
 [ElementBonus]
+DEFENSE_BONUS_VS_ARCHER         =   2
 
 [SupportBonus]
+MORALE_BONUS                    =   4
 
 [Level1]
 MaxHitPoints                    =   410

--- a/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
@@ -103,20 +103,19 @@ DEFENSE_BONUS_VS_ARCHER         =   3
 MORALE_BONUS                    =   6
 
 [Level3]
-MaxHitPoints                    =   590
+MaxHitPoints                    =   820
 
 [SpellData3]
-Spell1                          =   Forked Lightning
-ManaRegenerationRate            =   4
+MaxMana                         =   75
 
 [Attack0Data3]
-Damage                          =   34
+Damage                          =   44
 
 [ElementBonus3]
-DAMAGE_TAKEN_FROM_UNHOLY        =   .75
-IMMUNITY_TO_ENCHANTMENT         =   1
 
 [SupportBonus3]
+DEFENSE_BONUS_VS_ARCHER         =   5
+MORALE_BONUS                    =   8
 
 [HeroData]
 AwakenCost                      =   50

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -845,8 +845,8 @@ Duration = 12
 BonusSection = GritBonuses
 Sound = spells\protection.wav
 [GritBonuses]
-IMMUNITY_TO_ENCHANTMENT     =   1
 IGNORE_TERRAIN_BONUS        =   1
+IMMUNITY_TO_ENCHANTMENT     =   1
 
 [44]
 Name            =  True Grit 
@@ -862,7 +862,28 @@ TargetLoopEffect0 = invigloop
 Duration = 16
 BonusSection = TrueGritBonuses
 Sound = spells\protection.wav
+
 [TrueGritBonuses]
-IMMUNITY_TO_ENCHANTMENT     =   1
-IGNORE_TERRAIN_BONUS        =   1
 DAMAGE_TAKEN_FROM_ANY       =   0.75
+IGNORE_TERRAIN_BONUS        =   1
+IMMUNITY_TO_ENCHANTMENT     =   1
+
+[45]
+Name = Lightning Vestments
+ProperName = Lightning Vestments
+Description = Wreaths the caster's comrades in crackling electricity, protecting them from physical attacks and harming those that dare to engage them in melee combat. ;'
+Mana_Cost = 40
+Type = Group
+Offensive = 0
+Range = 10
+Morale = 0
+CasterStartEffect0 = None
+TargetDoCastEffect0 = None
+Duration = 30
+BonusSection = LightningVestmentBonuses
+Sound = spells\storm_shield.wav
+TargetLoopEffect0 = storm_shield
+
+[LightningVestmentBonuses]
+REVERSE_DAMAGE_WHEN_HIT		= 8
+DAMAGE_TAKEN_FROM_NON_MAGIC	= .9

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -871,8 +871,8 @@ IMMUNITY_TO_ENCHANTMENT     =   1
 [45]
 Name = Lightning Vestments
 ProperName = Lightning Vestments
-Description = Wreaths the caster's comrades in crackling electricity, protecting them from physical attacks and harming those that dare to engage them in melee combat. ;'
-Mana_Cost = 40
+Description = Wreaths the caster's comrades in crackling electricity that protects from physical attacks and harms those who dare to engage them in melee. ;'
+Mana_Cost = 45
 Type = Group
 Offensive = 0
 Range = 10
@@ -883,6 +883,7 @@ Duration = 30
 BonusSection = LightningVestmentBonuses
 Sound = spells\storm_shield.wav
 TargetLoopEffect0 = storm_shield
+TargetLoopEffect1 = blessing_fade
 
 [LightningVestmentBonuses]
 REVERSE_DAMAGE_WHEN_HIT		= 8


### PR DESCRIPTION
### Awakened:

	Increased HP from 320 to 440 
	
	Decreased Max Mana from 60 to 50 
	Decreased Mana regen from 3 to 2
	
	Removed Spell Courage & Lightning
	Added Spell Storm Shield
	
	Added Bonus DV vs Archer +2 (Personal)
	
	Added Bravery 4 (Provided)


### Enlightened:

	Increased HP from 410 to 560 
	Increased DV from 8 to 10
	Increased AV from 22 to 32
	
	Removed Unholy Resistance 90% (Personal)
	
	Added Bravery 5 (Provided)

### Restored:
	Increased HP from 500 to 700
	Increased AV from 28 to 38  
	
	
	Replaced Spell: Lightning with Lightning Vestments. (New spell. Company Wide 8 Reflect Damage + 90% Armored)
	
	Added Bonus DV vs Archer 3 (Provided)
	Added Bravery 6 (Provided)

### Ascended:
	Increased HP from 590 to 820 
	Increased AV from 34 to 44 
	Increased Max Mana from 60 to 75
	Decreased Mana Regen from 4 to 3
	
	Personal:
	Removed Unholy Resistance 75% (Personal)
	Removed Spell Immunity (Personal)
	
	Provided 
	Added Bonus DV vs Archer 5 (Provided)
	Added Bravery 8 (Provided )
