### PR TITLE
Lightbane localization fix

### DIFF
--- a/TGX Files/Data/BONUS.INI
+++ b/TGX Files/Data/BONUS.INI
@@ -1,0 +1,444 @@
+;Bonus INI
+
+;[ID]
+;name1 	= Positive (reverse when positive is bad)
+;name2 	= Negative (reverse when negative is good)
+;Action	= ADD, MULTIPLY, FLAG, SPECIAL
+;Description1 = x
+;Description2 = x
+
+[ATTACK_BONUS_TO_ANY]
+name1 	= STRING_1230_Attack_Bonus
+name2 	= STRING_1231_Weakened
+Action	= ADD
+Description1 = STRING_1232_Increases_attacks_by___d_
+Description2 = STRING_1233_Decreases_attacks_by___d_
+
+[ATTACK_BONUS_TO_MOUNTED]
+name1 	= STRING_1234_Cavalry_Foe
+name2 	= STRING_1235_not_used
+Action	= ADD
+Description1 = STRING_1236_Increases_attacks_against_cavalry_elements_by___d_
+
+[ATTACK_BONUS_TO_SHADOW]
+name1 	= STRING_1237_Shadowbane
+name2 	= STRING_1235_not_used
+Action	= ADD
+Description1 = STRING_1238_Increases_attacks_against_shadow_elements_by___d_
+
+[ATTACK_BONUS_TO_ARCHER]
+name1 	= STRING_1239_Archer_Foe
+name2 	= STRING_1235_not_used
+Action	= ADD
+Description1 = STRING_1240_Increases_attacks_against_archer_elements_by___d_
+
+[ATTACK_BONUS_TO_BUILDING]
+name1 	= STRING_1241_Siege_Bonus
+name2 	= STRING_1242_Siege_Penalty
+Action	= ADD
+Description1 = STRING_1243_Increases_attacks_against_buildings_by___d_
+Description2 = STRING_1244_Decreases_attacks_against_buildings_by___d_
+
+[ATTACK_BONUS_TO_ROUTED]
+name1 	= STRING_1245_Bloodlust
+name2 	= STRING_1246_Chivalry
+Action	= ADD
+Description1 = STRING_1247_Increases_attacks_against_routed_elements_by___d_
+Description2 = STRING_1248_Decreases_attacks_against_routed_elements_by___d_
+
+[HIT_POINTS_BONUS]
+name1 	= STRING_1249_Healthy
+name2 	= STRING_1250_Frail
+Action = MULTIPLY
+Description1 = STRING_1251_Increases_health_to__d___of_normal_
+Description2 = STRING_1252_Decreases_health_to__d___of_normal_
+
+[DEFENSE_BONUS_VS_ANY]
+name1 	= STRING_1253_Defense_Bonus
+name2 	= STRING_1254_Defense_Penalty
+Action	= ADD
+Description1 = STRING_1255___d_DV_bonus_against_all_elements_
+Description2 = STRING_1256___d_DV_penalty_against_all_elements_
+
+[DEFENSE_BONUS_VS_MOUNTED]
+name1 	= STRING_1257_Cavalry_Resistant
+name2 	= STRING_1258_Cavalry_Vulnerable
+Action	= ADD
+Description1 = STRING_1259___d_DV_bonus_against_cavalry_elements_
+Description2 = STRING_1260___d_DV_penalty_against_cavalry_elements_
+
+[DEFENSE_BONUS_VS_SHADOW]
+name1 	= STRING_1261_Shadow_Resistant
+name2 	= STRING_1262_Shadow_Vulnerable
+Action	= ADD
+Description1 = STRING_1263___d_DV_bonus_against_shadow_elements_
+Description2 = STRING_1264___d_DV_penalty_against_shadow_elements_
+
+[DEFENSE_BONUS_VS_ARCHER]
+name1 	= STRING_1265_Archer_Resistant
+name2 	= STRING_1266_Archer_Vulnerable
+Action	= ADD
+Description1 = STRING_1267___d_DV_bonus_against_archer_elements_
+Description2 = STRING_1268___d_DV_penalty_against_archer_elements_
+
+[DAMAGE_BONUS_TO_ANY]
+name1 	= STRING_1269_Damage_Bonus
+name2 	= STRING_1270_Damage_Penalty
+Action	= MULTIPLY
+Description1 = STRING_1271_Increases_damage_inflicted_to__d___of_normal_
+Description2 = STRING_1272_x
+
+[IGNORE_TERRAIN_BONUS]
+name1 = STRING_1273_Trailblazing
+name2 = STRING_1274_nt_used
+Action = FLAG
+Description1 = STRING_1275_Ignores_terrain_penalty_for_movement_
+Description2 = STRING_1272_x
+
+[WAS_DAMAGE_BONUS_TO_SHADOW]
+name1 	= STRING_1276_Shadow_Killer
+name2 	= STRING_1235_not_used
+Action	= MULTIPLY
+Description1 = STRING_1277_Increases_damage_inflicted_to_shadow_elements_to__d___of_normal_
+
+[WAS_DAMAGE_BONUS_TO_MOUNTED]
+name1 	= STRING_1278_Cavalry_Killer
+name2 	= STRING_1235_not_used
+Action	= MULTIPLY
+Description1 = STRING_1279_Increases_damage_inflicted_to_cavalry_elements_to__d___of_normal_
+
+[ATTACK_BONUS_TO_NONSHADOW]
+name1 	= STRING_3682_Lightbane
+name2 	= STRING_3683_Eosophobia
+Action	= ADD
+Description1 = STRING_1238_Increases_attacks_against_shadow_elements_by___d_
+Description2 = STRING_3684_Decreases_attacks_against_shadow_elements_by___d_
+
+[RELOAD_TIME_BONUS]
+name1 	= STRING_3685_Tired
+name2 	= STRING_3686_Haste
+Action	= MULTIPLY
+Description1 = STRING_3687_Increases_attack_recovery_time_to__d___of_normal_
+Description2 = STRING_3688_Decreases_attack_recovery_time_to__d___of_normal_
+
+[DAMAGE_TAKEN_FROM_ANY]
+name1 	= STRING_1250_Frail
+name2 	= STRING_1286_Tough
+Action	= MULTIPLY
+Description1 = STRING_1287_Increases_damage_taken_to__d___of_normal_
+Description2 = STRING_1288_Decreases_damage_taken_to__d___of_normal_
+
+[DAMAGE_TAKEN_FROM_MAGIC]
+name1 	= STRING_1289_Magic_Vulnerable
+name2 	= STRING_1290_Magic_Resistant
+Action	= MULTIPLY
+Description1 = STRING_1291_Increases_damage_taken_from_magic_attacks_to__d___of_normal_
+Description2 = STRING_1292_Decreases_damage_taken_from_magic_attacks_to__d___of_normal_
+
+[DAMAGE_TAKEN_FROM_RANGED]
+name1 	= STRING_1293_Range_Vulnerable
+name2 	= STRING_1294_Range_Resistant
+Action	= MULTIPLY
+Description1 = STRING_1295_Increases_damage_taken_from_range_attacks_to__d___of_normal_
+Description2 = STRING_1296_Decreases_damage_taken_from_range_attacks_to__d___of_normal_
+
+[DAMAGE_TAKEN_FROM_MELEE]
+name1 	= STRING_1297_Melee_Vulnerable
+name2 	= STRING_1298_Melee_Resistant
+Action	= MULTIPLY
+Description1 = STRING_1299_Increases_damage_taken_from_melee_attacks_to__d___of_normal_
+Description2 = STRING_1300_Decreases_damage_taken_from_melee_attacks_to__d___of_normal_
+
+[DAMAGE_TAKEN_FROM_NON_MAGIC]
+name1 	= STRING_1301_Flimsy
+name2 	= STRING_1302_Armored
+Action	= MULTIPLY
+Description1 = STRING_1303_Increases_damage_taken_from_non_magic_attacks_to__d___of_normal_
+Description2 = STRING_1304_Decreases_damage_taken_from_non_magic_attacks_to__d___of_normal_
+
+[REVERSE_DAMAGE_WHEN_HIT]
+name1 	= STRING_1305_Reverse_Damage
+name2 	= STRING_1235_not_used
+Action	= ADD
+Description1 = STRING_1306_Inflicts___d_damage_to_enemies_when_they_attack_element_in_melee_
+
+[MOVEMENT_BONUS]
+name1 	= STRING_1307_Movement_Bonus
+name2 	= STRING_1308_Movement_Penalty
+Action	= MULTIPLY
+Description1 = STRING_1309_Increases_the_movement_rate_of_an_element_to__d___of_normal_
+Description2 = STRING_1310_Decreases_the_movement_rate_of_an_element_to__d___of_normal_
+
+[PARALYZE_BONUS]
+name1 	= STRING_1311_Paralysis
+name2 	= STRING_1235_not_used
+Action	= FLAG
+Description1 = STRING_1312_Paralyzes_element_so_it_may_not_move_or_attack_
+
+[ENTANGLE_BONUS]
+name1 	= STRING_1313_Entangle
+name2 	= STRING_1235_not_used
+Action	= FLAG
+Description1 = STRING_1314_Entangles_element_so_it_may_not_move_
+
+[RESUPPLY_RATE_BONUS]
+name1 	= STRING_1315_Quicker_Recovery
+name2 	= STRING_1316_Slower_Recovery
+Action	= MULTIPLY
+Description1 = STRING_1317_Increases_rate_at_which_elements_are_resupplied_to__d___of_normal_
+Description2 = STRING_1318_Decreases_rate_at_which_elements_are_resupplied_to__d___of_normal_
+
+[ZONE_OF_CONTROL_BONUS]
+name1 	= STRING_1319_Dominion
+name2 	= STRING_1320_Poor_Control
+Action	= MULTIPLY
+Description1 = STRING_1321_Increases_the_company_s_zone_of_control_to__d___of_normal_
+Description2 = STRING_1322_Decreases_the_company_s_zone_of_control_to__d___of_normal_
+
+[MORALE_BONUS]
+name1 	= STRING_1323_Bravery
+name2 	= STRING_1324_Cowardice
+Action	= ADD
+Description1 = STRING_1325_Increases_company_s_base_morale_by___d_
+Description2 = STRING_1326_Decreases_company_s_base_morale_by___d_
+
+[MORALE_LOSS_RATE_BONUS]
+name1 	= STRING_1327_Panicky
+name2 	= STRING_1328_Courageous
+Action	= MULTIPLY
+Description1 = STRING_1329_Increases_the_company_s_loss_of_morale_in_combat_to__d___of_normal_
+Description2 = STRING_1330_Decreases_the_company_s_loss_of_morale_in_combat_to__d___of_normal_
+
+[MORALE_RECOVERY_RATE_BONUS]
+name1 	= STRING_1331_Inspiration
+name2 	= STRING_1332_Fearful
+Action	= MULTIPLY
+Description1 = STRING_1333_Increases_the_company_s_recovery_of_morale_to__d___of_normal_
+Description2 = STRING_1334_Decreases_the_company_s_recovery_of_morale_to__d___of_normal_
+
+[MORALE_CHECK_BONUS]
+name1 	= STRING_1335_Valor
+name2 	= STRING_1336_Timid
+Action	= ADD
+Description1 = STRING_1337_Lowers_the_point_at_which_company_may_rout_by__d_
+Description2 = STRING_1338_Raises_the_point_at_which_company_may_rout_by__d_
+
+[VISUAL_RANGE_BONUS]
+name1 	= STRING_1339_Recon
+name2 	= STRING_1340_Short_Sighted
+Action	= MULTIPLY
+Description1 = STRING_1341_Increases_the_company_s_visual_range_to__d___of_normal_
+Description2 = STRING_1342_Decreases_the_company_s_visual_range_to__d___of_normal_
+
+[ENTRENCHMENT_RATE_BONUS]
+name1 	= STRING_1343_Slow_Entrenching
+name2 	= STRING_1344_Rapid_Entrenching
+Action	= MULTIPLY
+Description1 = STRING_1345_Increases_the_company_s_time_to_entrench_to__d___of_normal_
+Description2 = STRING_1346_Decreases_the_company_s_time_to_entrench_to__d___of_normal_
+
+[DAMAGE_TAKEN_FROM_HOLY]
+name1 	= STRING_1347_Holy_Vulnerable
+name2 	= STRING_1348_Holy_Resistant
+Action	= MULTIPLY
+Description1 = STRING_1349_Increases_damage_taken_from_holy_attacks_to__d___of_normal_
+Description2 = STRING_1350_Decreases_damage_taken_from_holy_attacks_to__d___of_normal_
+
+[DAMAGE_TAKEN_FROM_UNHOLY]
+name1 	= STRING_1351_Unholy_Vulnerable
+name2 	= STRING_1352_Unholy_Resistant
+Action	= MULTIPLY
+Description1 = STRING_1353_Increases_damage_taken_from_unholy_attacks_to__d___of_normal_
+Description2 = STRING_1354_Decreases_damage_taken_from_unholy_attacks_to__d___of_normal_
+
+[DAMAGE_TAKEN_FROM_KHALDUNITE]
+name1 	= STRING_1355_Khaldunite_Vulnerable
+name2 	= STRING_1356_Khaldunite_Resistant
+Action	= MULTIPLY
+Description1 = STRING_1357_Increases_damage_taken_from_khaldunite_attacks_to__d___of_normal_
+Description2 = STRING_1358_Decreases_damage_taken_from_khaldunite_attacks_to__d___of_normal_
+
+[IMMUNITY_TO_ENCHANTMENT]
+name1 	= STRING_1359_Spell_Immunity
+name2 	= STRING_1359_Spell_Immunity
+Action	= FLAG
+Description1 = STRING_1360_Element_is_immune_to_the_effects_of_enchantment_spells_
+Description2 = STRING_1360_Element_is_immune_to_the_effects_of_enchantment_spells_
+
+[MELEE_HOLY_DAMAGE]
+name1 	= STRING_1361_Holy_Attacks
+name2 	= STRING_1235_not_used
+Action	= ADD
+Description1 = STRING_1362_Element_inflicts___d_additional_damage_to_creatures_of_shadow_
+
+[MELEE_UNHOLY_DAMAGE]
+name1 	= STRING_1363_Unholy_Attacks
+name2 	= STRING_1235_not_used
+Action	= ADD
+Description1 = STRING_1364_Element_inflicts___d_additional_damage_to_non_shadow_creatures_
+
+[CAUSE_KHALDUNITE_DAMAGE]
+name1 	= STRING_1365_Khaldunite_Weaponry
+name2 	= STRING_1235_not_used
+Action	= FLAG
+Description1 = STRING_1366_Element_now_inflicts_Khaldunite_based_damage_
+Description2 = STRING_1235_not_used
+
+[CAUSE_MAGIC_DAMAGE]
+name1 	= STRING_1367_Magic_Weaponry
+name2 	= STRING_1235_not_used
+Action	= FLAG
+Description1 = STRING_1368_Element_now_inflicts_Magic_based_damage_
+Description2 = STRING_1235_not_used
+
+[UPGRADE_BONUS_COST_GROUP_1]
+name1 	= STRING_1235_not_used
+name2 	= STRING_2998_Archer___Spear_Elements
+Action	= MULTIPLY
+Description1 = STRING_1235_not_used
+Description2 = STRING_1370_Archer_Scout_Commission_costs_are_reduced_to__d___of_normal_
+
+[UPGRADE_BONUS_COST_GROUP_2]
+name1 	= STRING_1235_not_used
+name2 	= STRING_2999_Sword___Axe_Elements
+Action	= MULTIPLY
+Description1 = STRING_1235_not_used
+Description2 = STRING_1372_Grenadier_Dragoon_Commission_costs_are_reduced_to__d___of_normal_
+
+[UPGRADE_BONUS_COST_GROUP_3]
+name1 	= STRING_1235_not_used
+name2 	= STRING_3000_Engineers___Settlers
+Action	= MULTIPLY
+Description1 = STRING_1235_not_used
+Description2 = STRING_1374_Engineer_Settler_Commission_costs_are_reduced_to__d___of_normal_
+
+[UPGRADE_BONUS_COST_GROUP_ALL]
+name1 	= STRING_1235_not_used
+name2 	= STRING_3001_All_Elements
+Action	= MULTIPLY
+Description1 = STRING_1235_not_used
+Description2 = STRING_1376_All_Units_Commission_costs_are_reduced_to__d___of_normal_
+
+[UPGRADE_BONUS_VISUAL_RANGE]
+name1	= STRING_1377_Visual_Range
+name2	= STRING_1235_not_used
+Action	= MULTIPLY
+Description1 = STRING_1378_Increases_a_settlement_s_visual_range_to__d___of_normal_
+
+[UPGRADE_BONUS_SUPPLY_RANGE]
+name1	= STRING_1379_Supply_Range
+name2	= STRING_1235_not_used
+Action	= MULTIPLY
+Description1 = STRING_1380_Increases_a_settlement_s_supply_range_to__d___of_normal_
+
+[UPGRADE_BONUS_HEALTH]
+name1	= STRING_1381_Health_Bonus
+name2	= STRING_1235_not_used
+Action	= MULTIPLY
+Description1 = STRING_1382_Increases_a_settlement_s_maximum_health_to__d___of_normal_
+
+[UPGRADE_BONUS_MILITIA_AV]
+name1	= STRING_1383_Militia_AV_Bonus
+name2	= STRING_1235_not_used
+Action	= ADD
+Description1 = STRING_1384_Increases_the_AV_of_the_militia_by___d_
+
+[UPGRADE_BONUS_MILITIA_DV]
+name1	= STRING_1385_Militia_DV_Bonus
+name2	= STRING_1235_not_used
+Action	= ADD
+Description1 = STRING_1386_Increases_the_DV_of_the_militia_by___d_
+
+[UPGRADE_BONUS_MILITIA_MAX]
+name1	= STRING_1387_Militia_Maximum_Bonus
+name2	= STRING_1235_not_used
+Action	= MULTIPLY
+Description1 = STRING_1388_Increases_the_maximum_number_of_the_militia_
+
+[UPGRADE_BONUS_VS_MAGIC]
+name1	= STRING_1235_not_used
+name2	= STRING_1389_Magic_Resistance_Bonus
+Action	= MULTIPLY
+Description1 = STRING_1235_not_used
+Description2 = STRING_1390_Reduces_damage_to_settlements_from_magical_attacks_to__d___of_normal_
+
+[UPGRADE_BONUS_VS_NON_MAGIC]
+name1	= STRING_1235_not_used
+name2	= STRING_1391_Non_Magic_Resistance_Bonus
+Action	= MULTIPLY
+Description1 = STRING_1235_not_used
+Description2 = STRING_1392_Reduces_damage_to_settlements_from_non_magical_attacks_to__d___of_normal_
+
+[UPGRADE_BONUS_DEFICIT_EXCHANGE_RATE]
+name1	= STRING_1235_not_used
+name2	= STRING_1393_Deficit_Exchange_Rate_Bonus
+Action	= MULTIPLY
+Description1 = STRING_1235_not_used
+Description2 = STRING_1394_Lowers_the_exchange_penalty_for_having_a_negative_supply_in_a_given_resource_to__d___of_normal_
+
+[UPGRADE_BONUS_MARKET_PRODUCTION]
+name1	= STRING_0069_Capitalism
+name2	= STRING_1395_not_implemented
+Action	= ADD
+Description1 = STRING_1396_Improves_the_production_of_the_Market_and_its_upgrades_by___d_
+Description2 = STRING_1235_not_used
+
+[UPGRADE_BONUS_COMPONENT_COST]
+name1	= STRING_1397_Inefficient_Construction
+name2	= STRING_1398_Efficient_Construction
+Action	= MULTIPLY
+Description1 = STRING_1399_Increases_the_cost_of_settlement_components_to__d___of_normal_
+Description2 = STRING_1400_Reduces_the_cost_of_settlement_components_to__d___of_normal_
+
+[WOOD_MINE_PRODUCTION]
+name1	= STRING_1395_not_implemented
+name2	= STRING_1395_not_implemented
+Action	= ADD
+Description1 = STRING_1395_not_implemented
+
+[MANA_MINE_PRODUCTION]
+name1	= STRING_1395_not_implemented
+name2	= STRING_1395_not_implemented
+Action	= ADD
+Description1 = STRING_1395_not_implemented
+
+[GOLD_MINE_PRODUCTION]
+name1	= STRING_1395_not_implemented
+name2	= STRING_1395_not_implemented
+Action	= ADD
+Description1 = STRING_1395_not_implemented
+
+[IRON_MINE_PRODUCTION]
+name1	= STRING_1395_not_implemented
+name2	= STRING_1395_not_implemented
+Action	= ADD
+Description1 = STRING_1395_not_implemented
+
+[STONE_MINE_PRODUCTION]
+name1	= STRING_1395_not_implemented
+name2	= STRING_1395_not_implemented
+Action	= ADD
+Description1 = STRING_1395_not_implemented
+
+[UPGRADE_BONUS_GOLD_LIMIT]
+name1	= STRING_1401_Gold_Reserve
+name2	= STRING_1402_Wastes_Space
+Action	= ADD
+Description1 = STRING_1403_Increases_the_gold_reserve_capacity_by___d_
+Description2 = STRING_1404_Decreases_the_gold_reserve_capacity_by___d_
+
+[UPGRADE_BONUS_CLAIRVOYANCE]
+name1	= STRING_1405_Oracles___Scryers
+name2	= STRING_1235_not_used
+Action	= ADD
+Description1 = STRING_1406_The_detection_zone_is_unaffected_by_terrain_
+Description2 = STRING_1235_not_used
+
+[UPGRADE_BONUS_VS_KHALDUNITE]
+name1	= STRING_1355_Khaldunite_Vulnerable
+name2	= STRING_4256_Khaldunite_Resistance
+Action	= MULTIPLY
+Description1 = STRING_4257_Increases_damage_to_settlements_from_khaldunite_attacks_to__d___of_normal_
+Description2 = STRING_4258_Reduces_damage_to_settlements_from_khaldunite_attacks_to__d___of_normal_
+
+

--- a/TGX Files/Data/LOCALIZED/STRINGS_01.INI
+++ b/TGX Files/Data/LOCALIZED/STRINGS_01.INI
@@ -1,0 +1,3769 @@
+# Language = English ; change this to the name of the language being localized to
+# String Stripper v2.3 (c)2000 TimeGate Studios
+# Compiled - Dec 22 2000 18:08:06
+# Run - 12/22/00 6:09:32 PM
+"# Change ""Localized Text"" column to a string that approximates the meaning of the ""Source Text"" string"
+# 
+"# Any text may be added to ""Comment"" column, this is used only for the translator's notes, will not be visible in game"
+# 
+"# Save intermediate changes in Excel format, but final ""Strings_01.ini"" file must be in tab-delimited format"
+# 
+# Do not insert new columns
+# 
+"# New rows may be inserted, but only for comment purposes, any rows starting with '#' will be ignored as comments"
+# 
+# Scanning 'C:\PAT\MAP EDITOR' for source files to strip...
+# Stripping \MAPS\CTF.TGM...
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+0	Trigger		Get Arya to the enemy flag.	Get Arya to the enemy flag.	mission objectives
+1	Trigger		Arya must not die.	Arya must not die.	mission objectives
+2	Trigger		Get Dogun to the enemy flag.	Get Dogun to the enemy flag.	mission objectives
+3	Trigger		Dogun must not die.	Dogun must not die.	mission objectives
+# Stripping \MAPS\DEVIL'S ISLAND.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+4	Trigger		You have discovered a Khaldunite Field.	You have discovered a Khaldunite Field.	Upon viewing the mine
+5	Trigger		You have discovered a Ironwood Grove.	You have discovered an Ironwood Grove.	Upon viewing the mine
+6	Trigger		You have discovered a Stone Outcropping.	You have discovered a Stone Outcropping.	Upon viewing the mine
+7	Trigger		You have discovered a Iron Deposit.	You have discovered an Iron Deposit.	Upon viewing the mine
+8	Trigger		You have discovered a Gold Deposit.	You have discovered a Gold Deposit.	Upon viewing the mine
+# Stripping \MAPS\DIVIDED WORLD.TGM...					
+# Stripping \MAPS\DRAGON PASS.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+9	Trigger		Dragonscale and Dragon Dust	Dragonscale and Dragon Dust	Technology found
+10	Trigger		Shock Trooper	Shock Trooper	Technology found
+11	Trigger		Cavalier	Cavalier	Technology found
+12	Trigger		Elite Archer	Elite Archer	Technology found
+13	Trigger		Enchanter	Enchanter	Technology found
+14	Trigger		Conjuror	Conjuror	Technology found
+15	Trigger		Warlock	Warlock	Technology found
+16	Trigger		Devout	Devout	Technology found
+17	Trigger		Archmage	Archmage	Technology found
+18	Trigger		Lich	Lich	Technology found
+19	Trigger		Avatar	Avatar	Technology found
+20	Trigger		Path Finder	Path Finder	Technology found
+21	Trigger		Kyran	Kyran	Hero Amulet found
+22	Trigger		Dogun	Dogun	Hero Amulet found
+23	Trigger		Vulgari	Vulgari	Hero Amulet found
+24	Trigger		Moggok	Moggok	Hero Amulet found
+25	Trigger		Illya	Illya	Hero Amulet found
+26	Trigger		Sadira	Sadira	Hero Amulet found
+27	Trigger		Gideon	Gideon	Hero Amulet found
+28	Trigger		Sarai	Sarai	Hero Amulet found
+29	Trigger		Shamael	Shamael	Hero Amulet found
+30	Trigger		Jamsheed	Jamsheed	Hero Amulet found
+31	Trigger		Melchior	Melchior	Hero Amulet found
+32	Trigger		Garadun	Garadun	Hero Amulet found
+33	Trigger		Leila	Leila	Hero Amulet found
+34	Trigger		Amber	Amber	Hero Amulet found
+35	Trigger		Sijansur	Sijansur	Hero Amulet found
+36	Trigger		Adellon	Adellon	Hero Amulet found
+37	Trigger		You have discovered a Khaldunite Spire.	You have discovered a Khaldunite Spire.	Upon viewing the mine
+# Stripping \MAPS\EDEN IN THE SAND.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+38	Trigger		Destroy the Drauga temple	Destroy the Drauga temple	mission objectives
+# Stripping \MAPS\FACTIONS.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+39	Trigger		Garadun Payne	Garadun Payne	Hero Amulet found
+40	Trigger		Ghalen Mordecai	Ghalen Mordecai	Hero Amulet found
+41	Trigger		Vargus	Vargus	Hero Amulet found
+42	Trigger		Naava Daishan	Naava Daishan	Hero Amulet found
+43	Trigger		Seth Aswan	Seth Aswan	Hero Amulet found
+44	Trigger		Adellon Majere	Adellon Majere	Hero Amulet found
+45	Trigger		Lazarus	Lazarus	Hero Amulet found
+# Stripping \MAPS\FROZEN STEPPES.TGM...					
+# Stripping \MAPS\LAKE WORLD.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+46	Trigger		Amber Yasin	Amber Yasin	Hero Amulet found
+47	Trigger		Sarai Marusek	Sarai Marusek	Hero Amulet found
+48	Trigger		Selvana	Selvana	Hero Amulet found
+49	Trigger		Eben Barush	Eben Barush	Hero Amulet found
+50	Trigger		Balthasar Aswan	Balthasar Aswan	Hero Amulet found
+51	Trigger		Arya Shahin	Arya Shahin	Hero Amulet found
+52	Trigger		Sadira Bahrum	Sadira Bahrum	Hero Amulet found
+53	Trigger		Kendra Langston	Kendra Langston	Hero Amulet found
+54	Trigger		Counter Magic	Counter Magic	Technology found
+55	Trigger		Crystal Ring	Crystal Ring	Technology found
+56	Trigger		Dead Zone	Dead Zone	Technology found
+57	Trigger		Enchanted Leather	Enchanted Leather	Technology found
+58	Trigger		Healing Potion	Healing Potion	Technology found
+59	Trigger		Ironwood Bow	Ironwood Bow	Technology found
+60	Trigger		Dragon Dust	Dragon Dust	Technology found
+61	Trigger		Mil college	Mil college	Technology found
+62	Trigger		Bone Reaver	Bone Reaver	Technology found
+63	Trigger		Golems	Golems	Technology found
+64	Trigger		Void Beasts	Void Beasts	Technology found
+65	Trigger		Elite Archers	Elite Archers	Technology found
+66	Trigger		Darius Javidan & Stength	Darius Javidan & Stength	Hero Amulet+tech found
+67	Trigger		Ruarc Varagoth	Ruarc Varagoth	Hero Amulet found
+68	Trigger		Tarifs	Tarifs	Technology found
+69	Trigger		Capitalism	Capitalism	Technology found
+70	Trigger		Acadeny	Acadeny	Technology found
+71	Trigger		Slaan Champion	Slaan Champion	Technology found
+72	Trigger		Militia	Militia	Technology found
+73	Trigger		Geomancy	Geomancy	Technology found
+74	Trigger		Advisors	Advisors	Technology found
+75	Trigger		Blessing of Shadow	Blessing of Shadow	Technology found
+# Stripping \MAPS\MM-05.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+76	Trigger		You have discovered a Khaldunite Cluster.	You have discovered a Khaldunite Cluster.	Upon viewing the mine
+77	Trigger		You have discovered a Iron Ore.	You have discovered an Iron Ore.	Upon viewing the mine
+78	Trigger		You have discovered a Gold Ore.	You have discovered a Gold Ore.	Upon viewing the mine
+# Stripping \MAPS\MM-M1.TGM...					
+# Stripping \MAPS\MM1-5P.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+79	Trigger		Find the Temple of Creation and the long lost cache of Kohan amulets.	Find the Temple of Creation and the long lost cache of Kohan amulets.	mission objectives
+# Stripping \MAPS\MM2-5P.TGM...					
+# Stripping \MAPS\OPPOSING FORCES.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+80	Trigger		Shohn Maht	Shohn Maht	Hero Amulet found
+81	Trigger		Praxus	Praxus	Hero Amulet found
+82	Trigger		Ilyana Aswan	Ilyana Aswan	Hero Amulet found
+# Stripping \MAPS\RHAKSHA CIRCLE.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+83	Trigger		Vashti	Vashti	Hero Amulet found
+84	Trigger		Jamsheed Javidan	Jamsheed Javidan	Hero Amulet found
+85	Trigger		Sadira Bahhrum	Sadira Bahhrum	Hero Amulet found
+86	Trigger		Thaddeus Maesun	Thaddeus Maesun	Hero Amulet found
+# Stripping \MAPS\RHAKSHA_FRONT.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+87	Trigger		target rampagers to south point	target rampagers to south point	==
+88	Trigger		Destroy the Rhaksha infestation to the north.	Destroy the Rhaksha infestation to the north.	mission objectives
+# Stripping \MAPS\THE CRAGG.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+89	Trigger		Lyssa Edan	Lyssa Edan	Hero Amulet found
+90	Trigger		Leila Javidan	Leila Javidan	Hero Amulet found
+91	Trigger		Sar Lashkar	Sar Lashkar	Hero Amulet found
+92	Trigger		Amon Koth	Amon Koth	Hero Amulet found
+93	Trigger		Javon Shahin	Javon Shahin	Hero Amulet found
+94	Trigger		Cyrus Naadev	Cyrus Naadev	Hero Amulet found
+95	Trigger		Darius Javidan	Darius Javidan	Hero Amulet found
+# Stripping \MAPS\WILD WORLD.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+96	Trigger		Lyssa amulet	Lyssa amulet	Hero Amulet found
+97	Trigger		King Ulric amulet and Counter magic tech	King Ulric amulet and Counter magic tech	Hero Amulet+tech found
+98	Trigger		Avatar tech	Avatar tech	Technology found
+99	Trigger		Shock trooper tech and Ghalen Mordecai amulet	Shock trooper tech and Ghalen Mordecai amulet	Hero Amulet+tech found
+100	Trigger		Ravyn Dunn amulet and Cavalier tech	Ravyn Dunn amulet and Cavalier tech	Hero Amulet found
+101	Trigger		Blessing of shadow tech	Blessing of shadow tech	Technology found
+102	Trigger		Devout tech	Devout tech	Technology found
+103	Trigger		UInholy blades technology	UInholy blades technology	Technology found
+104	Trigger		White steel blades tech	White steel blades tech	Technology found
+105	Trigger		Summon dark wolves	Summon dark wolves	Technology found
+106	Trigger		Lich technology	Lich technology	Technology found
+107	Trigger		Dragon dust and Dragonscale armor technologies	Dragon dust and Dragonscale armor technologies	Technology found
+108	Trigger		Khaldunite spear teech	Khaldunite spear teech	Technology found
+109	Trigger		Khaldunite arrow tech	Khaldunite arrow tech	Technology found
+110	Trigger		Khaldunite shield tech	Khaldunite shield tech	Technology found
+111	Trigger		Khaldunite blade tech	Khaldunite blade tech	Technology found
+112	Trigger		Praxus amulet and magic arrow and Pathfinder techs	Praxus amulet and magic arrow and Pathfinder techs	Hero Amulet+tech found
+113	Trigger		Summons Dark Wolves	Summons Dark Wolves	Technology found
+114	Trigger		Ethan Delroba amulet and potion of strength	Ethan Delroba amulet and potion of strength	Hero Amulet+tech found
+115	Trigger		Ruarc Varagoth amulet and Elite Archer	Ruarc Varagoth amulet and Elite Archer	Hero Amulet+tech found
+116	Trigger		Jasmin Shahin and Holy blades	Jasmin Shahin and Holy blades	Hero Amulet+tech found
+117	Trigger		Magic potion tech	Magic potion tech	Technology found
+118	Trigger		Naava Daishan and Enchanter tech	Naava Daishan and Enchanter tech	Hero Amulet+tech found
+119	Trigger		Dead zone tech	Dead zone tech	Technology found
+120	Trigger		Gideon Xarr amulet	Gideon Xarr amulet	Hero Amulet found
+121	Trigger		Vulgari Amulet and Unholy armor tech	Vulgari Amulet and Unholy armor tech	Hero Amulet+tech found
+122	Trigger		Selvana amulet	Selvana amulet	Hero Amulet found
+123	Trigger		Silken Robe	Silken Robe	Technology found
+124	Trigger		Enchanted leather tech	Enchanted leather tech	Technology found
+125	Trigger		Vargus amulet	Vargus amulet	Hero Amulet found
+126	Trigger		Dylan Gaarwood	Dylan Gaarwood	Hero Amulet found
+127	Trigger		 Balthasar Aswan and  Crystal ring	 Balthasar Aswan and  Crystal ring	Hero Amulet+tech found
+128	Trigger		Silk Armor tech	Silk Armor tech	Technology found
+129	Trigger		The Hunter amulet	The Hunter amulet	Hero Amulet found
+130	Trigger		Kendra Langston amulet	Kendra Langston amulet	Hero Amulet found
+131	Trigger		Adellon Majere and Archmage	Adellon Majere and Archmage	Hero Amulet+tech found
+132	Trigger		Slaan Champion tech	Slaan Champion tech	Technology found
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM1.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+133	Trigger		Mine some resources to support your quest.	Mine some resources to support your quest.	mission objectives
+134	Trigger		Clear the area of all potential dangers.	Clear the area of all potential dangers.	mission objectives
+135	Trigger		"Nurture the town of New Hope, developing it into a city."	"Nurture the town of New Hope, developing it into a city."	mission objectives
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM10.TGM...					
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM11.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+136	Trigger		Do not let the Ceyah capture your Citadel.	Do not let the Ceyah capture your Citadel.	mission objectives
+137	Trigger		Take control of the Ceyah port city.	Take control of the Ceyah port city.	mission objectives
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM12.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+138	Trigger		Do not let the Ceyah take control of this land during the confusion of the quake.	Do not let the Ceyah take control of this land during the confusion of the quake.	mission objectives
+139	Trigger		Assist the people of this land by helping them rebuild their homes.	Assist the people of this land by helping them rebuild their homes.	mission objectives
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM13.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+140	Trigger		Find and destroy Ceyahdev.	Find and destroy Ceyahdev.	mission objectives
+141	Trigger		Find Ceyahdev.	Find Ceyahdev.	mission objectives
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM14.TGM...					
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM15.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+142	Trigger		Fight your way to the Stormport and capture it so your fleet can land.	Fight your way to the Stormport and capture it so your fleet can land.	mission objective
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM16.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+143	Trigger		Do not let the Ceyah army overrun your base.	Do not let the Ceyah army overrun your base.	mission objective
+144	Trigger		Lay siege to Ahriman's Citadel and capture it.	Lay siege to Ahriman's Citadel and capture it.	mission objective
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM2.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+145	Trigger		Don't let the Drauga capture all the independant settlements.	Don't let the Drauga capture all the independant settlements.	mission objective
+146	Trigger		Confront the leader of the Drauga and stop their attacks.	Confront the leader of the Drauga and stop their attacks.	mission objective
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM3.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+147	Trigger		You have discovered a Iron Mine.	You have discovered an Iron Mine.	Upon viewing the mine
+148	Trigger		Do not let the rhaksha overrun all of the Drauga Villages.	Do not let the rhaksha overrun all of the Drauga Villages.	mission objective
+149	Trigger		Find and destroy the source of the Rhaksha menace.	Find and destroy the source of the Rhaksha menace.	mission objective
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM4.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+150	Trigger		Backup trigger to prevent Haroun win.	Backup trigger to prevent Haroun win.	Hack to prevent loss
+151	Trigger		Do not go to war with the greater Haroun kingdom.	Do not go to war with the greater Haroun kingdom.	mission objective
+152	Trigger		Establish an alliance treaty with the greater Haroun kingdom.	Establish an alliance treaty with the greater Haroun kingdom.	mission objective
+153	Trigger		Reunite the independant Haroun Sanctuaries under your banner.	Reunite the independant Haroun Sanctuaries under your banner.	mission objective
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM5.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+154	Trigger		You have discovered a Gold Mine.	You have discovered a Gold Mine.	Upon viewing the mine
+155	Trigger		Free the people under the control of the evil tyrant.	Free the people under the control of the evil tyrant.	mission objective
+156	Trigger		Destroy the evil tyrant before he takes over the entire land.	Destroy the evil tyrant before he takes over the entire land.	mission objective
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM6.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+157	Trigger		Don't let Roxanna get killed.	Don't let Roxanna get killed.	mission objective
+158	Trigger		Bring Roxxana to the Dark Rift.	Bring Roxxana to the Dark Rift.	mission objective
+159	Trigger		Determine where the Ceyah forces are coming from.	Determine where the Ceyah forces are coming from.	mission objective
+160	Trigger		Repair the damaged outposts and rebuild the destroyed ones.	Repair the damaged outposts and rebuild the destroyed ones.	mission objective
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM7.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+161	Trigger		You must kill the remaining Hive within 5 minutes.	You must kill the remaining Hive within 5 minutes.	mission objective
+162	Trigger		Determine what is transpiring in these lands and remedy the situation.	Determine what is transpiring in these lands and remedy the situation.	mission objective
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM8.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+163	Trigger		Engage the Ceyah army before they call for reinforcements.	Engage the Ceyah army before they call for reinforcements.	mission objective
+164	Trigger		Destroy the Ceyah army waiting in the east.	Destroy the Ceyah army waiting in the east.	mission objective
+165	Trigger		Liberate the city of Jansur.	Liberate the city of Jansur.	mission objective
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM9.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+166	Trigger		Dummy objective to prevent Haroun winning.	Dummy objective to prevent Haroun winning.	mission objective
+167	Trigger		Find and defeat Amon Koth.	Find and defeat Amon Koth.	mission objective
+# Stripping \MAPS\BASIC TUTORIAL\BTM1.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+168	Trigger		Complete all the directives given in the tutorial scenario.	Complete all the directives given in the tutorial scenario.	mission objective
+# Stripping \MAPS\BASIC TUTORIAL\BTM2.TGM...					
+# Stripping \MAPS\BASIC TUTORIAL\BTM3.TGM...					
+# Stripping \MAPS\BASIC TUTORIAL\BTM4.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+169	Trigger		You cannot go off attacking everything without reason. This will not help you obtain your goals.	You cannot go off attacking everything without reason. This will not help you obtain your goals.	Hack message
+# Stripping \MAPS\BASIC TUTORIAL\BTM5.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+170	Trigger		While you were wasting time treasure hunting the brigands have take hold of the pass.	While you were wasting time treasure hunting the brigands have take hold of the pass.	Hack message
+171	Trigger		By attacking the bandits before securing the pass you have failed in your objectives.	By attacking the bandits before securing the pass you have failed in your objectives.	Hack message
+# Stripping \MAPS\BASIC TUTORIAL\BTM6.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+172	Trigger		You have attacked the Shadow forces before preparing yourself. This mission is a failure.	You have attacked the Shadow forces before preparing yourself. This mission is a failure.	Hack message
+173	Trigger		Complete all the given directives in the tutorial scenario.	Complete all the given directives in the tutorial scenario.	mission objective
+# Stripping \MAPS\ADVANCED TUTORIAL\ATM1.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+174	Trigger		Complete all tasks given in the tutorial scenario.	Complete all tasks given in the tutorial scenario.	mission objective
+# Stripping \MAPS\ADVANCED TUTORIAL\ATM2.TGM...					
+# Stripping \MAPS\ADVANCED TUTORIAL\ATM3.TGM...					
+# Stripping \MAPS\ADVANCED TUTORIAL\ATM4.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+175	Trigger		Zone Hint	Zone Hint	Story Piece
+176	Trigger		Economic Hint	Economic Hint	Story Piece
+177	Trigger		100% of the settlements.	100% of the settlements.	Story Piece
+178	Trigger		Time for a regiment.	Time for a regiment.	Story Piece
+179	Trigger		Enemy Capital	Enemy Capital	Story Piece
+180	Trigger		Monolith	Monolith	Story Piece
+181	Trigger		Sand Ruins	Sand Ruins	Story Piece
+182	Trigger		Independant Village	Independant Village	Story Piece
+183	Trigger		Ceyah Killed Bandits	Ceyah Killed Bandits	Story Piece
+184	Trigger		Bandit Camp Visible	Bandit Camp Visible	Story Piece
+185	Trigger		Outpost Hint	Outpost Hint	Story Piece
+186	Trigger		Bandit Camp Destroyed	Bandit Camp Destroyed	Story Piece
+187	Trigger		Hill Ruins Found	Hill Ruins Found	Story Piece
+188	Trigger		Rhaksha Nest Found	Rhaksha Nest Found	Story Piece
+189	Trigger		Gold Mine Found	Gold Mine Found	Story Piece
+# Stripping \SOURCE\AI\C_MACHINE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+190	Message	51	Company %s is regrouping and cannot be given orders	Company %s is regrouping and cannot be given orders	Action Messages
+191	Message	45	%s has been explored and cannot be destroyed.	%s has been explored and cannot be destroyed.	Action Messages
+192	Message	23	%s cannot be destroyed.	%s cannot be destroyed.	Action Messages
+193	Message	33	You cannot afford repairs with %s	You cannot afford repairs with %s	Action Messages
+194	Message	38	You are not allowed to build outposts.	You are not allowed to build outposts.	Action Messages
+195	Message	47	You are at the maximum number of outposts (%d).	You are at the maximum number of outposts (%d).	Action Messages
+196	Message	41	You are not allowed to build settlements.	You are not allowed to build settlements.	Action Messages
+197	Message	50	You are at the maximum number of settlements (%d).	You are at the maximum number of settlements (%d).	Action Messages
+198	Message	39	%s's %s broke before your armies.	%s's %s broke before your armies.	Action Messages
+199	Message	36	%s cannot be disbanded at this time.	%s cannot be disbanded at this time.	Action Messages
+200	Message	23	%s disbanded.	%s disbanded.	Action Messages
+201	Unknown	4	down	down	==
+202	Message	31	%s is engaging enemy intruders.	%s is engaging enemy intruders.	Action Messages
+203	Message	45	You cannot afford to continue repairs with %s	You cannot afford to continue repairs with %s	Action Messages
+204	Message	48	You must have at least one engineer to repair %s	You must have at least one engineer to repair %s	Action Messages
+205	Message	47	You must have at least one settler to repair %s	You must have at least one settler to repair %s	Action Messages
+# Stripping \SOURCE\AI\MACHINE.CPP...					
+# Stripping \SOURCE\AI\PATH.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+206	Unknown	12	Unidentified	Unidentified	==
+207	Unknown	6	Solver	Solver	==
+# Stripping \SOURCE\AI\U_FOLLOW.CPP...					
+# Stripping \SOURCE\AI\U_MACHINE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+208	Message	42	%s was out of supply from %s for too long.	%s was out of supply from %s for too long.	Action Messages
+# Stripping \SOURCE\GAME\CAMPAIGN.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+209	Unknown	12	%s - Story%d	%s - Story%d	Loading Mission Message
+210	Unknown	16	Loading Mission	Loading Mission	Loading Mission Message
+211	Warning	41	"Map loaded, but there were problems:\n %s"	"Map loaded, but there were problems:\n %s"	Loading Mission Message
+212	Unknown	17	Loading Savegame	Loading Savegame	Loading Mission Message
+213	Unknown	11	Testing Map	Testing Map	==
+214	Unknown	18	Correcting Terrain	Correcting Terrain	==
+215	Unknown	13	Restoring Map	Restoring Map	==
+216	Warning	21	Error loading map: %s	Error loading map: %s	Loading Mission Message
+217	Unknown	11	%d Kingdoms	%d Kingdoms	==
+218	Unknown	41	Max %d Cities\nMax %d Mines\nMax %d Lairs	Max %d Cities\nMax %d Mines\nMax %d Lairs	==
+219	Unknown	38	Scenario play description unavailable.	Scenario play description unavailable.	Error Message
+220	Unknown	29	%d Cities\n%d Mines\n%d Lairs	%d Cities\n%d Mines\n%d Lairs	==
+221	Unknown	7	New Map	New Map	Message
+222	Unknown	14	No text found.	No text found.	Message
+223	Message	20	Can't find story %s.	Can't find story %s.	Error Message
+# Stripping \SOURCE\GAME\COMPANY.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+224	Unknown	5	Limbo	Limbo	Company Action Status
+225	Unknown	7	Resting	Resting	Company Action Status
+226	Unknown	10	Entrenched	Entrenched	Company Action Status
+227	Unknown	9	Fortified	Fortified	Company Action Status
+228	Unknown	6	Moving	Moving	Company Action Status
+229	Unknown	7	Chasing	Chasing	Company Action Status
+230	Unknown	7	Engaged	Engaged	Company Action Status
+231	Unknown	10	Retreating	Retreating	Company Action Status
+232	Unknown	7	Routing	Routing	Company Action Status
+233	Unknown	8	Building	Building	Company Action Status
+234	Unknown	9	Repairing	Repairing	Company Action Status
+235	Unknown	6	Unused	Unused	Company Action Status
+236	Unknown	7	Forming	Forming	Company Action Status
+237	Unknown	10	Regrouping	Regrouping	Company Action Status
+238	Unknown	8	Settling	Settling	Company Action Status
+239	Unknown	8	Guarding	Guarding	Company Action Status
+240	Unknown	9	Returning	Returning	Company Action Status
+241	Unknown	12	Not Supplied	Not Supplied	Company Action Status
+242	Error	26	loading company spell list	loading company spell list	==
+243	Message	19	%s settled %s.	%s settled %s.	Company Message
+244	Message	23	%s destroyed.	%s destroyed.	Company Message
+245	Message	28	%s's %s destroyed.	%s's %s destroyed.	Company Message
+246	Message	34	%s is not available to be attached	%s is not available to be attached	Attach Hero Message
+247	Message	34	%s cannot be attached at this time	%s cannot be attached at this time	Attach Hero Message
+248	Message	49	%s cannot be attached unless company is in supply	%s cannot be attached unless company is in supply	Attach Hero Message
+249	Message	26	%s has been attached to %s	%s has been attached to %s	Attach Hero Message
+250	Message	29	Company could not reorganize.	Company could not reorganize.	Company Message
+251	Message	34	%s cannot be detached at this time	%s cannot be detached at this time	Detach Hero Message
+252	Message	49	%s cannot be detached unless company is in supply	%s cannot be detached unless company is in supply	Detach Hero Message
+253	Message	43	%s cannot be detached unless at full health	%s cannot be detached unless at full health	Detach Hero Message
+254	Message	46	You do not have enough gold to detach %s.	You do not have enough gold to detach %s.	Detach Hero Message
+255	Message	28	%s has been detached from %s	%s has been detached from %s	Detach Hero Message
+256	Unknown	7	Unknown	Unknown	==
+257	Message	31	You have been redeemed %d gold.	You have been redeemed %d gold.	Gold Message
+258	Message	57	You must have at least one engineer to begin construction	You must have at least one engineer to begin construction	Engineer Message
+259	Message	56	You must have at least one settler to begin construction	You must have at least one settler to begin construction	Settler Message
+260	Message	73	You cannot build a structure there - it is too close to other structures.	You cannot build a structure there - it is too close to other structures.	Build Message
+261	Message	42	You cannot afford to build that structure.	You cannot afford to build that structure.	Build Message
+262	Message	57	"Could not lay foundation for %s, something is in the way."	"Could not lay foundation for %s, something is in the way."	Build Message
+263	Message	45	%s are too exhausted to continue pressed move.	%s are too exhausted to continue pressed move.	Company Message
+264	Message	22	%s advanced to %s	%s advanced to %s	Company Message
+# Stripping \SOURCE\GAME\GAMEDEFINES.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+265	g_hero_state_name	6	Amulet	Amulet	Hero Status
+266	g_hero_state_name	6	Asleep	Asleep	Hero Status
+267	g_hero_state_name	5	Awake	Awake	Hero Status
+268	g_hero_state_name	10	In Company	In Company	Hero Status
+269	g_experience_name	7	Recruit	Recruit	Company Experience Level
+270	g_experience_name	7	Regular	Regular	Company Experience Level
+271	g_experience_name	7	Veteran	Veteran	Company Experience Level
+272	g_experience_name	5	Elite	Elite	Company Experience Level
+273	g_resource_names	4	Gold	Gold	Resource Name
+274	g_resource_names	5	Stone	Stone	Resource Name
+275	g_resource_names	4	Wood	Wood	Resource Name
+276	g_resource_names	4	Iron	Iron	Resource Name
+277	g_resource_names	4	Mana	Mana	Resource Name
+278	g_relation_names	4	Self	Self	Player Status
+279	g_relation_names	4	Ally	Ally	Player Status
+280	g_relation_names	7	Neutral	Neutral	Player Status
+281	g_relation_names	5	Enemy	Enemy	Player Status
+282	g_treaty_names	8	Alliance	Alliance	Allied Status
+283	g_treaty_names	5	Peace	Peace	Allied Status
+284	g_treaty_names	3	War	War	Allied Status
+285	g_move_mode_names	12	All-Out Mode	All-Out Mode	Formation Name
+286	g_move_mode_names	11	Column Mode	Column Mode	Formation Name
+287	g_move_mode_names	11	Combat Mode	Combat Mode	Formation Name
+288	g_move_mode_names	13	Skirmish Mode	Skirmish Mode	Formation Name
+289	g_move_mode_names	12	Pressed Mode	Pressed Mode	Formation Name
+290	g_move_mode_names	12	Retreat Mode	Retreat Mode	Formation Name
+291	g_move_mode_names	9	Rout Mode	Rout Mode	Formation Name
+292	s_skill_level_names	4	Easy	Easy	Skill level
+293	s_skill_level_names	6	Medium	Medium	Skill level
+# Stripping \SOURCE\GAME\PLAYER.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+294	Unknown	11	Independent	Independent	Player Name
+295	Unknown	9	Player %d	Player %d	Player Name
+296	Message	38	All political relationships are locked	All political relationships are locked	Diplomacy Message
+297	Message	41	Relationship between %s and %s is locked.	Relationship between %s and %s is locked.	Diplomacy Message
+298	Unknown	28	Alliance established with %s	Alliance established with %s	Diplomacy Message
+299	Unknown	36	You have broken the alliance with %s	You have broken the alliance with %s	Diplomacy Message
+300	Unknown	27	%s has broken the alliance!	%s has broken the alliance!	Diplomacy Message
+301	Unknown	25	Peace established with %s	Peace established with %s	Diplomacy Message
+302	Unknown	27	You have declared war on %s	You have declared war on %s	Diplomacy Message
+303	Unknown	20	%s has declared war!	%s has declared war!	Diplomacy Message
+304	Message	28	Technology %s gained from %s	Technology %s gained from %s	Technology Message
+305	Message	20	Technology %s gained	Technology %s gained	Technology Message
+306	Message	44	Your production is %d%% short of your costs.	Your production is %d%% short of your costs.	Economy Message
+307	Message	31	Your economy has been repaired.	Your economy has been repaired.	Economy Message
+308	Message	41	%s has reached %d gold (alliance %d gold)	%s has reached %d gold (alliance %d gold)	Gold % Message
+309	Message	22	%s has reached %d gold	%s has reached %d gold	Gold % Message
+310	Message	45	%s has reached %d cities (alliance %d cities)	%s has reached %d cities (alliance %d cities)	City % Message
+311	Message	24	%s has reached %d cities	%s has reached %d cities	City % Message
+312	Message	46	%s controls %d%% of the cities (alliance %d%%)	%s controls %d%% of the cities (alliance %d%%)	City % Message
+313	Message	30	%s controls %d%% of the cities	%s controls %d%% of the cities	City % Message
+314	Message	24	Mission objective added.	Mission objective added.	Mission objective message
+315	Message	26	Mission objective removed.	Mission objective removed.	Mission objective message
+316	Message	34	Tribute greater than gold on hand.	Tribute greater than gold on hand.	Diplomacy Message
+317	Message	16	%s is not awake.	%s is not awake.	Hero Message
+318	Message	20	%s is not available.	%s is not available.	Hero Message
+319	Message	21	%s has returned home.	%s has returned home.	Hero Message
+320	Message	19	%s has been killed.	%s has been killed.	Hero Message
+321	Message	31	You cannot afford to awaken %s.	You cannot afford to awaken %s.	Hero Message
+322	Message	38	You cannot afford to awaken this hero.	You cannot afford to awaken this hero.	Hero Message
+323	Message	17	%s is not asleep.	%s is not asleep.	Hero Message
+324	Message	59	WARNING: trigger tried to remove hero %s that is on the map	WARNING: trigger tried to remove hero %s that is on the map	Hero Message
+325	Message	22	%s has left your camp.	%s has left your camp.	Hero Message
+326	Message	29	You have lost a Kohan Amulet.	You have lost a Kohan Amulet.	Amulet Message
+327	Message	24	You have been wiped out!	You have been wiped out!	Wipe Out Message
+328	Message	22	%s has been wiped out!	%s has been wiped out!	Wipe Out Message
+# Stripping \SOURCE\GAME\REGIMENT.CPP...					
+# Stripping \SOURCE\GAME\SAVEGAME.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+329	Unknown	17	Repairing Terrain	Repairing Terrain	Loading Mission Message
+330	Unknown	15	Initializing AI	Initializing AI	Loading Mission Message
+331	Unknown	10	Saving Map	Saving Map	Saving Message
+332	Message	15	Error saving %s	Error saving %s	Saving Message
+333	Message	11	Saved to %s	Saved to %s	Saving Message
+334	Message	9	%s loaded	%s loaded	Loading Message
+335	Message	17	Could not load %s	Could not load %s	Loading Message
+# Stripping \SOURCE\GAME\SCENARIO.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+336	Warning	91	Failed to place all players with given parameters.  Change settings and regenerate the map.	Failed to place all players with given parameters.  Change settings and regenerate the map.	Error Message
+337	Unknown	19	Uninitializing Game	Uninitializing Game	Loading Mission Message
+338	Unknown	18	Generating Terrain	Generating Terrain	Loading Mission Message
+339	Unknown	19	Placing Stuff To Do	Placing Stuff To Do	Loading Mission Message
+340	Unknown	10	Random Map	Random Map	Loading Mission Message
+341	Unknown	10	Settlement	Settlement	==
+342	Unknown	7	Village	Village	Settlement Name
+343	Unknown	4	Town	Town	Settlement Name
+344	Unknown	4	City	City	Settlement Name
+345	Unknown	7	Citadel	Citadel	Settlement Name
+346	Unknown	13	draugavillage	draugavillage	Settlement Name
+# Stripping \SOURCE\GAME\SPELL.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+347	Warning	23	could not find spell %s	could not find spell %s	Spell message
+348	Unknown	10	Projectile	Projectile	Spell Type
+349	Unknown	4	Area	Area	Spell Type
+350	Unknown	8	Personal	Personal	Spell Type
+351	Unknown	5	Group	Group	Spell Type
+352	Unknown	6	Summon	Summon	Spell Type
+353	Unknown	6	Single	Single	Spell Type
+354	Unknown	6	Volley	Volley	Spell Type
+355	Unknown	4	Heal	Heal	Spell Type
+356	Unknown	4	Holy	Holy	Spell Type
+357	Unknown	6	Unholy	Unholy	Spell Type
+358	Unknown	5	Leech	Leech	Spell Type
+359	Unknown	18	Summoned Creatures	Summoned Creatures	Summon Spell message
+360	Unknown	20	Summon spell failed.	Summon spell failed.	Summon Spell message
+# Stripping \SOURCE\GAME\TGBONUS.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+361	Unknown	3	Add	Add	Bonus Type
+362	Unknown	8	Multiply	Multiply	Bonus Type
+363	Unknown	4	Flag	Flag	Bonus Type
+364	Unknown	7	Special	Special	Bonus Type
+# Stripping \SOURCE\GAME\TGGAME.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+365	Unknown	15	Cataclysm Spoor	Cataclysm Spoor	**
+366	g_start_levels	11	No Outposts	No Outposts	Starting Outpost Condition
+367	g_start_levels	9	1 Outpost	1 Outpost	Starting Outpost Condition
+368	g_start_levels	10	2 Outposts	2 Outposts	Starting Outpost Condition
+369	g_start_levels	10	3 Outposts	3 Outposts	Starting Outpost Condition
+370	g_start_levels	10	4 Outposts	4 Outposts	Starting Outpost Condition
+371	Error	43	Campaign missions cannot be user savegames.	Campaign missions cannot be user savegames.	Custom Map Error
+372	Error	85	"Loading a campaign map in a non-campaign game or vice-versa (Player: %s, Campaign %s)"	"Loading a campaign map in a non-campaign game or vice-versa (Player: %s, Campaign %s)"	Custom Map Error
+373	Error	24	loading map data from %s	loading map data from %s	Custom Map Error
+374	Error	30	Map contains isolated objects.	Map contains isolated objects.	Custom Map Error
+375	Warning	49	Map contains isolated objects - use Repair Map.\n	Map contains isolated objects - use Repair Map.\n	Custom Map Warning
+376	Warning	26	Could not load object %s\n	Could not load object %s\n	Custom Map Warning
+377	Warning	41	Could not load %s: category has changed\n	Could not load %s: category has changed\n	Custom Map Warning
+378	Warning	38	Could not load %s: class has changed\n	Could not load %s: class has changed\n	Custom Map Warning
+379	Error	26	object load failed %d (%s)	object load failed %d (%s)	Custom Game Error
+380	Error	37	Player %d is non-AI but must be an AI	Player %d is non-AI but must be an AI	Custom Game Error
+381	Error	17	Loading player %d	Loading player %d	Custom Game Error
+382	Error	36	There is no human player in the map.	There is no human player in the map.	Custom Game Error
+383	Unknown	12	%s's Capital	%s's Capital	==
+384	Error	37	Could not place village for player %d	Could not place village for player %d	Custom Game Error
+385	Unknown	10	%s's Spire	%s's Spire	
+386	Unknown	15	Defensive Spire	Defensive Spire	
+387	Unknown	9	Lightning	Lightning	
+388	Unknown	29	Defensive Spire Self-Destruct	Defensive Spire Self-Destruct	
+389	Unknown	10	%s Company	%s Company	
+390	Message	37	You have been given %d Kohan amulets.	You have been given %d Kohan amulets.	Amulet Message
+391	Unknown	12	Mine Trigger	Mine Trigger	Upon viewing the mine
+392	Unknown	24	You have discovered: %s.	You have discovered: %s.	Upon viewing the mine
+393	Unknown	19	Custom Game Trigger	Custom Game Trigger	Trigger Name
+394	Unknown	12	%s's Kingdom	%s's Kingdom	Kingdom Name
+395	Message	74	The skies darken and the land begins to convulse. The Cataclysm has begun!	The skies darken and the land begins to convulse. The Cataclysm has begun!	Cataclysm Message
+396	Message	66	The convulsions trickle down to nothing.  The Cataclysm has ended.	The convulsions trickle down to nothing.  The Cataclysm has ended.	Cataclysm Message
+397	Message	26	Your kingdom has crumbled.	Your kingdom has crumbled.	Kingdom Loss Message
+398	Message	26	%s's kingdom has crumbled.	%s's kingdom has crumbled.	Kingdom Loss Message
+399	Unknown	11	Unspecified	Unspecified	==
+400	Warning	38	The Human player is set as disabled.\n	The Human player is set as disabled.\n	Player Message
+401	Unknown	40	Player %d is missing a start position.\n	Player %d is missing a start position.\n	Player Message
+402	Unknown	26	%s commissioned out of %s.	%s commissioned out of %s.	Company Message
+403	Unknown	21	%s engaged the enemy.	%s engaged the enemy.	Company Message
+404	Unknown	15	%s routed!	%s routed!	Company Message
+405	Unknown	67	You have run out of money and cannot afford to upkeep your kingdom.	You have run out of money and cannot afford to upkeep your kingdom.	Economy Message
+406	Unknown	27	The %s have been destroyed!	The %s have been destroyed!	Company Message
+407	Unknown	25	%s has joined your cause!	%s has joined your cause!	Settlement Message
+408	Unknown	32	%s has surrendered to the enemy!	%s has surrendered to the enemy!	Settlement Message
+409	Unknown	29	Construction of %s completed.	Construction of %s completed.	Settlement Message
+# Stripping \SOURCE\GAME\TGMISSIONSETTINGS.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+410	Unknown	7	Default	Default	Custom Game Type
+411	Unknown	8	Scenario	Scenario	Custom Game Type
+412	Unknown	6	Custom	Custom	Custom Game Type
+413	Unknown	10	Deathmatch	Deathmatch	Custom Game Type
+414	Unknown	9	Bloodbath	Bloodbath	Custom Game Type
+415	Unknown	7	Conquer	Conquer	Custom Game Type
+416	Unknown	6	Gnomes	Gnomes	Custom Game Type
+417	Unknown	12	Random %dx%d	Random %dx%d	Custom Game Type
+# Stripping \SOURCE\GAME\TGPLAYERSTATS.CPP...					
+# Stripping \SOURCE\GAME\TREATIES.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+418	Message	27	%s has accepted your treaty	%s has accepted your treaty	Diplomacy Message
+419	Message	27	%s has rejected your treaty	%s has rejected your treaty	Diplomacy Message
+420	Message	43	You have accepted the treaty proposed by %s	You have accepted the treaty proposed by %s	Diplomacy Message
+421	Message	43	You have rejected the treaty proposed by %s	You have rejected the treaty proposed by %s	
+422	Message	29	DEBUG: Trade treaty not found	DEBUG: Trade treaty not found	Diplomacy Message
+423	Message	41	%s has cancelled the offered peace treaty	%s has cancelled the offered peace treaty	Diplomacy Message
+424	Message	37	%s has cancelled the offered alliance	%s has cancelled the offered alliance	Diplomacy Message
+425	Message	49	You have cancelled the offered peace treaty to %s	You have cancelled the offered peace treaty to %s	Diplomacy Message
+426	Message	45	You have cancelled the offered alliance to %s	You have cancelled the offered alliance to %s	Diplomacy Message
+427	Message	35	%s has given you %d gold in tribute	%s has given you %d gold in tribute	Tribute Message
+428	Message	39	You have given %d gold in tribute to %s	You have given %d gold in tribute to %s	Tribute Message
+429	Message	47	You do not have enough gold to give %d tribute.	You do not have enough gold to give %d tribute.	Tribute Message
+430	Message	33	%s has offered you a peace treaty	%s has offered you a peace treaty	Diplomacy Message
+431	Message	30	%s has offered you an alliance	%s has offered you an alliance	Diplomacy Message
+432	Message	37	You have offered a peace treaty to %s	You have offered a peace treaty to %s	Diplomacy Message
+433	Message	34	You have offered an alliance to %s	You have offered an alliance to %s	Diplomacy Message
+# Stripping \SOURCE\GAME\ZONES.CPP...					
+# Stripping \SOURCE\GAME\QUEST\TGTRIGGERCONDITION.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+434	Unknown	4	None	None	Trigger Condition Name
+435	Unknown	16	Killed By Player	Killed By Player	Trigger Condition Name
+436	Unknown	11	Object Dead	Object Dead	Trigger Condition Name
+437	Unknown	21	Currently Near Object	Currently Near Object	Trigger Condition Name
+438	Unknown	12	Found Object	Found Object	Trigger Condition Name
+439	Unknown	17	Currently Visible	Currently Visible	Trigger Condition Name
+440	Unknown	15	Explored Object	Explored Object	Trigger Condition Name
+441	Unknown	18	Captured By Player	Captured By Player	Trigger Condition Name
+442	Unknown	12	Object Owned	Object Owned	Trigger Condition Name
+443	Unknown	5	Timer	Timer	Trigger Condition Name
+444	Unknown	17	Militia Killed By Player	Militia Killed By Player	Trigger Condition Name
+445	Unknown	11	Hero on Map	Hero on Map	Trigger Condition Name
+446	Unknown	14	Company Routed	Company Routed	Trigger Condition Name
+447	Unknown	15	Object A Near B	Object A Near B	Trigger Condition Name
+448	Unknown	18	Object Full Health	Object Full Health	Trigger Condition Name
+449	Unknown	14	Object Is Type	Object Is Type	Trigger Condition Name
+450	Unknown	17	Object In Supply	Object In Supply	Trigger Condition Name
+451	Unknown	18	Have X Settlements	Have X Settlements	Trigger Condition Name
+452	Unknown	15	Have X Outposts	Have X Outposts	Trigger Condition Name
+453	Unknown	12	Have X Mines	Have X Mines	Trigger Condition Name
+454	Unknown	8	Not Used	Not Used	Trigger Condition Name
+455	Unknown	16	T Pressed Button	T Pressed Button	Trigger Condition Name
+456	Unknown	14	Player Is Ally	Player Is Ally	Trigger Condition Name
+457	Unknown	17	Player Is Neutral	Player Is Neutral	Trigger Condition Name
+458	Unknown	15	Player Is Enemy	Player Is Enemy	Trigger Condition Name
+459	Unknown	21	Object Is Independent	Object Is Independent	Trigger Condition Name
+460	Unknown	17	T Object Selected	T Object Selected	Trigger Condition Name
+461	Unknown	16	T Button Visible	T Button Visible	Trigger Condition Name
+462	Unknown	24	Have Exactly X Companies	Have Exactly X Companies	Trigger Condition Name
+463	Message	46	Could not find button %s for trigger condition	Could not find button %s for trigger condition	Trigger Error Message
+# Stripping \SOURCE\GAME\QUEST\TGTRIGGEREFFECT.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+464	Unknown	6	Amount	Amount	Trigger Effect Name
+465	Unknown	5	Story	Story	Trigger Effect Name
+466	Unknown	10	Create Obj	Create Obj	Trigger Effect Name
+467	Unknown	7	Message	Message	Trigger Effect Name
+468	Unknown	11	Convert Obj	Convert Obj	Trigger Effect Name
+469	Unknown	8	Activate	Activate	Trigger Effect Name
+470	Unknown	8	Heal Obj	Heal Obj	Trigger Effect Name
+471	Unknown	11	Destroy Obj	Destroy Obj	Trigger Effect Name
+472	Unknown	15	Start Cataclysm	Start Cataclysm	Trigger Effect Name
+473	Unknown	5	Sound	Sound	Trigger Effect Name
+474	Unknown	15	Focus on Object	Focus on Object	Trigger Effect Name
+475	Unknown	12	Focus on Loc	Focus on Loc	Trigger Effect Name
+476	Unknown	12	End Scenario	End Scenario	Trigger Effect Name
+477	Unknown	7	Victory	Victory	Trigger Effect Name
+478	Unknown	12	Invulnerable	Invulnerable	Trigger Effect Name
+479	Unknown	6	On/Off	On/Off	Trigger Effect Name
+480	Unknown	10	Deactivate	Deactivate	Trigger Effect Name
+481	Unknown	18	SAI Ignore Company	SAI Ignore Company	Trigger Effect Name
+482	Unknown	15	SAI Build Units	SAI Build Units	Trigger Effect Name
+483	Unknown	12	Custom Story	Custom Story	Trigger Effect Name
+484	Unknown	10	Experience	Experience	Trigger Effect Name
+485	Unknown	18	SAI Change Profile	SAI Change Profile	Trigger Effect Name
+486	Unknown	11	Hurt Object	Hurt Object	Trigger Effect Name
+487	Unknown	15	Extend Briefing	Extend Briefing	Trigger Effect Name
+488	Unknown	5	Spell	Spell	Trigger Effect Name
+489	Unknown	5	Range	Range	Trigger Effect Name
+490	Unknown	12	Set Explored	Set Explored	Trigger Effect Name
+491	Unknown	15	T Disable Input	T Disable Input	Trigger Effect Name
+492	Unknown	14	T Enable Input	T Enable Input	Trigger Effect Name
+493	Unknown	14	T Flash Button	T Flash Button	Trigger Effect Name
+494	Unknown	14	Stop Cataclysm	Stop Cataclysm	Trigger Effect Name
+495	Unknown	10	Technology	Technology	Trigger Effect Name
+496	Unknown	9	Lose Hero	Lose Hero	Trigger Effect Name
+497	Unknown	23	Spell - Affect Everyone	Spell - Affect Everyone	Trigger Effect Name
+498	Unknown	11	SAI Opinion	SAI Opinion	Trigger Effect Name
+499	Unknown	17	SAI Awaken Heroes	SAI Awaken Heroes	Trigger Effect Name
+500	Unknown	16	Tutorial Hack On	Tutorial Hack On	Trigger Effect Name
+501	Unknown	6	Hack #	Hack #	Trigger Effect Name
+502	Unknown	17	Tutorial Hack Off	Tutorial Hack Off	Trigger Effect Name
+503	Unknown	18	Set Rampage Target	Set Rampage Target	Trigger Effect Name
+504	Unknown	19	Set Lairs Spreading	Set Lairs Spreading	Trigger Effect Name
+505	Message	25	%s has joined your cause.	%s has joined your cause.	Settlement Message
+506	Message	30	You have found a Kohan amulet!	You have found a Kohan amulet!	Booty Found Message
+507	Message	23	You have found %d gold.	You have found %d gold.	Booty Found Message
+508	Message	27	A %s has joined your cause.	A %s has joined your cause.	Settlement Message
+509	Message	30	You have gained favor with %s.	You have gained favor with %s.	Diplomacy Message
+510	Message	28	You have lost favor with %s.	You have lost favor with %s.	Diplomacy Message
+# Stripping \SOURCE\GAME\QUEST\TRIGGER.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+511	Message	34	A new quest has been given to you.	A new quest has been given to you.	==
+# Stripping \SOURCE\GAME\QUEST\TRIGGERDEFINES.CPP...					
+# Stripping \SOURCE\GAMEDATA\BUILDINGDATA.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+512	Unknown	7	Rhaksha	Rhaksha	==
+513	Unknown	8	Woodmill	Woodmill	Component Name (Tooltip?)
+514	Unknown	10	Blacksmith	Blacksmith	Component Name (Tooltip?)
+515	Unknown	6	Quarry	Quarry	Component Name (Tooltip?)
+516	Unknown	6	Market	Market	Component Name (Tooltip?)
+517	Unknown	8	Barracks	Barracks	Component Name (Tooltip?)
+518	Unknown	6	Temple	Temple	Component Name (Tooltip?)
+519	Unknown	7	Library	Library	Component Name (Tooltip?)
+520	Unknown	4	Wall	Wall	Component Name (Tooltip?)
+521	Unknown	9	Animation	Animation	==
+522	Unknown	7	%s ruin	%s ruin	==
+# Stripping \SOURCE\GAMEDATA\GAMEOPTIONS.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+523	Unknown	5	Music	Music	Option Name
+524	Unknown	11	Emanonevahi	Emanonevahi	Default Player Name
+525	Unknown	9	%s's game	%s's game	Default Multiplayer game name
+526	Unknown	4	none	none	==
+527	Unknown	8	engineer	engineer	Unit Name (Tooltip?)
+528	Unknown	8	military	military	Unit Name (Tooltip?)
+529	Unknown	5	scout	scout	Unit Name (Tooltip?)
+530	Unknown	7	footman	footman	Unit Name (Tooltip?)
+531	Unknown	6	zombie	zombie	Unit Name (Tooltip?)
+# Stripping \SOURCE\GAMEDATA\LOCALIZATION.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+532	Unknown	3	Yes	Yes	Button Message Options
+533	Unknown	2	No	No	Button Message Options
+534	Unknown	2	OK	OK	Button Message Options
+535	Unknown	6	Cancel	Cancel	Button Message Options
+536	Unknown	22	Enter New Player Name:	Enter New Player Name:	Rename Message
+537	Unknown	11	Player Name	Player Name	Editor Option
+538	Unknown	11	Undescribed	Undescribed	Editor Option
+539	Unknown	9	Last Film	Last Film	Default film name
+# Stripping \SOURCE\GAMEDATA\OBJECTNAMES.CPP...					
+# Stripping \SOURCE\GAMEDATA\OBJECTTYPE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+540	hero_level_name	8	Awakened	Awakened	Hero Level Status
+541	hero_level_name	11	Enlightened	Enlightened	Hero Level Status
+542	hero_level_name	8	Restored	Restored	Hero Level Status
+543	hero_level_name	8	Ascended	Ascended	Hero Level Status
+544	faction_names	11	Nationalist	Nationalist	Faction Name
+545	faction_names	8	Royalist	Royalist	Faction Name
+546	faction_names	7	Council	Council	Faction Name
+547	faction_names	5	Ceyah	Ceyah	Faction Name
+548	faction_names	3	Any	Any	==
+549	race_names	7	Mareten	Mareten	Race Name
+550	race_names	6	Drauga	Drauga	Race Name
+551	race_names	6	Haroun	Haroun	Race Name
+552	race_names	5	Gauri	Gauri	Race Name
+553	race_names	5	Slaan	Slaan	Race Name
+554	Unknown	12	Name Unknown	Name Unknown	==
+555	Unknown	14	Traits Unknown	Traits Unknown	==
+556	Unknown	9	%s corpse	%s corpse	Corpse Name
+557	Error	20	Missing unit type %s	Missing unit type %s	Error Message
+558	Error	26	too many object types (%d)	too many object types (%d)	Error Message
+# Stripping \SOURCE\GAMEDATA\TECHNOLOGY.CPP...					
+# Stripping \SOURCE\INTERFACE\BUTTON.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+559	Unknown	5	ENTER	ENTER	Tool Tip
+560	Unknown	3	ESC	ESC	Tool Tip
+561	Unknown	6	PAD-%d	PAD-%d	Tool Tip
+562	Unknown	6	escape	escape	Tool Tip
+563	Unknown	6	return	return	Tool Tip
+564	Unknown	6	numpad	numpad	Tool Tip
+565	Unknown	9	<NOT SET>	<NOT SET>	Editor Option
+566	Unknown	7	Overlay	Overlay	==
+# Stripping \SOURCE\INTERFACE\DATAMAP.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+567	Unknown	65	%s\n\nAttack: %.0f+%.0f\nDefense: %.0f+%.0f\nMax Hit Points: %.0f	%s\n\nAttack: %.0f+%.0f\nDefense: %.0f+%.0f\nMax Hit Points: %.0f	Unit Attributes
+568	Unknown	32	%s\nSell Price: %.0f\nUpkeep: %s	%s\nSell Price: %.0f\nUpkeep: %s	Component Attributes
+569	Unknown	13	Gold Cost: %d	Gold Cost: %d	Gold Attribute (Tooltip?)
+570	Unknown	19	Available Upgrades:	Available Upgrades:	Building Attribute
+571	Unknown	38	Ranged Attack Value\n(%d%% Efficiency)	Ranged Attack Value\n(%d%% Efficiency)	Unit Attribute (Tooltip?)
+572	Unknown	31	Attack Value\n(%d%% Efficiency)	Attack Value\n(%d%% Efficiency)	Unit Attribute (Tooltip?)
+573	Unknown	24	Not initialized properly	Not initialized properly	Error Message
+574	Unknown	12	Unknown Hero	Unknown Hero	Hero Error Message
+575	Unknown	8	Level: ?	Level: ?	Unit Attribute
+576	Unknown	23	Health: ?  AV: ?  DV: ?	Health: ?  AV: ?  DV: ?	Unit Attributes
+577	Unknown	11	Description	Description	Unit Attribute
+578	Unknown	7	notused	notused	==
+579	Unknown	5	None.	None.	==
+580	Unknown	12	Upgraded To:	Upgraded To:	Upgrade Message
+581	Unknown	12	Upgrading...	Upgrading...	Upgrade Status (Tooltip?)
+582	Unknown	24	Upgrade: %d%% Complete\n	Upgrade: %d%% Complete\n	Upgrade Status (Tooltip?)
+583	Unknown	67	Upgrade to %s\nRequires %d component%s and %d upgrade%s\nCost: %d%c	Upgrade to %s\nRequires %d component%s and %d upgrade%s\nCost: %d%c	Upgrade Message (Tooltip?)
+584	Unknown	28	Building %s: %.0f%% Complete	Building %s: %.0f%% Complete	Building Status (Tooltip?)
+585	Unknown	26	Available for Construction	Available for Construction	Component Slot Tooltip
+586	Unknown	13	%s Production	%s Production	Building's Production Status
+587	Unknown	33	%s Production (%+.0f%c = %+.0f%c)	%s Production (%+.0f%c = %+.0f%c)	Building's Production Status
+588	Unknown	18	Morale (%.0f/%.0f)	Morale (%.0f/%.0f)	Morale Tooltip
+589	Unknown	22	Build Outpost (%.0f%c)	Build Outpost (%.0f%c)	Build Outpost Tooltip
+590	Unknown	25	Build Settlement (%.0f%c)	Build Settlement (%.0f%c)	Build Settlement Tooltip
+591	Unknown	12	Cost: %.0f%c	Cost: %.0f%c	== Cost Status
+592	Unknown	51	%s\nAttack Efficiency - %d%%\nSpeed Modifier - %d%%	%s\nAttack Efficiency - %d%%\nSpeed Modifier - %d%%	Formation tooltip
+593	Unknown	12	\nRequires: 	\nRequires: 	Unit Requirements
+594	Unknown	9	In Supply	In Supply	Company Attribute
+595	Unknown	19	Demo Text Goes Here	Demo Text Goes Here	==
+596	Unknown	23	Defense Value (%+.0f%c)	Defense Value (%+.0f%c)	Company Attribute Tooltip
+597	Unknown	25	Movement Rate (%s %.0f%%)	Movement Rate (%s %.0f%%)	Company Attribute Tooltip
+598	Unknown	15	%d/%d Militia\n	%d/%d Militia\n	Militia Message
+599	Unknown	8	Mining\n	Mining\n	Mining Status
+600	Unknown	15	Out of Supply\n	Out of Supply\n	Mine Status
+601	Unknown	11	Upgrading\n	Upgrading\n	Building Attribute
+602	Unknown	14	Constructing\n	Constructing\n	Build Status
+603	Unknown	11	Unclaimed\n	Unclaimed\n	Mine Status
+604	Unknown	23	Cost of Mine: %.0f %c\n	Cost of Mine: %.0f %c\n	Mine Cost Tooltip
+605	Unknown	11	Destroyed\n	Destroyed\n	Building Status (Tooltip?)
+606	Unknown	13	Building %s\n	Building %s\n	Building Status (Tooltip?)
+607	Unknown	13	Under Siege\n	Under Siege\n	Building Status (Tooltip?)
+608	Unknown	16	Being Repaired\n	Being Repaired\n	Building Status (Tooltip?)
+609	Unknown	10	Explored\n	Explored\n	Ruin/Ancient City Status
+610	Unknown	9	Damaged\n	Damaged\n	Ruin/Ancient City Status
+611	Unknown	8	Normal\n	Normal\n	Ruin/Ancient City Status
+612	Unknown	25	Unlock Regiment Formation	Unlock Regiment Formation	Regiment Status
+613	Unknown	23	Lock Regiment Formation	Lock Regiment Formation	Regiment Status
+# Stripping \SOURCE\INTERFACE\PANELBUTTONS.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+614	Unknown	6	Attach	Attach	Hero Button Option
+615	Unknown	6	Detach	Detach	Hero Button Option
+616	Unknown	17	Attach hero to %s	Attach hero to %s	Hero Message
+617	Unknown	32	Detach hero from %s (Cost: %d%c)	Detach hero from %s (Cost: %d%c)	Hero Message
+618	Unknown	50	A single company must be selected to attach a hero	A single company must be selected to attach a hero	Attach Message
+# Stripping \SOURCE\INTERFACE\TGBASEINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+619	Unknown	8	Spells	Spells	Unit Attributes
+620	Unknown	18	Modifiers Gained	Modifiers Gained	Unit Attributes
+621	Unknown	18	Modifiers Provided	Modifiers Provided	Unit Attributes
+622	Unknown	20	Modifiers Provided	Modifiers Provided	Unit Attributes
+# Stripping \SOURCE\INTERFACE\TGBRIEFINGINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+623	Unknown	35	%c Destroy all non-allied kingdoms.	%c Destroy all non-allied kingdoms.	Mission Objective
+624	Unknown	30	%c Destroy all other kingdoms.	%c Destroy all other kingdoms.	Mission Objective
+625	Unknown	41	"%c Get %d%c (You: %d%c, Alliance: %d%c)\n"	"%c Get %d%c (You: %d%c, Alliance: %d%c)\n"	Mission Objective
+626	Unknown	20	%c Get %d%c (%d%c)\n	%c Get %d%c (%d%c)\n	Mission Objective
+627	Unknown	47	"%c Get %d Settlements (You: %d, Alliance: %d)\n"	"%c Get %d Settlements (You: %d, Alliance: %d)\n"	Mission Objective
+628	Unknown	28	%c Get %d Settlements (%d)\n	%c Get %d Settlements (%d)\n	Mission Objective
+629	Unknown	60	"%c Get %d%% of the Settlements (You: %d%%, Alliance: %d%%)\n"	"%c Get %d%% of the Settlements (You: %d%%, Alliance: %d%%)\n"	Mission Objective
+630	Unknown	39	%c Get %d%% of the Settlements (%d%%)\n	%c Get %d%% of the Settlements (%d%%)\n	Mission Objective
+# Stripping \SOURCE\INTERFACE\TGCAMPAIGNINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+631	Warning	25	%s is an invalid filename	%s is an invalid filename	Error Message
+632	Unknown	35	Are you sure you want to delete %s?	Are you sure you want to delete %s?	Delete Message
+633	Warning	35	Error loading player %s campaign %s	Error loading player %s campaign %s	Loading Message
+634	Unknown	17	Could not find %s	Could not find %s	Error Message
+635	Unknown	19	Campaign Completed!	Campaign Completed!	Campaign Screen Messages
+636	Unknown	17	Replay Mission %d	Replay Mission %d	Campaign Screen Messages
+# Stripping \SOURCE\INTERFACE\TGCINEMATICSINTERFACE.CPP...					
+# Stripping \SOURCE\INTERFACE\TGCOMPANYINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+637	Unknown	59	Preset already exists with same name.\n\nOkay to overwrite?	Preset already exists with same name.\n\nOkay to overwrite?	Warning Message
+638	Unknown	128	This hero is asleep and cannot be placed in a company until awakened. Do you wish to awaken this hero now?\nCost to awaken: %d%c	This hero is asleep and cannot be placed in a company until awakened. Do you wish to awaken this hero now?\nCost to awaken: %d%c	Hero Message
+639	Message	37	You cannot recruit while under siege!	You cannot recruit while under siege!	Recruit Error Message
+640	Unknown	17	#c TG_WHITE Empty	#c TG_WHITE Empty	==
+641	Unknown	12	Load Preset 	Load Preset 	Company Preset Menu
+642	Unknown	12	Save Preset 	Save Preset 	Company Preset Menu
+# Stripping \SOURCE\INTERFACE\TGCONNECTIONINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+643	Warning	33	Error Connecting to %s (error %d)	Error Connecting to %s (error %d)	Multiplayer Error Message
+644	Warning	37	Error Hosting Game (port %d error %d)	Error Hosting Game (port %d error %d)	Multiplayer Error Message
+645	Unknown	62	Retrieving server list. Please wait as this may take a minute.	Retrieving server list. Please wait as this may take a minute.	Multiplayer Server Message
+646	Unknown	18	[game in progress]	[game in progress]	Multiplayer Server Message
+647	Unknown	21	[waiting for players]	[waiting for players]	Multiplayer Server Message
+648	Unknown	20	Team %s: %s kingdoms	Team %s: %s kingdoms	Multiplayer Server Message
+649	Unknown	14	%s: %s/Team %s	%s: %s/Team %s	Multiplayer Server Message
+# Stripping \SOURCE\INTERFACE\TGCREDITSINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+650	Unknown	19	Was the Kohan: Immortal Sovereigns logo visible on the previous screen?	Was the Kohan: Immortal Sovereigns logo visible on the previous screen?	Prompt in WinMain.cpp, inserted here replacing an unused string "Credits Framebuffer"
+# Stripping \SOURCE\INTERFACE\TGDEBRIEFINGINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+651	Unknown	5	Score	Score	Debriefing Score Screen
+652	Unknown	8	Survived	Survived	Debriefing Score Screen
+653	Unknown	21	Total Enemy Destroyed	Total Enemy Destroyed	Debriefing Score Screen
+654	Unknown	19	Total Friendly Lost	Total Friendly Lost	Debriefing Score Screen
+655	Unknown	20	Total Enemy Captured	Total Enemy Captured	Debriefing Score Screen
+656	Unknown	23	Total Friendly Captured	Total Friendly Captured	Debriefing Score Screen
+657	Unknown	22	Commissioned Companies	Commissioned Companies	Debriefing Score Screen
+658	Unknown	14	Max. Companies	Max. Companies	Debriefing Score Screen
+659	Unknown	25	Enemy Companies Destroyed	Enemy Companies Destroyed	Debriefing Score Screen
+660	Unknown	28	Friendly Companies Destroyed	Friendly Companies Destroyed	Debriefing Score Screen
+661	Unknown	24	Enemy Buildings Captured	Enemy Buildings Captured	Debriefing Score Screen
+662	Unknown	27	Friendly Buildings Captured	Friendly Buildings Captured	Debriefing Score Screen
+663	Unknown	9	Max. Gold	Max. Gold	Debriefing Score Screen
+664	Unknown	13	Gold Produced	Gold Produced	Debriefing Score Screen
+665	Unknown	11	Booty Taken	Booty Taken	Debriefing Score Screen
+666	Unknown	18	Net Stone Produced	Net Stone Produced	Debriefing Score Screen
+667	Unknown	17	Net Wood Produced	Net Wood Produced	Debriefing Score Screen
+668	Unknown	17	Net Iron Produced	Net Iron Produced	Debriefing Score Screen
+669	Unknown	17	Net Mana Produced	Net Mana Produced	Debriefing Score Screen
+670	Unknown	11	Max. Cities	Max. Cities	Debriefing Score Screen
+671	Unknown	13	Max. Outposts	Max. Outposts	Debriefing Score Screen
+672	Unknown	10	Max. Mines	Max. Mines	Debriefing Score Screen
+673	Unknown	14	Cities Settled	Cities Settled	Debriefing Score Screen
+674	Unknown	15	Cities Captured	Cities Captured	Debriefing Score Screen
+675	Unknown	16	Components Built	Components Built	Debriefing Score Screen
+676	Unknown	14	Upgrades Built	Upgrades Built	Debriefing Score Screen
+677	Unknown	7	Your kingdom was victorious!	Your kingdom was victorious!	Debriefing Result Message
+678	Unknown	8	Your kingdom has been defeated.	Your kingdom has been defeated.	Debriefing Result Message
+679	Unknown	15	Enter Film Name	Enter Film Name	Saving a Film
+680	Unknown	41	#c %s %c Destroy all non-allied kingdoms.	#c %s %c Destroy all non-allied kingdoms.	Custom Game Win Conditions
+681	Unknown	36	#c %s %c Destroy all other kingdoms.	#c %s %c Destroy all other kingdoms.	Custom Game Win Conditions
+682	Unknown	47	"#c %s %c Get %d%c (You: %d%c, Alliance: %d%c)\n"	"#c %s %c Get %d%c (You: %d%c, Alliance: %d%c)\n"	Custom Game Win Conditions
+683	Unknown	26	#c %s %c Get %d%c (%d%c)\n	#c %s %c Get %d%c (%d%c)\n	Custom Game Win Conditions
+684	Unknown	53	"#c %s %c Get %d Settlements (You: %d, Alliance: %d)\n"	"#c %s %c Get %d Settlements (You: %d, Alliance: %d)\n"	Custom Game Win Conditions
+685	Unknown	34	#c %s %c Get %d Settlements (%d)\n	#c %s %c Get %d Settlements (%d)\n	Custom Game Win Conditions
+686	Unknown	66	"#c %s %c Get %d%% of the Settlements (You: %d%%, Alliance: %d%%)\n"	"#c %s %c Get %d%% of the Settlements (You: %d%%, Alliance: %d%%)\n"	Custom Game Win Conditions
+687	Unknown	45	#c %s %c Get %d%% of the Settlements (%d%%)\n	#c %s %c Get %d%% of the Settlements (%d%%)\n	Custom Game Win Conditions
+688	Unknown	12	Combat Value	Combat Value	Debriefing Score Screen
+689	Unknown	10	Population	Population	Debriefing Score Screen
+# Stripping \SOURCE\INTERFACE\TGEDITORGAMESETTINGS.CPP...					
+# Stripping \SOURCE\INTERFACE\TGEDITORPLAYERSETTINGS.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+690	Unknown	6	Active	Active	Editor Player Settings
+691	Unknown	8	Inactive	Inactive	Editor Player Settings
+692	Unknown	61	Player %d economy:      %c%+d   %c%+d   %c%+d   %c%+d   %c%+d	Player %d economy:      %c%+d   %c%+d   %c%+d   %c%+d   %c%+d	Editor Player Settings
+# Stripping \SOURCE\INTERFACE\TGEXITINTERFACE.CPP...					
+# Stripping \SOURCE\INTERFACE\TGGAMEINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+693	Unknown	71	These bonuses are available for units to provide only in support slots.	These bonuses are available for units to provide only in support slots.	Bonuses Provided Message
+694	Unknown	10	Component1	Component1	Component Numbers
+695	Unknown	10	Component2	Component2	Component Numbers
+696	Unknown	10	Component3	Component3	Component Numbers
+697	Unknown	10	Component4	Component4	Component Numbers
+698	Unknown	10	Component5	Component5	Component Numbers
+699	Unknown	10	Component6	Component6	Component Numbers
+700	Unknown	10	Component7	Component7	Component Numbers
+701	Unknown	16	Sell price: %d%c	Sell price: %d%c	Component Sell Price
+702	Unknown	10	Cost: %d%c	Cost: %d%c	Component Cost
+703	Message	10	message %d	message %d	Component Description
+704	Unknown	8	Everyone	Everyone	Chat Menu Option
+705	Unknown	6	Allied	Allied	Chat Menu Option
+706	Unknown	7	SAILore	SAILore	==
+707	Unknown	7	SAIText	SAIText	==
+708	Unknown	14	SAI Debug Info	SAI Debug Info	==
+709	Unknown	26	The map contains problems.	The map contains problems.	==
+710	Unknown	14	You have lost!	You have lost!	Game Result Message
+711	Unknown	13	You have won!	You have won!	Game Result Message
+712	Unknown	11	%s has won!	%s has won!	Game Result Message
+713	Unknown	19	Alliance victory! (	Alliance victory! (	Game Result Message
+714	Unknown	11	End Mission	End Mission	End Game Option
+715	Unknown	12	Keep Playing	Keep Playing	End Game Option
+716	Unknown	11	End of Film	End of Film	Film Message
+717	Unknown	28	All component slots are full	All component slots are full	Component Message
+718	Unknown	15	Build Component	Build Component	Component Tooltip
+719	Unknown	32	Cannot recruit while under seige	Cannot recruit while under seige	Recruit Message
+720	Unknown	17	Recruit a Company	Recruit a Company	Recruit Tooltip
+721	Unknown	19	%s\n%s\n%d XP\n%s\n	%s\n%s\n%d XP\n%s\n	== Hero Attributes
+722	Unknown	9	Available	Available	==
+723	Unknown	18	%s ( %d XP )\n%s\n	%s ( %d XP )\n%s\n	Company Attributes
+724	Unknown	35	%s\nHealth: %d/%d\nMilitia: %d/%d\n	%s\nHealth: %d/%d\nMilitia: %d/%d\n	Building Attributes
+725	Unknown	14	Status: Mining	Status: Mining	Settlement Status
+726	Unknown	21	Status: Out of Supply	Status: Out of Supply	Settlement Status
+727	Unknown	17	Status: Upgrading	Status: Upgrading	Settlement Status
+728	Unknown	20	Status: Constructing	Status: Constructing	Settlement Status
+729	Unknown	17	Status: Unclaimed	Status: Unclaimed	Mine Status
+730	Unknown	23	%s\nHealth: %d/%d\n%s\n	%s\nHealth: %d/%d\n%s\n	Building Attributes
+731	Unknown	18	#c TG_WHITE Normal	#c TG_WHITE Normal	== Text Coloring
+732	Unknown	22	#c TG_RED Constructing	#c TG_RED Constructing	Text Coloring
+733	Unknown	19	#c TG_RED Destroyed	#c TG_RED Destroyed	Text Coloring
+734	Unknown	21	#c TG_RED Building %s	#c TG_RED Building %s	Text Coloring
+735	Unknown	19	#c TG_RED Upgrading	#c TG_RED Upgrading	Text Coloring
+736	Unknown	24	#c TG_YELLOW Under Siege	#c TG_YELLOW Under Siege	Text Coloring
+737	Unknown	26	#c TG_WHITE Being Repaired	#c TG_WHITE Being Repaired	Text Coloring
+738	Unknown	19	#c TG_WHITE Damaged	#c TG_WHITE Damaged	Text Coloring
+739	Unknown	19	\n\n%s Applies To: 	\n\n%s Applies To: 	Technology Description
+740	Unknown	15	All Settlements	All Settlements	Technology Attribute
+741	Unknown	13	All Companies	All Companies	Technology Attribute
+742	Unknown	9	All Units	All Units	Technology Attribute
+743	Unknown	16	Settlement Panel	Settlement Panel	==
+744	Unknown	11	Modifiers	Modifiers	==
+745	Unknown	32	Destroy all non-allied kingdoms.	Destroy all non-allied kingdoms.	Mission Objective
+746	Unknown	27	Destroy all other kingdoms.	Destroy all other kingdoms.	Mission Objective
+747	Unknown	36	"Get %d%c (You: %d%c, Alliance: %d%c)"	"Get %d%c (You: %d%c, Alliance: %d%c)"	Custom Game Win Conditions
+748	Unknown	15	Get %d%c (%d%c)	Get %d%c (%d%c)	Custom Game Win Conditions
+749	Unknown	42	"Get %d Settlements (You: %d, Alliance: %d)"	"Get %d Settlements (You: %d, Alliance: %d)"	Custom Game Win Conditions
+750	Unknown	23	Get %d Settlements (%d)	Get %d Settlements (%d)	Custom Game Win Conditions
+751	Unknown	55	"Get %d%% of the Settlements (You: %d%%, Alliance: %d%%)"	"Get %d%% of the Settlements (You: %d%%, Alliance: %d%%)"	Custom Game Win Conditions
+752	Unknown	34	Get %d%% of the Settlements (%d%%)	Get %d%% of the Settlements (%d%%)	Custom Game Win Conditions
+753	Unknown	60	Icon: Current Relationship\nBorder: AI's Attitude toward you	Icon: Current Relationship\nBorder: AI's Attitude toward you	Politics Icon Description
+754	Unknown	26	Icon: Current Relationship	Icon: Current Relationship	Politics Icon Description
+755	Unknown	6	Locked	Locked	Politics Options
+756	Unknown	12	Declare War!	Declare War!	Politics Options
+757	Unknown	19	Accept Peace Treaty	Accept Peace Treaty	Politics Options
+758	Unknown	18	Offer Peace Treaty	Offer Peace Treaty	Politics Options
+759	Unknown	15	Cancel Alliance	Cancel Alliance	Politics Options
+760	Unknown	15	Accept Alliance	Accept Alliance	Politics Options
+761	Unknown	14	Offer Alliance	Offer Alliance	Politics Options
+762	Unknown	21	Cancel Alliance Offer	Cancel Alliance Offer	Politics Options
+763	Unknown	19	Cancel Peace Treaty	Cancel Peace Treaty	Politics Options
+764	Unknown	18	Remain In Alliance	Remain In Alliance	Politics Options
+765	Unknown	21	Reject Alliance Offer	Reject Alliance Offer	Politics Options
+766	Unknown	15	Remain At Peace	Remain At Peace	Politics Options
+767	Unknown	19	Reject Peace Treaty	Reject Peace Treaty	Politics Options
+768	Unknown	13	Remain At War	Remain At War	Politics Options
+769	Unknown	108	"Woodmill: 25 gold\n(Upkeep: 1 Stone, 2 Iron) Provides your kingdom with wood resources. +%d wood per minute."	"Woodmill: 25 gold\n(Upkeep: 1 Stone, 2 Iron) Provides your kingdom with wood resources. +%d wood per minute."	== Component Description
+770	Unknown	110	"Blacksmith: 25 gold\n(Upkeep: 2 Stone, 2 Wood) Provides your kingdom with iron resources. +%d iron per minute."	"Blacksmith: 25 gold\n(Upkeep: 2 Stone, 2 Wood) Provides your kingdom with iron resources. +%d iron per minute."	Component Description
+771	Unknown	107	"Quarry: 25 gold\n(Upkeep: 2 Wood, 1 Iron) Provides your kingdom with stone resources. +%d stone per minute."	"Quarry: 25 gold\n(Upkeep: 2 Wood, 1 Iron) Provides your kingdom with stone resources. +%d stone per minute."	Component Description
+772	Unknown	80	Market: 100 gold\nGenerates +5 gold per minute for each local resource building.	Market: 100 gold\nGenerates +5 gold per minute for each local resource building.	Component Description
+773	Unknown	105	"Barracks: 100 gold\n(Upkeep: 1 Stone, 2 Iron) Military facility that trains higher level combat elements."	"Barracks: 100 gold\n(Upkeep: 1 Stone, 2 Iron) Military facility that trains higher level combat elements."	Component Description
+774	Unknown	116	"Temple: 75 gold\n(Upkeep: 3 Stone, 1 Iron) This is a place of worship that contributes religious specialty elements."	"Temple: 75 gold\n(Upkeep: 3 Stone, 1 Iron) This is a place of worship that contributes religious specialty elements."	Component Description
+775	Unknown	105	Library: 125 gold\n(Upkeep: 2 Wood) All arcane knowledge and philosophies are studied within these walls.	Library: 125 gold\n(Upkeep: 2 Wood) All arcane knowledge and philosophies are studied within these walls.	Component Description
+776	Unknown	67	Wall: 50 gold\n(Upkeep: 5 Stone) Protects the populace from sieges.	Wall: 50 gold\n(Upkeep: 5 Stone) Protects the populace from sieges.	Component Description
+777	Unknown	9	Hero Lore	Hero Lore	Lore Tooltips
+778	Unknown	12	Company Lore	Company Lore	Lore Tooltips
+779	Unknown	13	Building Lore	Building Lore	Lore Tooltips
+780	Unknown	15	Technology Lore	Technology Lore	Lore Tooltips
+781	Unknown	10	Quest Lore	Quest Lore	Lore Tooltips
+782	Unknown	15	Objectives Lore	Objectives Lore	Lore Tooltips
+783	Unknown	11	Message Log	Message Log	Lore Tooltips
+784	Unknown	7	Outpost	Outpost	==
+785	Message	66	Cannot issue build order - engineer company is no longer selected.	Cannot issue build order - engineer company is no longer selected.	Engineer Message
+786	Unknown	7	Unnamed	Unnamed	==
+787	Message	66	Cannot issue settle order - settler company is no longer selected.	Cannot issue settle order - settler company is no longer selected.	Engineer Message
+788	Unknown	26	Do you want to disband %s?	Do you want to disband %s?	Disband Message
+789	Unknown	23	Do you want to raze %s?	Do you want to raze %s?	Raze Message
+790	Unknown	13	Politics Lore	Politics Lore	Lore Tooltips
+791	Unknown	13	Politics Menu	Politics Menu	Lore Tooltips
+792	Message	26	A tribute of %d sent to %s	A tribute of %d sent to %s	Tribute Message
+793	Message	29	Declaration of war sent to %s	Declaration of war sent to %s	Politics Message
+794	Unknown	23	Peace treaty acceptance	Peace treaty acceptance	Politics Option
+795	Unknown	18	Peace treaty offer	Peace treaty offer	Politics Option
+796	Message	13	%s sent to %s	%s sent to %s	Politics Message
+797	Message	35	Cancellation of alliance sent to %s	Cancellation of alliance sent to %s	Politics Message
+798	Unknown	19	Alliance acceptance	Alliance acceptance	Politics Message
+799	Unknown	14	Alliance offer	Alliance offer	Politics Message
+800	Unknown	10	Exit Game?	Exit Game?	Exit Game Message
+801	Unknown	40	Would you like to sell the %s from %s?\n	Would you like to sell the %s from %s?\n	Sell Message
+802	Message	43	Continuing Game - completion status locked.	Continuing Game - completion status locked.	Continuing Game Message
+803	Message	52	You cannot build within an existing population zone.	You cannot build within an existing population zone.	Build Message
+804	Message	46	That location is blocked.	That location is blocked.	Build Message
+805	Unknown	14	New Settlement	New Settlement	Build Settlement Tooltip
+806	Unknown	11	New Outpost	New Outpost	Build Outpost Tooltip
+807	Unknown	51	That is an Independent building. Attack it or move?	That is an Independent building. Attack it or move?	Indepenent City Message
+808	Unknown	6	Attack	Attack	Attack Tooltip
+809	Unknown	4	Move	Move	Move Tooltip
+810	Unknown	63	"That is an Independent building. Attack it, move, or repair it?"	"That is an Independent building. Attack it, move, or repair it?"	== Indepenent City Message
+811	Unknown	6	Repair	Repair	Repair Tooltip
+812	Unknown	11	In Supply\n	In Supply\n	Company Supply Status
+813	Unknown	10	Rank Bonus	Rank Bonus	Company Bonus Attributes
+814	Unknown	55	%s: attack and defense are at %.0f%% effectiveness.\n\n	%s: attack and defense are at %.0f%% effectiveness.\n\n	Bonus Atttibute Description
+815	Unknown	9	Modifiers	Modifiers	Modifiers Tooltip
+816	Message	44	Tutorial Disable Input: can't find button %s	Tutorial Disable Input: can't find button %s	==
+817	Message	44	Tutorial Flash Trigger: can't find button %s	Tutorial Flash Trigger: can't find button %s	==
+# Stripping \SOURCE\INTERFACE\TGGAMEMENU.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+818	Unknown	8	End Film	End Film	Option Menu Buttons
+819	Unknown	18	End Mission (Loss)	End Mission (Loss)	Option Menu Buttons
+820	Unknown	18	Leave Network Game	Leave Network Game	Option Menu Buttons
+821	Unknown	6	Resign	Resign	Option Menu Buttons
+822	Unknown	17	End Mission (Win)	End Mission (Win)	Option Menu Buttons
+823	Unknown	42	            Return to Desktop?            	            Return to Desktop?            	Quit Game Message
+# Stripping \SOURCE\INTERFACE\TGGENERATORSETTINGS.CPP...					
+# Stripping \SOURCE\INTERFACE\TGHOSTINTERFACE.CPP...					
+# Stripping \SOURCE\INTERFACE\TGJOININTERFACE.CPP...					
+# Stripping \SOURCE\INTERFACE\TGLOADSAVEINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+824	Unknown	38	Are you sure you want to save over %s?	Are you sure you want to save over %s?	Save Message
+825	Warning	41	Errors occurred while trying to delete %s.	Errors occurred while trying to delete %s.	Delete Message
+826	Warning	17	File is read only	File is read only	Save Message
+827	Warning	19	Cannot overwrite %s	Cannot overwrite %s	Save Message
+828	Unknown	8	Saved %s	Saved %s	Save Message
+# Stripping \SOURCE\INTERFACE\TGMAINMENU.CPP...					
+# Stripping \SOURCE\INTERFACE\TGMAPEDITORINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+829	Unknown	3	On 	On 	Editor Option
+830	Unknown	3	Off	Off	Editor Option
+831	Unknown	9	Warning: 	Warning: 	Editor Option
+832	Unknown	3	New	New	Editor Option
+833	Unknown	18	Return to Desktop?	Return to Desktop?	Quit Game Message
+834	Error	64	Fog explored information may not be correct until the next load.	Fog explored information may not be correct until the next load.	Fog Message
+835	Error	52	You cannot place a mountain on a terrain transition.	You cannot place a mountain on a terrain transition.	Terrain Message
+836	Error	60	"In order to edit an object, you must select a single object."	"In order to edit an object, you must select a single object."	Edit Message
+837	Error	36	This type of object is not editable.	This type of object is not editable.	Edit Message
+838	Unknown	13	Uninitialized	Uninitialized	Editor Option
+839	Unknown	15	Game Trigger %d	Game Trigger %d	Editor Option
+840	Unknown	9	 (Halted)	 (Halted)	Editor Option
+841	Unknown	16	Effect Message: 	Effect Message: 	Editor Option
+842	Unknown	5	Empty	Empty	Editor Option
+# Stripping \SOURCE\INTERFACE\TGMAPSELECT.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+843	Unknown	14	Searching Maps	Searching Maps	Custom Map Message
+844	Unknown	21	Generate a Random Map	Generate a Random Map	Custom Map Message
+845	Unknown	15	Up a Folder\n\n	Up a Folder\n\n	Custom Map Message
+846	Unknown	31	%s\n\nContains additional maps.	%s\n\nContains additional maps.	Custom Map Message
+847	Unknown	22	Randomly Generated Map	Randomly Generated Map	Custom Map Message
+848	Unknown	26	Randomly Generated Map\n\n	Randomly Generated Map\n\n	Custom Map Message
+849	Unknown	26	%s\n\nError reading map.\n	%s\n\nError reading map.\n	Custom Map Message
+850	Unknown	13	Custom Play: 	Custom Play: 	Custom Game Option
+851	Unknown	15	Scenario Play: 	Scenario Play: 	Custom Game Option
+852	Unknown	4	[Up]	[Up]	== Custom Game Option
+853	Unknown	16	No map selected.	No map selected.	Custom Game Message
+# Stripping \SOURCE\INTERFACE\TGMESSAGEBOX.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+854	Unknown	12	[no message]	[no message]	==
+# Stripping \SOURCE\INTERFACE\TGMULTIPLAYERINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+855	Unknown	6	Random	Random	Faction Option
+856	Unknown	8	Observer	Observer	Faction Option
+857	Unknown	7	No Team	No Team	Team Option
+858	Unknown	7	Team %d	Team %d	Team Option
+859	Unknown	22	%d (Up to %d Kingdoms)	%d (Up to %d Kingdoms)	Starting Hero Option
+860	Unknown	21	Use Scenario Settings	Use Scenario Settings	Multi. Settings Option
+861	Unknown	18	Customize Settings	Customize Settings	Multi. Settings Option
+862	Unknown	32	Single or Allied Victory Allowed	Single or Allied Victory Allowed	Multi. Victory Cond. Option
+863	Unknown	19	Single Victory Only	Single Victory Only	Multi. Victory Cond. Option
+864	Unknown	24	Entire Alliance Must Win	Entire Alliance Must Win	Multi. Victory Cond. Option
+865	Unknown	50	Delete local copy of %s?\n It appears corrupt (%s)	Delete local copy of %s?\n It appears corrupt (%s)	Custom Map Message
+866	Warning	42	There was an error downloading the map: %s	There was an error downloading the map: %s	Map Downloading Message
+867	Unknown	24	Download of %s cancelled	Download of %s cancelled	Map Downloading Message
+868	Unknown	22	Requesting download %s	Requesting download %s	Map Downloading Message
+869	Unknown	30	Downloading %s (%d%% complete)	Downloading %s (%d%% complete)	Map Downloading Message
+870	Unknown	9	Connected	Connected	Connection Message
+871	Unknown	10	Enter Name	Enter Name	Renaming Message
+872	Message	46	You cannot edit another player's ready status.	You cannot edit another player's ready status.	Multi. Settings Message
+873	Message	43	You are not allowed to change that setting.	You are not allowed to change that setting.	Multi. Settings Message
+874	Message	42	That setting is locked for this game type.	That setting is locked for this game type.	Multi. Settings Message
+875	Message	36	Request to change setting %s denied.	Request to change setting %s denied.	Multi. Settings Message
+876	Message	19	Setting %s changed	Setting %s changed	Multi. Settings Message
+877	Unknown	11	Kingdom #%d	Kingdom #%d	Map Scenario Setting
+878	Unknown	12	Observer #%d	Observer #%d	Map Scenario Setting
+879	Unknown	4	Kick	Kick	Multi. Kick Player option
+880	Unknown	11	Change Name	Change Name	Change Name Option
+881	Unknown	4	Open	Open	Empty Player Option
+882	Unknown	6	Closed	Closed	Empty Player Option
+883	Unknown	9	Random AI	Random AI	AI Skill Level
+884	Unknown	9	%s (Weak)	%s (Weak)	AI Skill Description
+885	Unknown	18	Randomly Generated	Randomly Generated	Name of Random Map
+# Stripping \SOURCE\INTERFACE\TGOBJECTEDITOR.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+886	Unknown	20	No related triggers.	No related triggers.	Editor Message
+887	Unknown	7	library	library	Components in Buildings
+888	Unknown	71	Too many components were selected. Unable to create all the components.	Too many components were selected. Unable to create all the components.	Editor Message
+889	Unknown	8	summoned	summoned	Company Attributes
+890	Unknown	6	morale	morale	Company Attributes
+891	Unknown	10	experience	experience	Company Attributes
+# Stripping \SOURCE\INTERFACE\TGOPTIONSINTERFACE.CPP...					
+# Stripping \SOURCE\INTERFACE\TGSPLASHSCREENINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+892	Unknown	12	Loading Game	Loading Game	Loading Game Message
+# Stripping \SOURCE\INTERFACE\TGVIEWFILMSINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+893	Unknown	17	No film selected.	No film selected.	Film Message
+894	Unknown	43	Unable to get selected text from film list.	Unable to get selected text from film list.	Film Message
+895	Unknown	25	Could not find campaign: 	Could not find campaign: 	Film Message
+896	Unknown	24	Could not find mission: 	Could not find mission: 	Film Message
+897	Unknown	88	"Unable to load Map Header, please make sure the map used in this film is available (%s)."	"Unable to load Map Header, please make sure the map used in this film is available (%s)."	Film Message
+898	Unknown	12	\nTeam %d:\n	\nTeam %d:\n	Film Attribute
+899	Unknown	16	\nIndependent:\n	\nIndependent:\n	Film Attribute
+900	Unknown	13	\nObserver:\n	\nObserver:\n	Film Attribute
+901	Unknown	14	\nPlayer: %s\n	\nPlayer: %s\n	Film Attribute
+902	Unknown	12	\nPlayers:\n	\nPlayers:\n	Film Attribute
+903	Unknown	11	Random Map 	Random Map 	Film Attribute
+904	Unknown	56	WARNING: Film version different from current version\n\n	WARNING: Film version different from current version\n\n	Film Message
+905	Unknown	11	Film Name: 	Film Name: 	Film Attribute
+906	Unknown	10	Map Name: 	Map Name: 	Film Attribute
+907	Unknown	11	Game Type: 	Game Type: 	Film Attribute
+908	Unknown	8	Campaign	Campaign	Film Attribute
+909	Unknown	22	[Film Is Incomplete]\n	[Film Is Incomplete]\n	Film Message
+# Stripping \SOURCE\INTERFACE\TGVOTEINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+910	Unknown	12	Contact Lost	Contact Lost	Multi. Lagging Screen Option
+911	Unknown	14	Falling Behind	Falling Behind	Multi. Lagging Screen Option
+912	Unknown	6	Saving	Saving	Multi. Lagging Screen Option
+913	Unknown	11	Not In Game	Not In Game	Multi. Lagging Screen Option
+914	Unknown	5	Ready	Ready	Multi. Lagging Screen Option
+915	Unknown	13	%d/%d to kick	%d/%d to kick	Multi. Lagging Screen Option
+916	Unknown	19	%d/%d to disconnect	%d/%d to disconnect	Multi. Lagging Screen Option
+# Stripping \SOURCE\MAIN\CPLAYER.CPP...					
+# Stripping \SOURCE\MAIN\FX.CPP...					
+# Stripping \SOURCE\MAIN\GAME.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+917	Unknown	5	Kohan	Kohan	==
+918	Unknown	4	Grid	Grid	Editor Show Menu
+919	Unknown	13	Control Zones	Control Zones	Editor Show Menu
+920	Unknown	12	Supply Zones	Supply Zones	Editor Show Menu
+921	Unknown	11	Guard Zones	Guard Zones	Editor Show Menu
+922	Unknown	16	Population Zones	Population Zones	Editor Show Menu
+923	Unknown	13	Combat Damage	Combat Damage	Editor Show Menu
+924	Unknown	13	Blocked Tiles	Blocked Tiles	Editor Show Menu
+925	Unknown	12	Tile Numbers	Tile Numbers	Editor Show Menu
+926	Unknown	18	Tile Terrain Types	Tile Terrain Types	Editor Show Menu
+927	Unknown	11	Health Bars	Health Bars	Editor Show Menu
+928	Unknown	15	Detection Zones	Detection Zones	Editor Show Menu
+929	Unknown	12	Strategic AI	Strategic AI	Editor Show Menu
+930	Unknown	11	SAI Regions	SAI Regions	Editor Show Menu
+931	Unknown	9	SAI Debug	SAI Debug	Editor Show Menu
+932	Unknown	10	Frame Rate	Frame Rate	Editor Show Menu
+933	Unknown	12	Text Windows	Text Windows	Editor Show Menu
+934	Unknown	8	Hotspots	Hotspots	Editor Show Menu
+935	Unknown	10	Smooth Fog	Smooth Fog	Editor Show Menu
+936	Unknown	17	Tile Blend Alphas	Tile Blend Alphas	Editor Show Menu
+937	Unknown	8	AI Paths	AI Paths	Editor Show Menu
+938	Unknown	15	Interface Debug	Interface Debug	Editor Show Menu
+939	Unknown	14	Mouse Position	Mouse Position	Editor Show Menu
+940	Unknown	8	No VSync	No VSync	Editor Show Menu
+941	Unknown	15	Visibility Grid	Visibility Grid	Editor Show Menu
+942	Unknown	14	Ethereal Units	Ethereal Units	Editor Show Menu
+943	Unknown	3	Fog	Fog	Editor Show Menu
+944	Unknown	15	 where name is:	 where name is:	==
+945	Unknown	7	Show On	Show On	Editor Show Setting
+946	Unknown	8	Show Off	Show Off	Editor Show Setting
+947	Unknown	25	Unrecognized SHOW command	Unrecognized SHOW command	Editor Message
+948	Unknown	17	Initializing Game	Initializing Game	Game Loading Message
+949	Unknown	26	Loading Spells and Effects	Loading Spells and Effects	Game Loading Message
+950	Unknown	15	Loading Objects	Loading Objects	Game Loading Message
+951	Unknown	17	Loading Campaigns	Loading Campaigns	Game Loading Message
+952	Unknown	17	Loading Interface	Loading Interface	Game Loading Message
+# Stripping \SOURCE\MAIN\GAMEMAIN.CPP...					
+# Stripping \SOURCE\MAIN\GLOBALS.CPP...					
+# Stripping \SOURCE\MAIN\SIM.CPP...					
+# Stripping \SOURCE\MAP\TGMAP.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+953	Error	22	Unavailable terrain type %d	Unavailable terrain type %d	Terrain Message
+# Stripping \SOURCE\MAP\TGTILE.CPP...					
+# Stripping \SOURCE\NETWORK\CDKEY.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+954	Unknown	38	Client %d was NOT authenticated (%s)\n	Client %d was NOT authenticated (%s)\n	CD key Message
+955	Unknown	34	Client %d was authenticated (%s)\n	Client %d was authenticated (%s)\n	CD key Message
+956	Unknown	39	"M:Welcome to the game, have fun! (%s)\n"	"M:Welcome to the game, have fun! (%s)\n"	CD key Message
+# Stripping \SOURCE\NETWORK\CLIENT.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+957	Unknown	23	Blocks for packet %d:  	Blocks for packet %d:  	Multi. Connection Message
+958	Unknown	14	Host timed out	Host timed out	Multi. Connection Message
+959	Unknown	13	Game was full	Game was full	Multi. Connection Message
+960	Unknown	29	You are banned from this game	You are banned from this game	Multi. Connection Message
+961	Unknown	26	Incompatible game versions	Incompatible game versions	Multi. Connection Message
+962	Unknown	20	Game already started	Game already started	Multi. Connection Message
+963	Unknown	18	Player not hosting	Player not hosting	Multi. Connection Message
+964	Unknown	25	Unable to find address %s	Unable to find address %s	Multi. Connection Message
+965	Unknown	16	Connecting to %s	Connecting to %s	Multi. Connection Message
+966	Unknown	7	Hosting	Hosting	Multi. Connection Message
+967	Unknown	30	Couldn't open file for reading	Couldn't open file for reading	Mulit. Error Message
+968	Unknown	18	Error loading file	Error loading file	Mulit. Error Message
+969	Unknown	29	Error loading incomplete film	Error loading incomplete film	Mulit. Error Message
+970	Unknown	9	Old Build	Old Build	Mulit. Error Message
+971	Unknown	24	Unsupported film version	Unsupported film version	Mulit. Error Message
+972	Unknown	30	Error loading campaign heroes.	Error loading campaign heroes.	Mulit. Error Message
+973	Unknown	36	Error loading campaign technologies.	Error loading campaign technologies.	Mulit. Error Message
+974	Unknown	13	Starting Film	Starting Film	Film Message
+975	Unknown	18	Error starting map	Error starting map	Mulit. Error Message
+976	Message	40	You cannot change another player's name.	You cannot change another player's name.	Multi. Settings Message
+977	Message	36	Only the host can change AI players.	Only the host can change AI players.	Multi. Settings Message
+978	Message	21	%s changed name to %s	%s changed name to %s	Multi. Settings Message
+979	Message	28	Player %d changed name to %s	Player %d changed name to %s	Multi. Settings Message
+980	Message	35	Only the host can change slot type.	Only the host can change slot type.	Multi. Settings Message
+981	Message	43	You cannot change another player's kingdom.	You cannot change another player's kingdom.	Multi. Settings Message
+982	Message	41	You cannot take another player's kingdom.	You cannot take another player's kingdom.	Multi. Settings Message
+983	Message	56	Only the host may change an AI player's team or faction.	Only the host may change an AI player's team or faction.	Multi. Settings Message
+984	Message	51	You cannot change another player's team or faction.	You cannot change another player's team or faction.	Multi. Settings Message
+985	Unknown	22	[suggests changing %s]	[suggests changing %s]	Multi. Settings Message
+986	Unknown	18	Download Completed	Download Completed	Map Downloading Message
+987	Message	40	Only the host may change the game speed.	Only the host may change the game speed.	Multi. Settings Message
+988	Message	35	Game speed set to %.0f%% of normal.	Game speed set to %.0f%% of normal.	Multi. Settings Message
+989	Unknown	11	gimmie five	gimmie five	Cheat Code
+990	Unknown	9	free gold	free gold	Cheat Code
+991	Unknown	15	mass production	mass production	Cheat Code
+992	Unknown	9	hoody hoo	hoody hoo	Cheat Code
+993	Unknown	10	time flies	time flies	Cheat Code
+994	Unknown	11	speed it up	speed it up	Cheat Code
+995	Unknown	10	good to go	good to go	Cheat Code
+996	Unknown	12	feeling fine	feeling fine	Cheat Code
+997	Unknown	14	overpopulation	overpopulation	Cheat Code
+998	Unknown	12	griff shadow	griff shadow	Cheat Code
+999	Unknown	12	faction free	faction free	Cheat Code
+1000	Unknown	17	there is no spoon	there is no spoon	Cheat Code
+1001	Unknown	15	the end is near	the end is near	Cheat Code
+1002	Unknown	17	unpleasant dreams	unpleasant dreams	Cheat Code
+1003	Unknown	8	i repent	i repent	Cheat Code
+1004	Unknown	7	endgame	endgame	Cheat Code
+1005	Unknown	7	yeahbam	yeahbam	Cheat Code
+1006	Unknown	8	allready	allready	Cheat Code
+1007	Unknown	28	The game has already started	The game has already started	Multi. Settings Message
+1008	Message	18	%s joined the game	%s joined the game	Multi. Settings Message
+1009	Message	62	Welcome to Auto-Host. Game will launch when everyone is ready.	Welcome to Auto-Host. Game will launch when everyone is ready.	Multi. Settings Message
+1010	Unknown	14	 quit the game	 quit the game	Multiplayer Message
+1011	Unknown	11	 was kicked	 was kicked	Multiplayer Message
+1012	Unknown	10	 timed out	 timed out	Multiplayer Message
+1013	Unknown	17	 went out of sync	 went out of sync	Multiplayer Message
+1014	Unknown	17	 couldn't keep up	 couldn't keep up	Multiplayer Message
+1015	Unknown	32	 had an invalid copy of the map.	 had an invalid copy of the map.	Multiplayer Message
+1016	Unknown	35	 had a problem downloading the map.	 had a problem downloading the map.	Multiplayer Message
+1017	Unknown	25	Host terminated the game.	Host terminated the game.	Multiplayer Message
+1018	Message	31	%s has assumed the role of host	%s has assumed the role of host	Multiplayer Message
+1019	Unknown	11	Backup Host	Backup Host	Multiplayer Message
+1020	Unknown	30	You were kicked from the game.	You were kicked from the game.	Multiplayer Message
+1021	Unknown	14	You timed out.	You timed out.	Multiplayer Message
+1022	Unknown	24	Synchronization failure.	Synchronization failure.	Multiplayer Message
+1023	Unknown	16	Couldn't keep up	Couldn't keep up	Multiplayer Message
+1024	Unknown	33	Your copy of that map is invalid.	Your copy of that map is invalid.	Multiplayer Message
+1025	Unknown	40	There was a problem downloading the map.	There was a problem downloading the map.	Multiplayer Message
+1026	Message	43	"As an observer, you may not pause the game."	"As an observer, you may not pause the game."	Pause Message
+1027	Message	27	You cannot unpause the game	You cannot unpause the game	Pause Message
+1028	Unknown	18	Orders Suspended 	Orders Suspended 	Multiplayer Message
+1029	Unknown	11	Game Paused	Game Paused	Pause Message
+1030	Unknown	15	Game Paused by 	Game Paused by 	Pause Message
+1031	Unknown	51	[host is attempting to launch - please click Ready]	[host is attempting to launch - please click Ready]	Multiplayer Message
+1032	Message	22	Not everyone is ready.	Not everyone is ready.	Multiplayer Message
+1033	Message	39	There are not enough CDs for this game.	There are not enough CDs for this game.	CD key Message
+1034	Message	26	Cannot launch without a CD	Cannot launch without a CD	CD key Message
+1035	Message	25	Not everyone has the map.	Not everyone has the map.	Multi. Connection Status
+1036	Unknown	17	Admin not started	Admin not started	Multi. Connection Status
+1037	Unknown	16	 is not in game.	 is not in game.	Multi. Connection Status
+1038	Unknown	20	" is not in game, ..."	" is not in game, ..."	Multi. Connection Status
+1039	Unknown	12	 is loading.	 is loading.	Multi. Connection Status
+1040	Unknown	16	" is loading, ..."	" is loading, ..."	Multi. Connection Status
+1041	Unknown	12	 is lagging.	 is lagging.	Multi. Connection Status
+1042	Unknown	16	" is lagging, ..."	" is lagging, ..."	Multi. Connection Status
+1043	Unknown	37	 can't keep up (game speed too high).	 can't keep up (game speed too high).	Multi. Connection Status
+1044	Unknown	41	" can't keep up (game speed too high), ..."	" can't keep up (game speed too high), ..."	Multi. Connection Status
+1045	Unknown	20	There are no players	There are no players	Multi. Connection Status
+1046	Message	47	ProcessMoveOrder for non-company: id %d type %s	ProcessMoveOrder for non-company: id %d type %s	==
+1047	Message	15	%s has resigned	%s has resigned	Player Resign Message
+1048	Message	23	You have given %s to %s	You have given %s to %s	Tribute Message
+1049	Message	28	You have been given %s by %s	You have been given %s by %s	Tribute Message
+1050	Message	60	Too many players - everyone must be playing a valid kingdom.	Too many players - everyone must be playing a valid kingdom.	Multiplayer Message
+1051	Message	58	There are not enough heroes to allocate %d to each kingdom	There are not enough heroes to allocate %d to each kingdom	Multiplayer Message
+1052	Message	46	Too many players - not enough start positions.	Too many players - not enough start positions.	Multiplayer Message
+1053	Message	43	%s has voted to disconnect lagging players.	%s has voted to disconnect lagging players.	Lagging Vote Message
+1054	Message	58	%s has retracted their vote to disconnect lagging players.	%s has retracted their vote to disconnect lagging players.	Lagging Vote Message
+1055	Message	23	%s has voted to kick %s	%s has voted to kick %s	Lagging Vote Message
+1056	Message	38	%s has retracted their vote to kick %s	%s has retracted their vote to kick %s	Lagging Vote Message
+# Stripping \SOURCE\NETWORK\GAMESPY.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1057	Message	36	Registering with GameSpy server list	Registering with GameSpy server list	Multi. Connection Message
+1058	Message	38	Unregistering from GameSpy server list	Unregistering from GameSpy server list	Multi. Connection Message
+1059	Unknown	61	Could not retrieve DNS information for GameSpy master server.	Could not retrieve DNS information for GameSpy master server.	Multi. Connection Message
+1060	Unknown	43	Could not connect to GameSpy master server.	Could not connect to GameSpy master server.	Multi. Connection Message
+1061	Unknown	58	Problem retrieving server list from GameSpy master server.	Problem retrieving server list from GameSpy master server.	Multi. Connection Message
+1062	Unknown	8	Finished	Finished	Multi. Connection Message
+1063	Unknown	12	Getting list	Getting list	Multi. Connection Message
+1064	Unknown	13	Searching LAN	Searching LAN	Multi. Connection Message
+1065	Unknown	16	Querying Servers	Querying Servers	Multi. Connection Message
+# Stripping \SOURCE\NETWORK\PACKET.CPP...					
+# Stripping \SOURCE\NETWORK\WINSOCK.CPP...					
+# Stripping \SOURCE\OBJECT\ABSTRACT.CPP...					
+# Stripping \SOURCE\OBJECT\MINE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1066	Message	22	%s has been destroyed.	%s has been destroyed.	Mine Status
+1067	Message	34	You cannot afford to build a mine.	You cannot afford to build a mine.	Mine Status
+1068	Message	38	The mine cannot be upgraded right now.	The mine cannot be upgraded right now.	Mine Status
+1069	Message	38	You cannot afford to upgrade the mine.	You cannot afford to upgrade the mine.	Mine Status
+# Stripping \SOURCE\OBJECT\OBJECT.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1070	Warning	48	Tile-based object %d (%s) doesn't fit anymore.\n	Tile-based object %d (%s) doesn't fit anymore.\n	Error Message
+1071	Unknown	4	ff42	ff42	==
+# Stripping \SOURCE\OBJECT\OBJECTQUEUE.CPP...					
+# Stripping \SOURCE\OBJECT\SETTLEMENT.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1072	Warning	32	Component %s has bad paid cost\n	Component %s has bad paid cost\n	Component Error Message
+1073	Error	35	Could not create component %d in %s	Could not create component %d in %s	Component Error Message
+1074	Warning	30	Upgrade %s has bad paid cost\n	Upgrade %s has bad paid cost\n	Component Error Message
+1075	Error	40	Component %d does not have an upgrade %s	Component %d does not have an upgrade %s	Component Error Message
+1076	Message	18	%s has captured %s	%s has captured %s	Capture ** Message
+1077	Message	30	%s has captured a Kohan Amulet	%s has captured a Kohan Amulet	Capture Amulet Message
+1078	Message	28	You have captured %s from %s	You have captured %s from %s	Capture ** Message
+1079	Message	40	You have captured a Kohan Amulet from %s	You have captured a Kohan Amulet from %s	Capture Amulet Message
+1080	Message	33	%s has captured the %s technology	%s has captured the %s technology	Capture Technology Message
+1081	Message	33	The wall has been breached at %s.	The wall has been breached at %s.	Destroy Wall Message
+1082	Message	33	You have breached the wall at %s.	You have breached the wall at %s.	Destroy Wall Message
+1083	Message	46	The %s has been destroyed in the attack on %s.	The %s has been destroyed in the attack on %s.	Destroy Component Message
+1084	Message	41	Your attack on %s has destroyed their %s.	Your attack on %s has destroyed their %s.	Destroy Component Message
+1085	Message	25	You have gained %.0f gold	You have gained %.0f gold	Gain Gold Message
+1086	Message	42	Upgrade order for the %s has been aborted.	Upgrade order for the %s has been aborted.	Abort Upgrade Message
+1087	Message	38	Upgrade order for %s has been aborted.	Upgrade order for %s has been aborted.	Abort Upgrade Message
+1088	Message	26	%s upgrade to %s completed	%s upgrade to %s completed	Upgrade Message
+1089	Message	34	Construction of %s completed in %s	Construction of %s completed in %s	Upgrade Message
+1090	Message	29	Upgrade to %s completed in %s	Upgrade to %s completed in %s	Upgrade Message
+1091	Message	46	%s is currently busy and cannot build anything	%s is currently busy and cannot build anything	Component Message
+1092	Message	20	%s already has a %s.	%s already has a %s.	Component Message
+1093	Message	30	Insufficient gold to build %s.	Insufficient gold to build %s.	Component Message
+1094	Message	26	There is no %s to upgrade.	There is no %s to upgrade.	Component Message
+1095	Message	27	The %s is already upgraded.	The %s is already upgraded.	Component Message
+1096	Message	32	Insufficient gold to upgrade %s.	Insufficient gold to upgrade %s.	Component Message
+1097	Message	30	%s does not have a %s to sell.	%s does not have a %s to sell.	Sell Message
+1098	Message	16	%s sold for %d%c	%s sold for %d%c	Sell Message
+1099	Message	35	Not enough structures to upgrade %s	Not enough structures to upgrade %s	Upgrade Message
+1100	Message	44	Not enough upgraded structures to upgrade %s	Not enough upgraded structures to upgrade %s	Upgrade Message
+1101	Message	31	Insufficient gold to upgrade %s	Insufficient gold to upgrade %s	Upgrade Message
+1102	Message	48	You are at the maximum number of companies (%d).	You are at the maximum number of companies (%d).	Recruit Message
+1103	Message	53	You cannot commission a company without a front line.	You cannot commission a company without a front line.	Recruit Message
+1104	Message	39	%s is not available to be commissioned.	%s is not available to be commissioned.	Recruit Message
+1105	Message	40	You cannot commission while under siege.	You cannot commission while under siege.	Recruit Message
+1106	Message	45	You cannot afford to commission that company.	You cannot afford to commission that company.	Recruit Message
+1107	Message	46	"The world is full, cannot create that company."	"The world is full, cannot create that company."	Recruit Message
+1108	Message	21	Cannot place company.	Cannot place company.	Recruit Message
+1109	Message	22	Cannot create company.	Cannot create company.	Recruit Message
+1110	Message	31	Error creating company element.	Error creating company element.	Recruit Message
+# Stripping \SOURCE\OBJECT\TGBASE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1111	Warning	58	%s's guard zone is too small (%.0f).  Corrected to %.0f.\n	%s's guard zone is too small (%.0f).  Corrected to %.0f.\n	==
+1112	Unknown	10	%s Raiders	%s Raiders	Monster Company Name
+1113	Unknown	11	%s Denizens	%s Denizens	Monster Company Name
+1114	Unknown	10	%s Militia	%s Militia	Militia Company Name
+1115	Message	24	%s dispatched.	%s dispatched.	Militia Message
+# Stripping \SOURCE\OBJECT\TGBUILDING.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1116	Message	28	Construction of %s completed	Construction of %s completed	Component Message
+1117	Message	25	%s has fallen into ruins.	%s has fallen into ruins.	Building Message
+1118	Message	21	You have destroyed %s	You have destroyed %s	Building Message
+1119	Message	42	%d gold has been recovered from the ruins.	%d gold has been recovered from the ruins.	Booty Message
+1120	Message	18	%s is under siege!	%s is under siege!	Building Message
+1121	Message	51	%s is under siege and cannot be razed at this time.	%s is under siege and cannot be razed at this time.	Building Message
+1122	Message	50	%s is threatened and cannot be razed at this time.	%s is threatened and cannot be razed at this time.	Building Message
+1123	Message	26	It is too late to raze %s.	It is too late to raze %s.	Building Message
+1124	Message	17	%s has been razed	%s has been razed	Building Message
+# Stripping \SOURCE\OBJECT\TGLAIR.CPP...					
+# Stripping \SOURCE\OBJECT\TGPROJECTILE.CPP...					
+# Stripping \SOURCE\OBJECT\TGTERRAINFEATURE.CPP...					
+# Stripping \SOURCE\OBJECT\TGUNIT.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1125	Message	41	%s of %s has been lost to the wilderness.	%s of %s has been lost to the wilderness.	Unit Message
+1126	Unknown	6	Wraith	Wraith	Unti Name
+1127	Error	58	Loading hero %s but level on hero (%d) is not correct (%d)	Loading hero %s but level on hero (%d) is not correct (%d)	Hero Message
+1128	Error	53	Loading hero %s but is not in active or inactive list	Loading hero %s but is not in active or inactive list	Hero Message
+1129	Error	19	hero %s ID mismatch	hero %s ID mismatch	Hero Message
+1130	Error	40	That hero has already been commissioned.	That hero has already been commissioned.	Hero Message
+1131	Message	16	%s has become %s	%s has become %s	==
+# Stripping \SOURCE\RADAR\RADAR.CPP...					
+# Stripping \SOURCE\RADAR\TGRADAR.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1132	Unknown	19	Generating Mini-Map	Generating Mini-Map	Game Loading Message
+# Stripping \SOURCE\SAI\SAI_MAIN.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1133	Unknown	25	%s  Player: %d (ID: %d)\n	%s  Player: %d (ID: %d)\n	==
+1134	Unknown	26	CV: %5.2f  Max CV: %5.2f\n	CV: %5.2f  Max CV: %5.2f\n	AI Language
+1135	Unknown	21	Capt: %s  Front: %s\n	Capt: %s  Front: %s\n	AI Language
+1136	Unknown	9	Spt1: %s 	Spt1: %s 	AI Language
+1137	Unknown	8	Spt2: %s	Spt2: %s	AI Language
+1138	Unknown	9	Goal: %s 	Goal: %s 	AI Language
+1139	Unknown	19	"Target:%s (%d,%d)\n"	"Target:%s (%d,%d)\n"	AI Language
+1140	Unknown	54	Val: %.0f Str: %.0f Enemy: %.0f\nRequired: %.0f-%.0f\n	Val: %.0f Str: %.0f Enemy: %.0f\nRequired: %.0f-%.0f\n	AI Language
+1141	Unknown	24	%s  Owner: %d (ID: %d)\n	%s  Owner: %d (ID: %d)\n	AI Language
+1142	Unknown	22	Type: %s   State: %d\n	Type: %s   State: %d\n	AI Language
+1143	Unknown	18	"Tile X/Y: %d, %d  "	"Tile X/Y: %d, %d  "	AI Language
+1144	Unknown	18	"Reg. X/Y: %d, %d\n"	"Reg. X/Y: %d, %d\n"	AI Language
+1145	Unknown	26	HP: %6.1f  Max HP: %6.1f\n	HP: %6.1f  Max HP: %6.1f\n	AI Language
+1146	Unknown	10	Goal: %s  	Goal: %s  	AI Language
+1147	Unknown	17	Front Units: %s\n	Front Units: %s\n	AI Language
+1148	Unknown	56	"Region: %d  (%d, %d)  \n Tile range: X(%d-%d) Y(%d-%d)\n"	"Region: %d  (%d, %d)  \n Tile range: X(%d-%d) Y(%d-%d)\n"	AI Language
+1149	Unknown	27	There are %d connections.\n	There are %d connections.\n	AI Language
+1150	Unknown	36	%d: Reg:%d  Ps%%:%3.2f  Mov: %3.2f\n	%d: Reg:%d  Ps%%:%3.2f  Mov: %3.2f\n	AI Language
+1151	Unknown	35	\n\nPl: Str Inf Econ Cos Bdg Base\n	\n\nPl: Str Inf Econ Cos Bdg Base\n	AI Language
+1152	Unknown	25	"\n\nPl: Supply	Explored\n"	"\n\nPl: Supply	Explored\n"	AI Language
+1153	Unknown	23	\n\nPl: Sup(%) Exp(%)\n	\n\nPl: Sup(%) Exp(%)\n	AI Language
+1154	Unknown	26	Player: %d   Profile: %s\n	Player: %d   Profile: %s\n	AI Language
+1155	Unknown	39	\nRate: %+.0f/%+.0f/%+.0f/%+.0f/%+.0f\n	\nRate: %+.0f/%+.0f/%+.0f/%+.0f/%+.0f\n	AI Language
+1156	Unknown	63	\nBank:%6.2f Delta: %6.2f\nBdg(%5.2f) Str(%5.2f) Unt(%5.2f)\n\n	\nBank:%6.2f Delta: %6.2f\nBdg(%5.2f) Str(%5.2f) Unt(%5.2f)\n\n	AI Language
+1157	Unknown	24	Rel:%d Op:%3.1f(%3.1f)\n	Rel:%d Op:%3.1f(%3.1f)\n	AI Language
+1158	Unknown	19	"%s(%d,%d) (Co:%d)\n"	"%s(%d,%d) (Co:%d)\n"	AI Language
+1159	Unknown	43	\nCos:%d(At max? %d) Com:%d Con:%d OOS:%d\n	\nCos:%d(At max? %d) Com:%d Con:%d OOS:%d\n	AI Language
+1160	Unknown	44	\nCos:%d(At max? N/A) Com:%d Con:%d OOS:%d\n	\nCos:%d(At max? N/A) Com:%d Con:%d OOS:%d\n	AI Language
+1161	Unknown	26	"\nSet:%d(%d), Eng:%d(%d)\n"	"\nSet:%d(%d), Eng:%d(%d)\n"	AI Language
+1162	Unknown	14	\nFront units 	\nFront units 	AI Language
+1163	Unknown	16	\nSupport units 	\nSupport units 	AI Language
+1164	Unknown	23	\nCan build units? %d\n	\nCan build units? %d\n	AI Language
+1165	Unknown	19	\n Num eval goals: 	\n Num eval goals: 	AI Language
+1166	Unknown	19	\n Num exec goals: 	\n Num exec goals: 	AI Language
+# Stripping \SOURCE\SAI\TGSAIGOAL.CPP...					
+# Stripping \SOURCE\SAI\TGSAIMAP.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1167	Message	14	AI Initialized	AI Initialized	Game Loading Message
+# Stripping \SOURCE\SAI\TGSAIPLAYER.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1168	Unknown	11	Company #%d	Company #%d	AI Company Message
+# Stripping \SOURCE\SAI\TGSAIPOLITICS.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1169	Message	31	opinion %d -> %d -= %.1f = %.1f	opinion %d -> %d -= %.1f = %.1f	Politics Favor Message
+1170	Message	31	opinion %d -> %d += %.1f = %.1f	opinion %d -> %d += %.1f = %.1f	Politics Favor Message
+1171	Message	31	tribute %d -> %d += %.1f = %.1f	tribute %d -> %d += %.1f = %.1f	Tribute Message
+# Stripping \SOURCE\SAI\TGSAIPROFILES.CPP...					
+# Stripping \SOURCE\SOUND\TGSOUND.CPP...					
+# Stripping \SOURCE\SPRITE\TGART.CPP...					
+# Stripping \SOURCE\SPRITE\TGART15.CPP...					
+# Stripping \SOURCE\SPRITE\TGART16.CPP...					
+# Stripping \SOURCE\SPRITE\TGCURSOR.CPP...					
+# Stripping \SOURCE\SPRITE\TGDRAWMANAGER.CPP...					
+# Stripping \SOURCE\SPRITE\TGFONT.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1172	Unknown	3	Gem	Gem	Icon for Mana
+1173	Unknown	5	Sword	Sword	Icon for Attack Value
+1174	Unknown	6	Shield	Shield	Icon for Defense Value
+1175	Unknown	3	Bow	Bow	Icon for Ranged Attack Value
+1176	Unknown	4	Boot	Boot	Icon for Movement Rate
+1177	Unknown	3	Eye	Eye	Icon for Visual Range
+1178	Unknown	6	Person	Person	Icon for Company #/Limit
+1179	Unknown	9	Semicolon	Semicolon	Icon for
+1180	Unknown	6	Return	Return	Icon for
+1181	Unknown	3	Amp	Amp	Icon for
+# Stripping \SOURCE\SPRITE\TGGRAPHPRIM.CPP...					
+# Stripping \SOURCE\SPRITE\TGMOVIEMANAGER.CPP...					
+# Stripping \SOURCE\SPRITE\TGTEXTWINDOW.CPP...					
+# Stripping \SOURCE\TERRAIN\RANDOMMAP.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1182	Unknown	8	rlog.txt	rlog.txt	==
+1183	Unknown	27	RANDOMMAP Finish %d %d - %d	RANDOMMAP Finish %d %d - %d	Random Map Message
+1184	Unknown	19	Random Map Inactive	Random Map Inactive	Random Map Message
+1185	Unknown	23	Random Map Loading Data	Random Map Loading Data	Random Map Message
+1186	Unknown	27	Random Map Generating Tiles	Random Map Generating Tiles	Random Map Message
+1187	Unknown	21	Random Map Correcting	Random Map Correcting	Random Map Message
+1188	Unknown	20	Random Map Finishing	Random Map Finishing	Random Map Message
+1189	Unknown	33	Random Map Placing Water Boundary	Random Map Placing Water Boundary	Random Map Message
+1190	Unknown	31	Random Map Placing Map Features	Random Map Placing Map Features	Random Map Message
+1191	Unknown	27	Random Map Generating Radar	Random Map Generating Radar	Random Map Message
+1192	Unknown	6	Frigid	Frigid	Terrain Message
+1193	Unknown	4	Cold	Cold	Terrain Message
+1194	Unknown	4	Cool	Cool	Terrain Message
+1195	Unknown	8	Mountain	Mountain	Terrain Message
+1196	Unknown	6	Tundra	Tundra	Terrain Message
+1197	Unknown	6	Forest	Forest	Terrain Message
+1198	Unknown	4	Pole	Pole	Terrain Message
+1199	Unknown	3	Dry	Dry	Terrain Message
+1200	Unknown	3	Wet	Wet	Terrain Message
+1201	Unknown	4	Lush	Lush	Terrain Message
+1202	Unknown	6	Jungle	Jungle	Terrain Message
+1203	Unknown	6	Desert	Desert	Terrain Message
+1204	Unknown	7	Drowned	Drowned	Terrain Message
+1205	Unknown	8	Tropical	Tropical	Terrain Message
+1206	Unknown	7	Warning	Warning	Terrain Message
+# Stripping \SOURCE\TERRAIN\TGTERRAIN.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1207	Error	46	You can only place deep water on shallow water	You can only place deep water on shallow water	Terrain Message
+1208	Unknown	20	"PLACE: %d on (%d,%d)"	"PLACE: %d on (%d,%d)"	Terrain Message
+1209	Unknown	41	"correct (%d,%d) with %d (base %d over %d)"	"correct (%d,%d) with %d (base %d over %d)"	Terrain Message
+1210	Warning	47	"There are inaccessible objects (%s at %d,%d).\n"	"There are inaccessible objects (%s at %d,%d).\n"	Terrain Message
+1211	Warning	58	"There are objects in inaccessible regions (%s at %d,%d).\n"	"There are objects in inaccessible regions (%s at %d,%d).\n"	Terrain Message
+1212	Warning	94	A large region has been marked as inaccessible since it is not connected to the main region.\n	A large region has been marked as inaccessible since it is not connected to the main region.\n	Terrain Message
+# Stripping \SOURCE\TERRAIN\TGTERRAINTYPE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1213	g_terrain_name	5	Grass	Grass	Terrain Name
+1214	g_terrain_name	5	Rough	Rough	Terrain Name
+1215	g_terrain_name	5	Beach	Beach	Terrain Name
+1216	g_terrain_name	5	Hills	Hills	Terrain Name
+1217	g_terrain_name	4	Snow	Snow	Terrain Name
+1218	g_terrain_name	5	Water	Water	Terrain Name
+1219	g_terrain_name	4	Evil	Evil	Terrain Name
+1220	g_terrain_name	7	Forest2	Forest2	Terrain Name
+# Stripping \SOURCE\UTILITY\BINARYSEARCH.CPP...					
+# Stripping \SOURCE\UTILITY\CSTRING.CPP...					
+# Stripping \SOURCE\UTILITY\CTOKER.CPP...					
+# Stripping \SOURCE\UTILITY\MATHLIB.CPP...					
+# Stripping \SOURCE\UTILITY\RNG.CPP...					
+# Stripping \SOURCE\UTILITY\TGARRAY.CPP...					
+# Stripping \SOURCE\UTILITY\TGMUTEX.CPP...					
+# Stripping \SOURCE\UTILITY\TGSIGNAL.CPP...					
+# Stripping \SOURCE\UTILITY\UTILITY.CPP...					
+# Stripping \SOURCE\WORLDINTERFACE\WI_BUILDING.CPP...					
+# Stripping \SOURCE\WORLDINTERFACE\WI_COMPANY.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1221	Message	66	Construction of %s can only be completed by a company of settlers.	Construction of %s can only be completed by a company of settlers.	Settler Message
+# Stripping \SOURCE\WORLDINTERFACE\WI_GHOST.CPP...					
+# Stripping \SOURCE\WORLDINTERFACE\WI_PLAYER.CPP...					
+# Stripping \SOURCE\WORLDINTERFACE\WI_REGIMENT.CPP...					
+# Stripping \SOURCE\WORLDINTERFACE\WORLDINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1222	Unknown	17	Launching Mission	Launching Mission	Loading Game Message
+1223	Warning	26	Failed to load mission: %s	Failed to load mission: %s	Loading Game Message
+1224	Warning	85	Failed to generate map.  Try increasing the size or decreasing the number of players.	Failed to generate map.  Try increasing the size or decreasing the number of players.	Loading Game Message
+1225	Unknown	7	Footman	Footman	Unit Name
+1226	Unknown	6	Archer	Archer	Unit Name
+1227	Unknown	5	Scout	Scout	Unit Name
+1228	Unknown	7	Warmage	Warmage	Unit Name
+1229	Unknown	3	Orc	Orc	Unit Name
+# Stripping \DATA\BONUS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1230	ATTACK_BONUS_TO_ANY name1	12	Attack Bonus	Attack Bonus	Bonuses and Modifiers
+1231	ATTACK_BONUS_TO_ANY name2	8	Weakened	Weakened	Bonuses and Modifiers
+1232	ATTACK_BONUS_TO_ANY Description1	25	Increases attacks by %+d.	Increases attacks by %+d.	Bonuses and Modifiers
+1233	ATTACK_BONUS_TO_ANY Description2	25	Decreases attacks by %+d.	Decreases attacks by %+d.	Bonuses and Modifiers
+1234	ATTACK_BONUS_TO_MOUNTED name1	11	Cavalry Foe	Cavalry Foe	Bonuses and Modifiers
+1235	ATTACK_BONUS_TO_MOUNTED name2	8	not used	not used	Bonuses and Modifiers
+1236	ATTACK_BONUS_TO_MOUNTED Description1	50	Increases attacks against cavalry elements by %+d.	Increases attacks against cavalry elements by %+d.	Bonuses and Modifiers
+1237	ATTACK_BONUS_TO_SHADOW name1	10	Shadowbane	Shadowbane	Bonuses and Modifiers
+1238	ATTACK_BONUS_TO_SHADOW Description1	49	Increases attacks against non-shadow elements by %+d.	Increases attacks against non-shadow elements by %+d.	Bonuses and Modifiers
+1239	ATTACK_BONUS_TO_ARCHER name1	10	Archer Foe	Archer Foe	Bonuses and Modifiers
+1240	ATTACK_BONUS_TO_ARCHER Description1	49	Increases attacks against archer elements by %+d.	Increases attacks against archer elements by %+d.	Bonuses and Modifiers
+1241	ATTACK_BONUS_TO_BUILDING name1	11	Siege Bonus	Siege Bonus	Bonuses and Modifiers
+1242	ATTACK_BONUS_TO_BUILDING name2	13	Siege Penalty	Siege Penalty	Bonuses and Modifiers
+1243	ATTACK_BONUS_TO_BUILDING Description1	43	Increases attacks against buildings by %+d.	Increases attacks against buildings by %+d.	Bonuses and Modifiers
+1244	ATTACK_BONUS_TO_BUILDING Description2	43	Decreases attacks against buildings by %+d.	Decreases attacks against buildings by %+d.	Bonuses and Modifiers
+1245	ATTACK_BONUS_TO_ROUTED name1	9	Bloodlust	Bloodlust	Bonuses and Modifiers
+1246	ATTACK_BONUS_TO_ROUTED name2	8	Chivalry	Chivalry	Bonuses and Modifiers
+1247	ATTACK_BONUS_TO_ROUTED Description1	49	Increases attacks against routed elements by %+d.	Increases attacks against routed elements by %+d.	Bonuses and Modifiers
+1248	ATTACK_BONUS_TO_ROUTED Description2	49	Decreases attacks against routed elements by %+d.	Decreases attacks against routed elements by %+d.	Bonuses and Modifiers
+1249	HIT_POINTS_BONUS name1	7	Healthy	Healthy	Bonuses and Modifiers
+1250	HIT_POINTS_BONUS name2	5	Frail	Frail	Bonuses and Modifiers
+1251	HIT_POINTS_BONUS Description1	35	Increases health to %d%% of normal.	Increases health to %d%% of normal.	Bonuses and Modifiers
+1252	HIT_POINTS_BONUS Description2	35	Decreases health to %d%% of normal.	Decreases health to %d%% of normal.	Bonuses and Modifiers
+1253	DEFENSE_BONUS_VS_ANY name1	13	Defense Bonus	Defense Bonus	Bonuses and Modifiers
+1254	DEFENSE_BONUS_VS_ANY name2	15	Defense Penalty	Defense Penalty	Bonuses and Modifiers
+1255	DEFENSE_BONUS_VS_ANY Description1	34	%+d DV bonus against all elements.	%+d DV bonus against all elements.	Bonuses and Modifiers
+1256	DEFENSE_BONUS_VS_ANY Description2	36	%+d DV penalty against all elements.	%+d DV penalty against all elements.	Bonuses and Modifiers
+1257	DEFENSE_BONUS_VS_MOUNTED name1	17	Cavalry Resistant	Cavalry Resistant	Bonuses and Modifiers
+1258	DEFENSE_BONUS_VS_MOUNTED name2	18	Cavalry Vulnerable	Cavalry Vulnerable	Bonuses and Modifiers
+1259	DEFENSE_BONUS_VS_MOUNTED Description1	38	%+d DV bonus against cavalry elements.	%+d DV bonus against cavalry elements.	Bonuses and Modifiers
+1260	DEFENSE_BONUS_VS_MOUNTED Description2	40	%+d DV penalty against cavalry elements.	%+d DV penalty against cavalry elements.	Bonuses and Modifiers
+1261	DEFENSE_BONUS_VS_SHADOW name1	16	Shadow Resistant	Shadow Resistant	Bonuses and Modifiers
+1262	DEFENSE_BONUS_VS_SHADOW name2	17	Shadow Vulnerable	Shadow Vulnerable	Bonuses and Modifiers
+1263	DEFENSE_BONUS_VS_SHADOW Description1	37	%+d DV bonus against shadow elements.	%+d DV bonus against shadow elements.	Bonuses and Modifiers
+1264	DEFENSE_BONUS_VS_SHADOW Description2	39	%+d DV penalty against shadow elements.	%+d DV penalty against shadow elements.	Bonuses and Modifiers
+1265	DEFENSE_BONUS_VS_ARCHER name1	16	Archer Resistant	Archer Resistant	Bonuses and Modifiers
+1266	DEFENSE_BONUS_VS_ARCHER name2	17	Archer Vulnerable	Archer Vulnerable	Bonuses and Modifiers
+1267	DEFENSE_BONUS_VS_ARCHER Description1	37	%+d DV bonus against archer elements.	%+d DV bonus against archer elements.	Bonuses and Modifiers
+1268	DEFENSE_BONUS_VS_ARCHER Description2	39	%+d DV penalty against archer elements.	%+d DV penalty against archer elements.	Bonuses and Modifiers
+1269	DAMAGE_BONUS_TO_ANY name1	12	Damage Bonus	Damage Bonus	Bonuses and Modifiers
+1270	DAMAGE_BONUS_TO_ANY name2	14	Damage Penalty	Damage Penalty	Bonuses and Modifiers
+1271	DAMAGE_BONUS_TO_ANY Description1	45	Increases damage inflicted to %d%% of normal.	Increases damage inflicted to %d%% of normal.	Bonuses and Modifiers
+1272	DAMAGE_BONUS_TO_ANY Description2	1	x	x	Bonuses and Modifiers
+1273	IGNORE_TERRAIN_BONUS name1	12	Trailblazing	Trailblazing	Bonuses and Modifiers
+1274	IGNORE_TERRAIN_BONUS name2	7	nt used	nt used	Bonuses and Modifiers
+1275	IGNORE_TERRAIN_BONUS Description1	37	Ignores terrain penalty for movement.	Ignores terrain penalty for movement.	Bonuses and Modifiers
+1276	DAMAGE_BONUS_TO_SHADOW name1	13	Shadow Killer	Shadow Killer	Bonuses and Modifiers
+1277	DAMAGE_BONUS_TO_SHADOW Description1	64	Increases damage inflicted to shadow elements to %d%% of normal.	Increases damage inflicted to shadow elements to %d%% of normal.	Bonuses and Modifiers
+1278	DAMAGE_BONUS_TO_MOUNTED name1	14	Cavalry Killer	Cavalry Killer	Bonuses and Modifiers
+1279	DAMAGE_BONUS_TO_MOUNTED Description1	65	Increases damage inflicted to cavalry elements to %d%% of normal.	Increases damage inflicted to cavalry elements to %d%% of normal.	Bonuses and Modifiers
+1280	DAMAGE_BONUS_TO_BUILDING name1	6	Sapper	Sapper	Bonuses and Modifiers
+1281	DAMAGE_BONUS_TO_BUILDING name2	17	Not Siege Capable	Not Siege Capable	Bonuses and Modifiers
+1282	DAMAGE_BONUS_TO_BUILDING Description1	58	Increases damage inflicted to buildings to %d%% of normal.	Increases damage inflicted to buildings to %d%% of normal.	Bonuses and Modifiers
+1283	DAMAGE_BONUS_TO_BUILDING Description2	58	Decreases damage inflicted to buildings to %d%% of normal.	Decreases damage inflicted to buildings to %d%% of normal.	Bonuses and Modifiers
+1284	DAMAGE_BONUS_TO_ARCHER name1	13	Archer Killer	Archer Killer	Bonuses and Modifiers
+1285	DAMAGE_BONUS_TO_ARCHER Description1	64	Increases damage inflicted to archer elements to %d%% of normal.	Increases damage inflicted to archer elements to %d%% of normal.	Bonuses and Modifiers
+1286	DAMAGE_TAKEN_FROM_ANY name2	5	Tough	Tough	Bonuses and Modifiers
+1287	DAMAGE_TAKEN_FROM_ANY Description1	41	Increases damage taken to %d%% of normal.	Increases damage taken to %d%% of normal.	Bonuses and Modifiers
+1288	DAMAGE_TAKEN_FROM_ANY Description2	41	Decreases damage taken to %d%% of normal.	Decreases damage taken to %d%% of normal.	Bonuses and Modifiers
+1289	DAMAGE_TAKEN_FROM_MAGIC name1	16	Magic Vulnerable	Magic Vulnerable	Bonuses and Modifiers
+1290	DAMAGE_TAKEN_FROM_MAGIC name2	15	Magic Resistant	Magic Resistant	Bonuses and Modifiers
+1291	DAMAGE_TAKEN_FROM_MAGIC Description1	60	Increases damage taken from magic attacks to %d%% of normal.	Increases damage taken from magic attacks to %d%% of normal.	Bonuses and Modifiers
+1292	DAMAGE_TAKEN_FROM_MAGIC Description2	60	Decreases damage taken from magic attacks to %d%% of normal.	Decreases damage taken from magic attacks to %d%% of normal.	Bonuses and Modifiers
+1293	DAMAGE_TAKEN_FROM_RANGED name1	16	Range Vulnerable	Range Vulnerable	Bonuses and Modifiers
+1294	DAMAGE_TAKEN_FROM_RANGED name2	15	Range Resistant	Range Resistant	Bonuses and Modifiers
+1295	DAMAGE_TAKEN_FROM_RANGED Description1	60	Increases damage taken from range attacks to %d%% of normal.	Increases damage taken from range attacks to %d%% of normal.	Bonuses and Modifiers
+1296	DAMAGE_TAKEN_FROM_RANGED Description2	60	Decreases damage taken from range attacks to %d%% of normal.	Decreases damage taken from range attacks to %d%% of normal.	Bonuses and Modifiers
+1297	DAMAGE_TAKEN_FROM_MELEE name1	16	Melee Vulnerable	Melee Vulnerable	Bonuses and Modifiers
+1298	DAMAGE_TAKEN_FROM_MELEE name2	15	Melee Resistant	Melee Resistant	Bonuses and Modifiers
+1299	DAMAGE_TAKEN_FROM_MELEE Description1	60	Increases damage taken from melee attacks to %d%% of normal.	Increases damage taken from melee attacks to %d%% of normal.	Bonuses and Modifiers
+1300	DAMAGE_TAKEN_FROM_MELEE Description2	60	Decreases damage taken from melee attacks to %d%% of normal.	Decreases damage taken from melee attacks to %d%% of normal.	Bonuses and Modifiers
+1301	DAMAGE_TAKEN_FROM_NON_MAGIC name1	6	Flimsy	Flimsy	Bonuses and Modifiers
+1302	DAMAGE_TAKEN_FROM_NON_MAGIC name2	7	Armored	Armored	Bonuses and Modifiers
+1303	DAMAGE_TAKEN_FROM_NON_MAGIC Description1	64	Increases damage taken from non-magic attacks to %d%% of normal.	Increases damage taken from non-magic attacks to %d%% of normal.	Bonuses and Modifiers
+1304	DAMAGE_TAKEN_FROM_NON_MAGIC Description2	64	Decreases damage taken from non-magic attacks to %d%% of normal.	Decreases damage taken from non-magic attacks to %d%% of normal.	Bonuses and Modifiers
+1305	REVERSE_DAMAGE_WHEN_HIT name1	14	Reverse Damage	Reverse Damage	Bonuses and Modifiers
+1306	REVERSE_DAMAGE_WHEN_HIT Description1	65	Inflicts %+d damage to enemies when they attack element in melee.	Inflicts %+d damage to enemies when they attack element in melee.	Bonuses and Modifiers
+1307	MOVEMENT_BONUS name1	14	Movement Bonus	Movement Bonus	Bonuses and Modifiers
+1308	MOVEMENT_BONUS name2	16	Movement Penalty	Movement Penalty	Bonuses and Modifiers
+1309	MOVEMENT_BONUS Description1	60	Increases the movement rate of an element to %d%% of normal.	Increases the movement rate of an element to %d%% of normal.	Bonuses and Modifiers
+1310	MOVEMENT_BONUS Description2	60	Decreases the movement rate of an element to %d%% of normal.	Decreases the movement rate of an element to %d%% of normal.	Bonuses and Modifiers
+1311	PARALYZE_BONUS name1	9	Paralysis	Paralysis	Bonuses and Modifiers
+1312	PARALYZE_BONUS Description1	47	Paralyzes element so it may not move or attack.	Paralyzes element so it may not move or attack.	Bonuses and Modifiers
+1313	ENTANGLE_BONUS name1	8	Entangle	Entangle	Bonuses and Modifiers
+1314	ENTANGLE_BONUS Description1	37	Entangles element so it may not move.	Entangles element so it may not move.	Bonuses and Modifiers
+1315	RESUPPLY_RATE_BONUS name1	16	Quicker Recovery	Quicker Recovery	Bonuses and Modifiers
+1316	RESUPPLY_RATE_BONUS name2	15	Slower Recovery	Slower Recovery	Bonuses and Modifiers
+1317	RESUPPLY_RATE_BONUS Description1	66	Increases rate at which elements are resupplied to %d%% of normal.	Increases rate at which elements are resupplied to %d%% of normal.	Bonuses and Modifiers
+1318	RESUPPLY_RATE_BONUS Description2	66	Decreases rate at which elements are resupplied to %d%% of normal.	Decreases rate at which elements are resupplied to %d%% of normal.	Bonuses and Modifiers
+1319	ZONE_OF_CONTROL_BONUS name1	8	Dominion	Dominion	Bonuses and Modifiers
+1320	ZONE_OF_CONTROL_BONUS name2	12	Poor Control	Poor Control	Bonuses and Modifiers
+1321	ZONE_OF_CONTROL_BONUS Description1	58	Increases the company's zone of control to %d%% of normal.	Increases the company's zone of control to %d%% of normal.	Bonuses and Modifiers
+1322	ZONE_OF_CONTROL_BONUS Description2	58	Decreases the company's zone of control to %d%% of normal.	Decreases the company's zone of control to %d%% of normal.	Bonuses and Modifiers
+1323	MORALE_BONUS name1	7	Bravery	Bravery	Bonuses and Modifiers
+1324	MORALE_BONUS name2	9	Cowardice	Cowardice	Bonuses and Modifiers
+1325	MORALE_BONUS Description1	39	Increases company's base morale by %+d.	Increases company's base morale by %+d.	Bonuses and Modifiers
+1326	MORALE_BONUS Description2	39	Decreases company's base morale by %+d.	Decreases company's base morale by %+d.	Bonuses and Modifiers
+1327	MORALE_LOSS_RATE_BONUS name1	7	Panicky	Panicky	Bonuses and Modifiers
+1328	MORALE_LOSS_RATE_BONUS name2	10	Courageous	Courageous	Bonuses and Modifiers
+1329	MORALE_LOSS_RATE_BONUS Description1	67	Increases the company's loss of morale in combat to %d%% of normal.	Increases the company's loss of morale in combat to %d%% of normal.	Bonuses and Modifiers
+1330	MORALE_LOSS_RATE_BONUS Description2	67	Decreases the company's loss of morale in combat to %d%% of normal.	Decreases the company's loss of morale in combat to %d%% of normal.	Bonuses and Modifiers
+1331	MORALE_RECOVERY_RATE_BONUS name1	11	Inspiration	Inspiration	Bonuses and Modifiers
+1332	MORALE_RECOVERY_RATE_BONUS name2	7	Fearful	Fearful	Bonuses and Modifiers
+1333	MORALE_RECOVERY_RATE_BONUS Description1	61	Increases the company's recovery of morale to %d%% of normal.	Increases the company's recovery of morale to %d%% of normal.	Bonuses and Modifiers
+1334	MORALE_RECOVERY_RATE_BONUS Description2	61	Decreases the company's recovery of morale to %d%% of normal.	Decreases the company's recovery of morale to %d%% of normal.	Bonuses and Modifiers
+1335	MORALE_CHECK_BONUS name1	5	Valor	Valor	Bonuses and Modifiers
+1336	MORALE_CHECK_BONUS name2	5	Timid	Timid	Bonuses and Modifiers
+1337	MORALE_CHECK_BONUS Description1	49	Lowers the point at which company may rout by %d.	Lowers the point at which company may rout by %d.	Bonuses and Modifiers
+1338	MORALE_CHECK_BONUS Description2	49	Raises the point at which company may rout by %d.	Raises the point at which company may rout by %d.	Bonuses and Modifiers
+1339	VISUAL_RANGE_BONUS name1	5	Recon	Recon	Bonuses and Modifiers
+1340	VISUAL_RANGE_BONUS name2	13	Short Sighted	Short Sighted	Bonuses and Modifiers
+1341	VISUAL_RANGE_BONUS Description1	55	Increases the company's visual range to %d%% of normal.	Increases the company's visual range to %d%% of normal.	Bonuses and Modifiers
+1342	VISUAL_RANGE_BONUS Description2	55	Decreases the company's visual range to %d%% of normal.	Decreases the company's visual range to %d%% of normal.	Bonuses and Modifiers
+1343	ENTRENCHMENT_RATE_BONUS name1	16	Slow Entrenching	Slow Entrenching	Bonuses and Modifiers
+1344	ENTRENCHMENT_RATE_BONUS name2	17	Rapid Entrenching	Rapid Entrenching	Bonuses and Modifiers
+1345	ENTRENCHMENT_RATE_BONUS Description1	59	Increases the company's time to entrench to %d%% of normal.	Increases the company's time to entrench to %d%% of normal.	Bonuses and Modifiers
+1346	ENTRENCHMENT_RATE_BONUS Description2	59	Decreases the company's time to entrench to %d%% of normal.	Decreases the company's time to entrench to %d%% of normal.	Bonuses and Modifiers
+1347	DAMAGE_TAKEN_FROM_HOLY name1	15	Holy Vulnerable	Holy Vulnerable	Bonuses and Modifiers
+1348	DAMAGE_TAKEN_FROM_HOLY name2	14	Holy Resistant	Holy Resistant	Bonuses and Modifiers
+1349	DAMAGE_TAKEN_FROM_HOLY Description1	59	Increases damage taken from holy attacks to %d%% of normal.	Increases damage taken from holy attacks to %d%% of normal.	Bonuses and Modifiers
+1350	DAMAGE_TAKEN_FROM_HOLY Description2	59	Decreases damage taken from holy attacks to %d%% of normal.	Decreases damage taken from holy attacks to %d%% of normal.	Bonuses and Modifiers
+1351	DAMAGE_TAKEN_FROM_UNHOLY name1	17	Unholy Vulnerable	Unholy Vulnerable	Bonuses and Modifiers
+1352	DAMAGE_TAKEN_FROM_UNHOLY name2	16	Unholy Resistant	Unholy Resistant	Bonuses and Modifiers
+1353	DAMAGE_TAKEN_FROM_UNHOLY Description1	61	Increases damage taken from unholy attacks to %d%% of normal.	Increases damage taken from unholy attacks to %d%% of normal.	Bonuses and Modifiers
+1354	DAMAGE_TAKEN_FROM_UNHOLY Description2	61	Decreases damage taken from unholy attacks to %d%% of normal.	Decreases damage taken from unholy attacks to %d%% of normal.	Bonuses and Modifiers
+1355	DAMAGE_TAKEN_FROM_KHALDUNITE name1	21	Khaldunite Vulnerable	Khaldunite Vulnerable	Bonuses and Modifiers
+1356	DAMAGE_TAKEN_FROM_KHALDUNITE name2	20	Khaldunite Resistant	Khaldunite Resistant	Bonuses and Modifiers
+1357	DAMAGE_TAKEN_FROM_KHALDUNITE Description1	65	Increases damage taken from khaldunite attacks to %d%% of normal.	Increases damage taken from khaldunite attacks to %d%% of normal.	Bonuses and Modifiers
+1358	DAMAGE_TAKEN_FROM_KHALDUNITE Description2	65	Decreases damage taken from khaldunite attacks to %d%% of normal.	Decreases damage taken from khaldunite attacks to %d%% of normal.	Bonuses and Modifiers
+1359	IMMUNITY_TO_ENCHANTMENT name1	14	Spell Immunity	Spell Immunity	Bonuses and Modifiers
+1360	IMMUNITY_TO_ENCHANTMENT Description1	55	Element is immune to the effects of enchantment spells.	Element is immune to the effects of enchantment spells.	Bonuses and Modifiers
+1361	MELEE_HOLY_DAMAGE name1	12	Holy Attacks	Holy Attacks	Bonuses and Modifiers
+1362	MELEE_HOLY_DAMAGE Description1	62	Element inflicts %+d additional damage with melee attacks to creatures of shadow.	Element inflicts %+d additional damage with melee attacks to creatures of shadow.	Bonuses and Modifiers
+1363	MELEE_UNHOLY_DAMAGE name1	14	Unholy Attacks	Unholy Attacks	Bonuses and Modifiers
+1364	MELEE_UNHOLY_DAMAGE Description1	63	Element inflicts %+d additional damage with melee attacks to non-shadow creatures.	Element inflicts %+d additional damage with melee attacks to non-shadow creatures.	Bonuses and Modifiers
+1365	CAUSE_KHALDUNITE_DAMAGE name1	19	Khaldunite Weaponry	Khaldunite Weaponry	Bonuses and Modifiers
+1366	CAUSE_KHALDUNITE_DAMAGE Description1	45	Element now inflicts Khaldunite based damage.	Element now inflicts Khaldunite based damage.	Bonuses and Modifiers
+1367	CAUSE_MAGIC_DAMAGE name1	14	Magic Weaponry	Magic Weaponry	Bonuses and Modifiers
+1368	CAUSE_MAGIC_DAMAGE Description1	40	Element now inflicts Magic based damage.	Element now inflicts Magic based damage.	Bonuses and Modifiers
+1369	UPGRADE_BONUS_COST_GROUP_1 name2	18	Commission Group 1	Commission Group 1	Bonuses and Modifiers
+1370	UPGRADE_BONUS_COST_GROUP_1 Description2	60	Archer, Footman, &amp. Scout Commission costs are reduced to %d%% of normal.	Archer, Footman, &amp. Scout Commission costs are reduced to %d%% of normal.	Bonuses and Modifiers
+1371	UPGRADE_BONUS_COST_GROUP_2 name2	17	Commission Group 2	Commission Group 2	Bonuses and Modifiers
+1372	UPGRADE_BONUS_COST_GROUP_2 Description2	65	Grenadier &amp. Dragoon Commission costs are reduced to %d%% of normal.	Grenadier &amp. Dragoon Commission costs are reduced to %d%% of normal.	Bonuses and Modifiers
+1373	UPGRADE_BONUS_COST_GROUP_3 name2	18	Commission Group 3	Commission Group 3	Bonuses and Modifiers
+1374	UPGRADE_BONUS_COST_GROUP_3 Description2	64	Engineer Settler Commission costs are reduced to %d%% of normal.	Engineer Settler Commission costs are reduced to %d%% of normal.	Bonuses and Modifiers
+1375	UPGRADE_BONUS_COST_GROUP_ALL name2	19	Commission Group all	Commission Group all	Bonuses and Modifiers
+1376	UPGRADE_BONUS_COST_GROUP_ALL Description2	57	All Units Commission costs are reduced to %d%% of normal.	All Units Commission costs are reduced to %d%% of normal.	Bonuses and Modifiers
+1377	UPGRADE_BONUS_VISUAL_RANGE name1	12	Visual Range	Visual Range	Bonuses and Modifiers
+1378	UPGRADE_BONUS_VISUAL_RANGE Description1	56	Increases a settlement's visual range to %d%% of normal.	Increases a settlement's visual range to %d%% of normal.	Bonuses and Modifiers
+1379	UPGRADE_BONUS_SUPPLY_RANGE name1	12	Supply Range	Supply Range	Bonuses and Modifiers
+1380	UPGRADE_BONUS_SUPPLY_RANGE Description1	56	Increases a settlement's supply range to %d%% of normal.	Increases a settlement's supply range to %d%% of normal.	Bonuses and Modifiers
+1381	UPGRADE_BONUS_HEALTH name1	12	Health Bonus	Health Bonus	Bonuses and Modifiers
+1382	UPGRADE_BONUS_HEALTH Description1	58	Increases a settlement's maximum health to %d%% of normal.	Increases a settlement's maximum health to %d%% of normal.	Bonuses and Modifiers
+1383	UPGRADE_BONUS_MILITIA_AV name1	16	Militia AV Bonus	Militia AV Bonus	Bonuses and Modifiers
+1384	UPGRADE_BONUS_MILITIA_AV Description1	39	Increases the AV of the militia by %+d.	Increases the AV of the militia by %+d.	Bonuses and Modifiers
+1385	UPGRADE_BONUS_MILITIA_DV name1	16	Militia DV Bonus	Militia DV Bonus	Bonuses and Modifiers
+1386	UPGRADE_BONUS_MILITIA_DV Description1	39	Increases the DV of the militia by %+d.	Increases the DV of the militia by %+d.	Bonuses and Modifiers
+1387	UPGRADE_BONUS_MILITIA_MAX name1	21	Militia Maximum Bonus	Militia Maximum Bonus	Bonuses and Modifiers
+1388	UPGRADE_BONUS_MILITIA_MAX Description1	44	Increases the maximum number of the militia.	Increases the maximum number of the militia.	Bonuses and Modifiers
+1389	UPGRADE_BONUS_VS_MAGIC name2	22	Magic Resistance Bonus	Magic Resistance Bonus	Bonuses and Modifiers
+1390	UPGRADE_BONUS_VS_MAGIC Description2	69	Reduces damage to settlements from magical attacks to %d%% of normal.	Reduces damage to settlements from magical attacks to %d%% of normal.	Bonuses and Modifiers
+1391	UPGRADE_BONUS_VS_NON_MAGIC name2	26	Non-Magic Resistance Bonus	Non-Magic Resistance Bonus	Bonuses and Modifiers
+1392	UPGRADE_BONUS_VS_NON_MAGIC Description2	73	Reduces damage to settlements from non-magical attacks to %d%% of normal.	Reduces damage to settlements from non-magical attacks to %d%% of normal.	Bonuses and Modifiers
+1393	UPGRADE_BONUS_DEFICIT_EXCHANGE_RATE name2	27	Deficit Exchange Rate Bonus	Deficit Exchange Rate Bonus	Bonuses and Modifiers
+1394	UPGRADE_BONUS_DEFICIT_EXCHANGE_RATE Description2	95	Lowers the exchange penalty for having a negative supply in a given resource to %d%% of normal.	Lowers the exchange penalty for having a negative supply in a given resource to %d%% of normal.	Bonuses and Modifiers
+1395	UPGRADE_BONUS_MARKET_PRODUCTION name2	15	not implemented	not implemented	Bonuses and Modifiers
+1396	UPGRADE_BONUS_MARKET_PRODUCTION Description1	62	Improves the production of the Market and its upgrades by %+d.	Improves the production of the Market and its upgrades by %+d.	Bonuses and Modifiers
+1397	UPGRADE_BONUS_COMPONENT_COST name1	24	Inefficient Construction	Inefficient Construction	Bonuses and Modifiers
+1398	UPGRADE_BONUS_COMPONENT_COST name2	22	Efficient Construction	Efficient Construction	Bonuses and Modifiers
+1399	UPGRADE_BONUS_COMPONENT_COST Description1	62	Increases the cost of settlement components to %d%% of normal.	Increases the cost of settlement components to %d%% of normal.	Bonuses and Modifiers
+1400	UPGRADE_BONUS_COMPONENT_COST Description2	60	Reduces the cost of settlement components to %d%% of normal.	Reduces the cost of settlement components to %d%% of normal.	Bonuses and Modifiers
+1401	UPGRADE_BONUS_GOLD_LIMIT name1	12	Gold Reserve	Gold Reserve	Bonuses and Modifiers
+1402	UPGRADE_BONUS_GOLD_LIMIT name2	12	Wastes Space	Wastes Space	Bonuses and Modifiers
+1403	UPGRADE_BONUS_GOLD_LIMIT Description1	43	Increases the gold reserve capacity by %+d.	Increases the gold reserve capacity by %+d.	Bonuses and Modifiers
+1404	UPGRADE_BONUS_GOLD_LIMIT Description2	43	Decreases the gold reserve capacity by %+d.	Decreases the gold reserve capacity by %+d.	Bonuses and Modifiers
+1405	UPGRADE_BONUS_CLAIRVOYANCE name1	17	Oracles & Scryers	Oracles & Scryers	Bonuses and Modifiers
+1406	UPGRADE_BONUS_CLAIRVOYANCE Description1	44	The detection zone is unaffected by terrain.	The detection zone is unaffected by terrain.	Bonuses and Modifiers
+# Stripping \DATA\CATACLYSM.INI...					
+# Stripping \DATA\COLORS.INI...					
+# Stripping \DATA\SETTINGS.INI...					
+# Stripping \DATA\SPELLS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1407	0 ProperName	8	Fireball	Fireball	Spell Description
+1408	0 Description	75	Generates a ball of searing flames that shoots out and strikes an opponent.	Generates a ball of searing flames that shoots out and strikes an opponent.	Spell Description
+1409	1 ProperName	13	Mystic Shield	Mystic Shield	Spell Description
+1410	1 Description	80	Protects the mage from ranged and magical attacks with a field of mystic energy.	Protects the mage from ranged and magical attacks with a field of mystic energy.	Spell Description
+1411	2 ProperName	8	Recovery	Recovery	Spell Description
+1412	2 Description	46	Heals a large amount of damage in one element.	Heals a large amount of damage in one element.	Spell Description
+1413	3 ProperName	8	Blessing	Blessing	Spell Description
+1414	3 Description	65	Blesses all friendly elements with bonuses to attack and defense.	Blesses all friendly elements with bonuses to attack and defense.	Spell Description
+1415	4 ProperName	11	Shadowshock	Shadowshock	Spell Description
+1416	4 Description	65	Caster throws a blast of evil energies that stun all who are hit.	Caster throws a blast of evil energies that stun all who are hit.	Spell Description
+1417	5 ProperName	11	Summon Dead	Summon Dead	Spell Description
+1418	5 Description	63	Summons forth the dead from their graves to fight for the mage.	Summons forth the dead from their graves to fight for the mage.	Spell Description
+1419	6 Description	56	Heals a small amount of damage in all friendly elements.	Heals a small amount of damage in all friendly elements.	Spell Description
+1420	7 ProperName	9	Dreadfire	Dreadfire	Spell Description
+1421	7 Description	82	"Generates a ball of hellish, black flames that shoots out and strikes an opponent."	"Generates a ball of hellish, black flames that shoots out and strikes an opponent."	Spell Description
+1422	8 ProperName	10	Earthburst	Earthburst	Spell Description
+1423	8 Description	70	Sends a wave of energy through the ground to burst up beneath enemies.	Sends a wave of energy through the ground to burst up beneath enemies.	Spell Description
+1424	9 ProperName	13	Banish Shadow	Banish Shadow	Spell Description
+1425	9 Description	109	Emits a burst of holy energy that strikes out against creatures of shadow.  Only affects creatures of Shadow.	Emits a burst of holy energy that strikes out against creatures of shadow.  Only affects creatures of Shadow.	Spell Description
+1426	10 ProperName	7	Courage	Courage	Spell Description
+1427	10 Description	69	"Blesses the company with a burst of courage, increasing their morale."	"Blesses the company with a burst of courage, increasing their morale."	Spell Description
+1428	11 ProperName	12	Mystic Armor	Mystic Armor	Spell Description
+1429	11 Description	72	Protects the mage from non-magical attacks with a suit of mystic energy.	Protects the mage from non-magical attacks with a suit of mystic energy.	Spell Description
+1430	12 ProperName	10	Life Leech	Life Leech	Spell Description
+1431	12 Description	72	Drains the life of enemy elements and bestows it upon friendly elements.	Drains the life of enemy elements and bestows it upon friendly elements.	Spell Description
+1432	13 ProperName	12	Storm Shield	Storm Shield	Spell Description
+1433	13 Description	61	Calls forth a roiling storm of energy that protects the mage.	Calls forth a roiling storm of energy that protects the mage.	Spell Description
+1434	14 ProperName	10	Immolation	Immolation	Spell Description
+1435	14 Description	61	Calls forth an aura of seething flames that protect the mage.	Calls forth an aura of seething flames that protect the mage.	Spell Description
+1436	15 ProperName	16	Summon Elemental	Summon Elemental	Spell Description
+1437	15 Description	69	Summons forth a powerful elemental creature to do the mage's bidding.	Summons forth a powerful elemental creature to do the mage's bidding.	Spell Description
+1438	16 ProperName	17	Summon Shadelings	Summon Shadelings	Spell Description
+1439	16 Description	60	Summons a group of shadelings to defend their demonic master.	Summons a group of shadelings to defend their demonic master.	Spell Description
+1440	17 ProperName	8	Paralyze	Paralyze	Spell Description
+1441	17 Description	52	"Paralyzes a single element, rendering them helpless."	"Paralyzes a single element, rendering them helpless."	Spell Description
+1442	18 ProperName	10	Protection	Protection	Spell Description
+1443	18 Description	59	Blesses friendly elements with protection from all attacks.	Blesses friendly elements with protection from all attacks.	Spell Description
+1444	19 ProperName	13	Cloud Of Fear	Cloud Of Fear	Spell Description
+1445	19 Description	85	Creates a bubbling cloud of darkness that lowers the morale of enemies caught within.	Creates a bubbling cloud of darkness that lowers the morale of enemies caught within.	Spell Description
+1446	20 ProperName	7	Webbing	Webbing	Spell Description
+1447	20 Description	67	"Shoots a splatter of silk at a target, immobilizing it temporarily."	"Shoots a splatter of silk at a target, immobilizing it temporarily."	Spell Description
+1448	21 ProperName	8	Lethargy	Lethargy	Spell Description
+1449	21 Description	69	Summons up a grey mist that weakens all enemy elements caught within.	Summons up a grey mist that weakens all enemy elements caught within.	Spell Description
+1450	22 ProperName	17	Horde Of The Dead	Horde Of The Dead	Spell Description
+1451	22 Description	52	Summons forth an entire company of the walking dead.	Summons forth an entire company of the walking dead.	Spell Description
+1452	23 ProperName	14	Mystic Barrier	Mystic Barrier	Spell Description
+1453	23 Description	65	Protects the mage from all attacks with a field of mystic energy.	Protects the mage from all attacks with a field of mystic energy.	Spell Description
+1454	24 ProperName	19	Darkfire Immolation	Darkfire Immolation	Spell Description
+1455	24 Description	66	"Calls forth an aura of unholy, black flames that protect the mage."	"Calls forth an aura of unholy, black flames that protect the mage."	Spell Description
+1456	25 ProperName	17	Shadow's Blessing	Shadow's Blessing	Spell Description
+1457	25 Description	60	Blesses all friendly elements by trading defense for attack.	Blesses all friendly elements by trading defense for attack.	Spell Description
+1458	26 ProperName	11	Poison Spit	Poison Spit	Spell Description
+1459	26 Description	59	"Sprays a stream of sticky, poisonous spittle at the target."	"Sprays a stream of sticky, poisonous spittle at the target."	Spell Description
+1460	27 Description	70	"Launches a stream of crackling energy at a target, leaving him crispy."	"Launches a stream of crackling energy at a target, leaving him crispy."	Spell Description
+1461	28 ProperName	11	Dragon Fire	Dragon Fire	Spell Description
+1462	28 Description	86	A tremendous torrent of flames unmatched by anything the mortals or Kohan can produce.	A tremendous torrent of flames unmatched by anything the mortals or Kohan can produce.	Spell Description
+1463	29 ProperName	10	Soul Leech	Soul Leech	Spell Description
+1464	30 ProperName	9	Ice Storm	Ice Storm	Spell Description
+1465	30 Description	69	A concussive blast of arctic air that freezes a target in his tracks.	A concussive blast of arctic air that freezes a target in his tracks.	Spell Description
+1466	31 ProperName	22	Summon Shadeling Swarm	Summon Shadeling Swarm	Spell Description
+1467	31 Description	63	Summons forth a swarm of shadelings to do the priest's bidding.	Summons forth a swarm of shadelings to do the priest's bidding.	Spell Description
+1468	32 ProperName	15	Volley of Flame	Volley of Flame	Spell Description
+1469	32 Description	78	Generates a series of searing flames that fly forth and strike down the enemy.	Generates a series of searing flames that fly forth and strike down the enemy.	Spell Description
+1470	33 ProperName	12	Wash of Pain	Wash of Pain	Spell Description
+1471	33 Description	91	"Dark powers send waves of pain over its unlucky victims, leaving them frail and vulnerable."	"Dark powers send waves of pain over its unlucky victims, leaving them frail and vulnerable."	Spell Description
+1472	34 ProperName	19	Magic Vulnerability	Magic Vulnerability	Spell Description
+1473	34 Description	71	Powerful magics cause targets to become susceptible to magical attacks.	Powerful magics cause targets to become susceptible to magical attacks.	Spell Description
+1474	35 ProperName	14	Attract Arrows	Attract Arrows	Spell Description
+1475	35 Description	100	"Strange mystic forces cause the enemy to attract projectiles, increasing the damage taken from them."	"Strange mystic forces cause the enemy to attract projectiles, increasing the damage taken from them."	Spell Description
+1476	36 ProperName	15	Mystic Immunity	Mystic Immunity	Spell Description
+1477	36 Description	75	Strong mystic forces are used to protect a company from enchantment spells.	Strong mystic forces are used to protect a company from enchantment spells.	Spell Description
+1478	37 ProperName	13	Holy Strength	Holy Strength	Spell Description
+1479	37 Description	93	The powers of the heavens are imparted upon the company allowing them to inflict Holy damage.	The powers of the heavens are imparted upon the company allowing them to inflict Holy damage.	Spell Description
+1480	38 ProperName	15	Unholy Strength	Unholy Strength	Spell Description
+1481	38 Description	92	The powers of darkness are imparted upon the company allowing them to inflict unholy damage.	The powers of darkness are imparted upon the company allowing them to inflict unholy damage.	Spell Description
+1482	39 ProperName	11	Fire Shield	Fire Shield	Spell Description
+1483	39 Description	82	Envelopes a target in an aura of seething flames that harms those that attack him.	Envelopes a target in an aura of seething flames that harms those that attack him.	Spell Description
+1484	40 ProperName	9	Fireblast	Fireblast	Spell Description
+1485	41 ProperName	10	Ice Shield	Ice Shield	Spell Description
+1486	41 Description	116	"Surrounds the caster with swirling, icy winds that chill attackers and wreak havoc on projectiles aimed at the mage."	"Surrounds the caster with swirling, icy winds that chill attackers and wreak havoc on projectiles aimed at the mage."	Spell Description
+1487	42 ProperName	13	Heaven's Bolt	Heaven's Bolt	Spell Description
+1488	42 Description	121	"Launches a stream of divine energy at an evil target, burning it with holy retribution. Only affects creatures of Shadow."	"Launches a stream of divine energy at an evil target, burning it with holy retribution. Only affects creatures of Shadow."	Spell Description
+1489	43 ProperName	13	True Blessing	True Blessing	Spell Description
+1490	44 ProperName	12	True Healing	True Healing	Spell Description
+1491	44 Description	78	A more powerful heal spell that works on all friendly elements in the company.	A more powerful heal spell that works on all friendly elements in the company.	Spell Description
+1492	45 ProperName	17	Elemental Summons	Elemental Summons	Spell Description
+1493	45 Description	78	Summons forth a pair of powerful elemental creatures to do the mage's bidding.	Summons forth a pair of powerful elemental creatures to do the mage's bidding.	Spell Description
+1494	46 ProperName	15	Shivering Blast	Shivering Blast	Spell Description
+1495	46 Description	67	A concussive blast of arctic air that freezes all targets in range.	A concussive blast of arctic air that freezes all targets in range.	Spell Description
+1496	47 ProperName	13	Conflagration	Conflagration	Spell Description
+1497	47 Description	75	A powerful spell that causes the air to ignite around the caster's enemies.	A powerful spell that causes the air to ignite around the caster's enemies.	Spell Description
+1498	48 ProperName	14	Summon Rhaksha	Summon Rhaksha	Spell Description
+1499	48 Description	48	Spawns a company of Rhaksha to engage in battle.	Spawns a company of Rhaksha to engage in battle.	Spell Description
+1500	49 ProperName	15	Shrine Blessing	Shrine Blessing	Spell Description
+1501	50 ProperName	17	Shrine Protection	Shrine Protection	Spell Description
+1502	51 ProperName	17	Young Dragon Fire	Young Dragon Fire	Spell Description
+1503	51 Description	68	A tremendous torrent of flames surpassed only by an adult firedrake.	A tremendous torrent of flames surpassed only by an adult firedrake.	Spell Description
+1504	52 ProperName	18	Storm Drake Breath	Storm Drake Breath	Spell Description
+1505	53 ProperName	13	Immortal Fury	Immortal Fury	Spell Description
+1506	53 Description	122	"Fills all friendly elements with a boiling rage, increasing their attack and morale attributes, but lowering their defense."	"Fills all friendly elements with a boiling rage, increasing their attack and morale attributes, but lowering their defense."	Spell Description
+1507	54 Description	66	Imbues friendly elements with a strong sense of valor and bravery.	Imbues friendly elements with a strong sense of valor and bravery.	Spell Description
+1508	55 ProperName	16	Spirit of Battle	Spirit of Battle	Spell Description
+1509	55 Description	90	Surrounds all friendly elements with an aura of power that increases all combat abilities.	Surrounds all friendly elements with an aura of power that increases all combat abilities.	Spell Description
+1510	56 ProperName	18	Summon Dark Wolves	Summon Dark Wolves	Spell Description
+1511	56 Description	77	Summons forth a pack of ravenous Dark Wolves to terrorize the mage's victims.	Summons forth a pack of ravenous Dark Wolves to terrorize the mage's victims.	Spell Description
+1512	57 ProperName	16	Volley of Shadow	Volley of Shadow	Spell Description
+1513	58 ProperName	20	Summon Shadow Demons	Summon Shadow Demons	Spell Description
+1514	58 Description	71	Summons forth a group of shadow demons to do the Shadow Lord's bidding.	Summons forth a group of shadow demons to do the Shadow Lord's bidding.	Spell Description
+1515	59 ProperName	20	Summon Shadow Beasts	Summon Shadow Beasts	Spell Description
+1516	59 Description	65	Summons forth a pack of shadow beasts to do the caster's bidding.	Summons forth a pack of shadow beasts to do the caster's bidding.	Spell Description
+1517	60 ProperName	13	Vulnerability	Vulnerability	Spell Description
+1518	60 Description	62	Weakens the enemy making them unable to defend against attack.	Weakens the enemy making them unable to defend against attack.	Spell Description
+1519	61 ProperName	7	Renewal	Renewal	Spell Description
+1520	61 Description	51	Heals a very large amount of damage in one element.	Heals a very large amount of damage in one element.	Spell Description
+1521	62 ProperName	10	Earthshock	Earthshock	Spell Description
+1522	62 Description	75	Creates a series of eruptions to blast out of the ground beneath the enemy.	Creates a series of eruptions to blast out of the ground beneath the enemy.	Spell Description
+1523	63 ProperName	16	Forked Lightning	Forked Lightning	Spell Description
+1524	63 Description	73	A torrent of lightning bolts stream out striking all who oppose the mage.	A torrent of lightning bolts stream out striking all who oppose the mage.	Spell Description
+# Stripping \DATA\TECHNOLOGY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1525	Dead Zone Description	141	"A strong ritual that provides all undead elements under your control with the blessing of darkness, increasing the strength of their attacks."	"A strong ritual that provides all undead elements under your control with the blessing of darkness, increasing the strength of their attacks."	Technology Description
+1526	Khaldunite Shield ProperName	17	Khaldunite Shield	Khaldunite Shield	Technology Description
+1527	Khaldunite Shield Description	149	"Shields made from a special alloy of khaldunite, silver, and steel are highly resistant to magical attacks, protecting their users from enemy spells."	"Shields made from a special alloy of khaldunite, silver, and steel are highly resistant to magical attacks, protecting their users from enemy spells."	Technology Description
+1528	Khaldunite Arrow ProperName	16	Khaldunite Arrow	Khaldunite Arrow	Technology Description
+1529	Khaldunite Arrow Description	154	Arrowheads composed of khaldunite-steel alloys inflict the special khaldunite damage which has proven to be invaluable when combating creatures of shadow.	Arrowheads composed of khaldunite-steel alloys inflict the special khaldunite damage which has proven to be invaluable when combating creatures of shadow.	Technology Description
+1530	Khaldunite Spear ProperName	16	Khaldunite Spear	Khaldunite Spear	Technology Description
+1531	Khaldunite Spear Description	154	Spear tips composed of khaldunite-steel alloys inflict the special khaldunite damage which has proven to be invaluable when combating creatures of shadow.	Spear tips composed of khaldunite-steel alloys inflict the special khaldunite damage which has proven to be invaluable when combating creatures of shadow.	Technology Description
+1532	Magic Arrow ProperName	11	Magic Arrow	Magic Arrow	Technology Description
+1533	Magic Arrow Description	118	These arrow heads are composed of enchanted steel making them capable of inflicting magical damage upon their targets.	These arrow heads are composed of enchanted steel making them capable of inflicting magical damage upon their targets.	Technology Description
+1534	Magic Blade ProperName	11	Magic Blade	Magic Blade	Technology Description
+1535	Magic Blade Description	122	These swords and axes are composed of enchanted steel making them capable of inflicting magical damage upon their targets.	These swords and axes are composed of enchanted steel making them capable of inflicting magical damage upon their targets.	Technology Description
+1536	Khaldunite Blade ProperName	16	Khaldunite Blade	Khaldunite Blade	Technology Description
+1537	Khaldunite Blade Description	159	Swords and axes composed of khaldunite-steel alloys inflict the special khaldunite damage which has proven to be invaluable when combating creatures of shadow.	Swords and axes composed of khaldunite-steel alloys inflict the special khaldunite damage which has proven to be invaluable when combating creatures of shadow.	Technology Description
+1538	Dragonscale Armor ProperName	17	Dragonscale Armor	Dragonscale Armor	Technology Description
+1539	Dragonscale Armor Description	91	Armor made from the scales and leather of dragons which is resistant to non-magical attacks	Armor made from the scales and leather of dragons which is resistant to non-magical attacks	Technology Description
+1540	Shadowskin Armor ProperName	16	Shadowskin Armor	Shadowskin Armor	Technology Description
+1541	Shadowskin Armor Description	131	"This leather armor is tainted by the realm of the shadow, making it resistant to non-magical attacks."	"This leather armor is tainted by the realm of the shadow, making it resistant to non-magical attacks."	Technology Description
+1542	Enchanted Leather Description	98	"This leather has special enchantment placed on it, making it more protective than normal leathers."	"This leather has special enchantment placed on it, making it more protective than normal leathers."	Technology Description
+1543	Crystal Ring Description	117	"Special crystal rings that are capable of amplifying magical power, increasing the melee attacks of priests and mages."	"Special crystal rings that are capable of amplifying magical power, increasing the melee attacks of priests and mages."	Technology Description
+1544	Silken Robe Description	108	Robes woven from the silk of giant spiders making them more resistant than the normal mage and priest robes.	Robes woven from the silk of giant spiders making them more resistant than the normal mage and priest robes.	Technology Description
+1545	Enchanted Grain ProperName	15	Enchanted Grain	Enchanted Grain	Technology Description
+1546	Enchanted Grain Description	134	"The special properties of this enchanted grain improves the health and stamina of mounts, increasing the strength of mounted elements."	"The special properties of this enchanted grain improves the health and stamina of mounts, increasing the strength of mounted elements."	Technology Description
+1547	Healing Potion Description	83	"Special elixirs that aid in healing troops, returning them to full strength faster."	"Special elixirs that aid in healing troops, returning them to full strength faster."	Technology Description
+1548	Potion of Strength ProperName	18	Potion of Strength	Potion of Strength	Technology Description
+1549	Potion of Strength Description	55	These special potions increase the health of all units.	These special potions increase the health of all units.	Technology Description
+1550	Avatar Description	178	"Avatars are the ultimate holy warriors, destined to battle the shadow in every form it takes. Requires a Barracks and Temple to recruit. Cannot be recruited in Ceyah settlements."	"Avatars are the ultimate holy warriors, destined to battle the shadow in every form it takes. Requires a Barracks and Temple to recruit. Cannot be recruited in Ceyah settlements."	Technology Description
+1551	Lich Description	155	"The lich is a special form of Wraith, even more terrifying in power and capacity for evil. Requires a Ceyah Settlement, Mana Forge, and Library to recruit."	"The lich is a special form of Wraith, even more terrifying in power and capacity for evil. Requires a Ceyah Settlement, Mana Forge, and Library to recruit."	Technology Description
+1552	Archmage Description	167	The powerful Archmage is capable of wielding both priestly powers and arcane magic. Requires a Temple and Library to recruit. Cannot be recruited in Ceyah settlements.	The powerful Archmage is capable of wielding both priestly powers and arcane magic. Requires a Temple and Library to recruit. Cannot be recruited in Ceyah settlements.	Technology Description
+1553	Enchanter Description	174	Enchanters are the masters of spell manipulation. They can both protect their own troops from spells and make spells more effective on enemies. Requires an Astrology Hall to recruit.	Enchanters are the masters of spell manipulation. They can both protect their own troops from spells and make spells more effective on enemies. Requires an Astrology Hall to recruit.	Technology Description
+1554	Conjuror Description	129	"Conjurors have delved into the dark side of summoning, able to summon creatures of shadow to fight for them. Requires an Astrology Hall to recruit."	"Conjurors have delved into the dark side of summoning, able to summon creatures of shadow to fight for them. Requires an Astrology Hall to recruit."	Technology Description
+1555	Devout Description	205	"These priestesses have been so warped by their channeling of dark powers that they have become insane fanatics, capable of channeling terrifying spells. Requires a Ceyah settlement and the Nightbringer upgrade to recruit."	"These priestesses have been so warped by their channeling of dark powers that they have become insane fanatics, capable of channeling terrifying spells. Requires a Ceyah settlement and the Nightbringer upgrade to recruit."	Technology Description
+1556	Pathfinder ProperName	10	Pathfinder	Pathfinder	Technology Description
+1557	Pathfinder Description	164	"Pathfinders are specially trained, elite members of the secret Ranger society. Requires a Woodmill and Library to recruit. Cannot be recruited in Ceyah settlements."	"Pathfinders are specially trained, elite members of the secret Ranger society. Requires a Woodmill and Library to recruit. Cannot be recruited in Ceyah settlements."	Technology Description
+1558	Cavalier Description	197	"Cavaliers are the elite cavalry elements of the Mareten. They are more dangerous than normal dragoons and wield Khaldunite weaponry. Requires a Blacksmith, Barracks, Temple, and Library to recruit."	"Cavaliers are the elite cavalry elements of the Mareten. They are more dangerous than normal dragoons and wield Khaldunite weaponry. Requires a Blacksmith, Barracks, Temple, and Library to recruit."	Technology Description
+1559	Shock Trooper ProperName	11	Elite Guard	Elite Guard	Technology Description
+1560	Shock Trooper Description	178	"No ground troop is more deadly than the Kohan Elite Guard. Few can stand before them on the field of battle. Requires a Blacksmith, Barracks, Temple, and Library to recruit."	"No ground troop is more deadly than the Kohan Elite Guard. Few can stand before them on the field of battle. Requires a Blacksmith, Barracks, Temple, and Library to recruit."	Technology Description
+1561	Elite Archer Description	149	"The elite bowmen are Kohan archers wielding powerful bows that fire khaldunite arrows. Requires a Woodmill, Barracks, Temple, and Library to recruit."	"The elite bowmen are Kohan archers wielding powerful bows that fire khaldunite arrows. Requires a Woodmill, Barracks, Temple, and Library to recruit."	Technology Description
+1562	Magic Plate ProperName	11	Magic Plate	Magic Plate	Technology Description
+1563	Magic Plate Description	103	Platemail armor constructed with enchanted steel provides more protection than its mundane counterpart.	Platemail armor constructed with enchanted steel provides more protection than its mundane counterpart.	Technology Description
+1564	Counter Magic Description	106	"This new magic allows the court mages to protect settlements from magical attacks, reducing damage by 75%."	"This new magic allows the court mages to protect settlements from magical attacks, reducing damage by 75%."	Technology Description
+1565	Holy Blades ProperName	11	Holy Blades	Holy Blades	Technology Description
+1566	Holy Blades Description	142	"These swords and axes are blessed by the priests of the Creator, imbuing them with the power to inflict holy damage against creatures of evil."	"These swords and axes are blessed by the priests of the Creator, imbuing them with the power to inflict holy damage against creatures of evil."	Technology Description
+1567	Unholy Blades ProperName	13	Unholy Blades	Unholy Blades	Technology Description
+1568	Unholy Blades Description	133	"These swords and axes are blessed by the priests of darkness, imbuing them with the power to inflict unholy damage against the enemy."	"These swords and axes are blessed by the priests of darkness, imbuing them with the power to inflict unholy damage against the enemy."	Technology Description
+1569	Holy Armor ProperName	10	Holy Armor	Holy Armor	Technology Description
+1570	Holy Armor Description	101	This specially blessed armor protects its wearer from the damage caused by unholy forces and weapons.	This specially blessed armor protects its wearer from the damage caused by unholy forces and weapons.	Technology Description
+1571	Unholy Armor ProperName	12	Unholy Armor	Unholy Armor	Technology Description
+1572	Unholy Armor Description	98	This specially cursed armor protects its wearer from the damage caused by holy forces and weapons.	This specially cursed armor protects its wearer from the damage caused by holy forces and weapons.	Technology Description
+1573	Silk Armor ProperName	10	Silk Armor	Silk Armor	Technology Description
+1574	Silk Armor Description	115	Specially crafted silk tunics that are worn under normal armor protect the wearer from arrows and similar missiles.	Specially crafted silk tunics that are worn under normal armor protect the wearer from arrows and similar missiles.	Technology Description
+1575	Dragon Dust Description	136	"A strange but powerful substance that reacts violently with flame, dragon dust is well used for destroying fortifications and buildings."	"A strange but powerful substance that reacts violently with flame, dragon dust is well used for destroying fortifications and buildings."	Technology Description
+1576	Bone Reaver Description	146	Evil magicks allow the creation of powerful undead with a lust for the blood of the living. Requires a Ceyah settlement and Blacksmith to recruit.	Evil magicks allow the creation of powerful undead with a lust for the blood of the living. Requires a Ceyah settlement and Blacksmith to recruit.	Technology Description
+1577	Rhaksha Slave ProperName	13	Rhaksha Slave	Rhaksha Slave	Technology Description
+1578	Rhaksha Slave Description	172	"It has been learned that Rhaksha are just intelligent enough to capture and enslave, turning them into cheap fodder for your armies. Requires a Ceyah settlement to recruit."	"It has been learned that Rhaksha are just intelligent enough to capture and enslave, turning them into cheap fodder for your armies. Requires a Ceyah settlement to recruit."	Technology Description
+1579	Slaan Champion Description	90	These noble cousins of the Slaan have cast their lot in with the Kohan against the Shadow.	These noble cousins of the Slaan have cast their lot in with the Kohan against the Shadow.	Technology Description
+1580	Warlock Description	201	The enigmatic warlock is privy to strange powerful magics that border on the realm of shadow. They first weaken their enemies then destroy them with blasts of fire. Requires a Mage College to recruit.	The enigmatic warlock is privy to strange powerful magics that border on the realm of shadow. They first weaken their enemies then destroy them with blasts of fire. Requires a Mage College to recruit.	Technology Description
+1581	White Steel Blades ProperName	17	White Steel Blade	White Steel Blade	Technology Description
+1582	White Steel Blades Description	96	A new alloy of steel that is lighter and stronger is used to create more deadly swords and axes.	A new alloy of steel that is lighter and stronger is used to create more deadly swords and axes.	Technology Description
+1583	Ironwood Bow Description	99	Masterfully crafted bows crafted from the strong ironwood trees are more powerful than normal bows.	Masterfully crafted bows crafted from the strong ironwood trees are more powerful than normal bows.	Technology Description
+1584	Blessing of Shadow Description	139	"A strong ritual that provides all shadow forces under your control with the blessing of darkness, increasing the strength of their attacks."	"A strong ritual that provides all shadow forces under your control with the blessing of darkness, increasing the strength of their attacks."	Technology Description
+1585	Military College ProperName	16	Military College	Military College	Technology Description
+1586	Military College Description	182	The military college is an institution that allows for the more efficient recruiting and commissioning of military forces. This reduces the cost of commissioning most military units.	The military college is an institution that allows for the more efficient recruiting and commissioning of military forces. This reduces the cost of commissioning most military units.	Technology Description
+1587	Academy of Magicks ProperName	18	Academy of Magicks	Academy of Magicks	Technology Description
+1588	Academy of Magicks Description	159	"By instituting houses of learning for the magic arts in all settlements, those settlements are better equipped to deal with a siege involving mystical attacks."	"By instituting houses of learning for the magic arts in all settlements, those settlements are better equipped to deal with a siege involving mystical attacks."	Technology Description
+1589	Economic Advisors ProperName	17	Economic Advisors	Economic Advisors	Technology Description
+1590	Economic Advisors Description	235	By appointing economic advisors to the vassals whom manage your kingdom's settlements a more efficient kingdom-wide economy is born. This increases vault limitations.	By appointing economic advisors to the vassals whom manage your kingdom's settlements a more efficient kingdom-wide economy is born. This increases vault limitations.	Technology Description
+1591	Geomancy Description	188	"The elemental magic of geomancy allows the creation of stronger, magically fused stones to be used in the construction of settlements and outposts. This increases their base health by 25%."	"The elemental magic of geomancy allows the creation of stronger, magically fused stones to be used in the construction of settlements and outposts. This increases their base health by 25%."	Technology Description
+1592	Militia Training ProperName	16	Militia Training	Militia Training	Technology Description
+1593	Militia Training Description	108	Kingdom-wide military programs that train local militia to be a more efficient and effective fighting force.	Kingdom-wide military programs that train local militia to be a more efficient and effective fighting force.	Technology Description
+1594	Golems ProperName	14	Golem Warriors	Golem Warriors	Technology Description
+1595	Golems Description	127	The use of powerful elemental magic has allowed the creation of stone warriors that obey their masters with mindless precision. Requires a Quarry and Library to recruit.	The use of powerful elemental magic has allowed the creation of stone warriors that obey their masters with mindless precision. Requires a Quarry and Library to recruit.	Technology Description
+# Stripping \DATA\TRANSLATION.INI...					
+# Stripping \DATA\CAMPAIGNDATA\CAMPAIGN0.INI...					
+# Stripping \DATA\CAMPAIGNDATA\CAMPAIGN1.INI...					
+# Stripping \DATA\CAMPAIGNDATA\CAMPAIGN2.INI...					
+# Stripping \DATA\EFFECTDATA\EMITTERS\_EMITTER_TEMPLATE.INI...					
+# Stripping \DATA\EFFECTDATA\EMITTERS\BLUE_SPARKLE.INI...					
+# Stripping \DATA\EFFECTDATA\EMITTERS\CLOUD_OF_FEAR.INI...					
+# Stripping \DATA\EFFECTDATA\EMITTERS\CONFLAGRATION.INI...					
+# Stripping \DATA\EFFECTDATA\EMITTERS\DRAGON_BREATH_FAN.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\FIRE.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\FIREBALL_TRAILER.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\FIREBALLFX.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\FLAME_ARROW_TRAILER.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\GREEN_SPARKLE.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\METEOR_FX.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\ORANGE_SPARKLE.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\PURPLE_FIREBALL_TRAILER.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\PURPLE_FIREBALLFX.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\PURPLE_SPARKLE.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\RED_SPARKLE.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\SHADOW_BREATH_FAN.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\SHADOW_DEMON_COMBUSTION.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\SHADOW_DEMON_COMBUSTION_TRAIL.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\SHADOW_LORD_COMBUSTION.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\SHADOWSTORM.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\SHARD_FAN.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\STRAIGHT_DARKFIRE.INI...
+# Stripping \DATA\EFFECTDATA\EMITTERS\STREAMER.INI...
+# Stripping \DATA\EFFECTDATA\OBJECTFADE\BLESSING_FADE.INI...
+# Stripping \DATA\EFFECTDATA\OBJECTFADE\ICESTORM_FADE.INI...
+# Stripping \DATA\EFFECTDATA\OBJECTFADE\IMMORTAL_FURY_FADE.INI...
+# Stripping \DATA\EFFECTDATA\OBJECTFADE\LETHARGY_FADE.INI...
+# Stripping \DATA\EFFECTDATA\OBJECTFADE\LIFELEECH_FADE.INI...
+# Stripping \DATA\EFFECTDATA\OBJECTFADE\LIGHTNING_FADE.INI...
+# Stripping \DATA\EFFECTDATA\OBJECTFADE\POISON_FADE.INI...
+# Stripping \DATA\EFFECTDATA\OBJECTFADE\PROTECTION_FADE.INI...
+# Stripping \DATA\EFFECTDATA\PARTICLES\PARTICLE.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\BANISH_SHADOW.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\BANISHCAST.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\BLESSING.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\BLESSINGLOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\COURAGE.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\DARK_IMM_LOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\DARK_IMM_LOOP_BACK.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\DARK_IMMOLATION.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\DARK_RIFT_DIE.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\DARKFIRE_GATHER.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\DRAKEBURST.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\EARTHSHOCK.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\ELEMENTAL_HITFX.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\EXPLOSION.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\FIREBALL_GATHER.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\GROUND_ERUPTION.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\HEAL.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\HOLY_STRENGTH.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\HOLY_STRENGTH_LOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\ICE SHIELD.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\ICE_SHIELD_BACK.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\ICE_SHIELD_FRONT.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\ICECAST.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\ICESTORM.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\IMM_LOOP_BACK.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\IMMOLATION.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\IMMOLATION_LOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\IMMORTAL_FURY.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\LETHARGY.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\LETHARGY_FLOOR.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\LIFELEECH.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\MAGIC_VULNERABILITY.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\MYSTIC_BARRIER.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\MYSTIC_IMMUNITY.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\MYSTIC_SHIELD_LOOPING_BACK.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\MYSTIC_SHIELD_LOOPING_FRONT.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\MYSTICARMOR.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\MYSTICARMORCAST.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\MYSTICSHIELD.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\NECROMANCER_HITFX.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\PALADIN_HITFX.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\PARALYZE_LOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\POISONCAST.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\POISONHIT.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\POISONLOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\PROTECTION.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\PROTECTION_LOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\RECOVERY.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\RED_EARTHBURST.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\SHADBLESSLOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\SHADOWBLESSING.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\SHADOWDEMON_CAST.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\SORCERESS_HITFX.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\SPIRIT_OF_BATTLE.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\SPIRIT_OF_BATTLE_LOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\STORM_SHIELD.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\SUMMON.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\UNHOLY_STRENGTH.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\UNHOLY_STRENGTH_LOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\UNSUMMON.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\VULNERABILITY.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\WARMAGE_HITFX.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\WASH_PAIN.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\WASH_PAIN_LOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\WEB.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\WEBLOOP.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\WIZARD_HITFX.INI...
+# Stripping \DATA\EFFECTDATA\SPRITES\WRAITH_HITFX.INI...					
+# Stripping \DATA\INTERFACEDATA\_INTERFACE_TEMPLATE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1596	Button5 Caption	8	pulldown	pulldown	Interface Options
+1597	MenuTitle Text	5	Title	Title	Interface Options
+# Stripping \DATA\INTERFACEDATA\BRIEFING.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1598	MenuTitle Text	16	Mission Briefing	Mission Briefing	Briefing Menu Options
+1599	ButtonExit ButtonText	4	Exit	Exit	Briefing Menu Options
+1600	ButtonContinue ButtonText	8	Continue	Continue	Briefing Menu Options
+1601	BriefingTitle Text	8	Briefing	Briefing	Briefing Menu Options
+1602	BriefingStory Text	13	briefing_area	briefing_area	Briefing Menu Options
+1603	BriefingRestart ButtonText	16	Restart Briefing	Restart Briefing	Briefing Menu Options
+1604	ObjectivesTitle Text	10	Objectives	Objectives	Briefing Menu Options
+# Stripping \DATA\INTERFACEDATA\CAMPAIGN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1605	CampaignMenuTitle Text	13	Campaign Menu	Campaign Menu	Campaign Menu Options
+1606	PlayerListTitle Text	14	Character Name	Character Name	Campaign Menu Options
+1607	DeletePlayerButton ButtonText	6	Delete	Delete	Campaign Menu Options
+1608	RadioHardDifficultyLabel Text	4	Hard	Hard	Campaign Menu Options
+1609	PlayMenuButton ButtonText	4	Play	Play	Campaign Menu Options
+1610	SaveGameTitle Text	11	Saved Games	Saved Games	Campaign Menu Options
+1611	LoadSavedButton ButtonText	4	Load	Load	Campaign Menu Options
+1612	NextMissionTitle Text	12	Next Mission	Next Mission	Campaign Menu Options
+1613	NextMissionDescription TextOffsetX	1	5	5	==
+1614	NextMissionDescription TextOffsetY	1	2	2	==
+1615	HeroListTitle Text	9	Hero List	Hero List	Campaign Menu Options
+1616	TechnologyListTitle Text	15	Technology List	Technology List	Campaign Menu Options
+# Stripping \DATA\INTERFACEDATA\COMPANY_EDITOR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1617	ValueHeroHealth Text	7	Health:	Health:	Company Editor Menu
+1618	ValueHeroPanelLevel Text	6	Level:	Level:	Company Editor Menu
+1619	ValueHeroPanelExperience Text	11	Experience:	Experience:	Company Editor Menu
+1620	HeroAttributes ToolTipText	15	Hero Attributes	Hero Attributes	Company Editor Menu
+1621	HeroUpkeep ToolTipText	11	Hero Upkeep	Hero Upkeep	Company Editor Menu
+1622	UnitAttributes ToolTipText	15	Unit Attributes	Unit Attributes	Company Editor Menu
+1623	UnitUpkeep ToolTipText	11	Unit Upkeep	Unit Upkeep	Company Editor Menu
+1624	ValueUnitCost Text	9	Unit Cost	Unit Cost	Company Editor Menu
+1625	GoldIcon Text	6	&gold.	&gold.	Company Editor Menu
+1626	DarkBlueTile Text	16	Company Creation	Company Creation	Company Editor Menu
+1627	Frontline1 ToolTipText	5	Dummy	Dummy	Company Editor Menu
+1628	CommissionButton ButtonText	10	Commission	Commission	Company Editor Menu
+1629	EditCompanyName TextColor	5	WHITE	WHITE	Company Editor Menu
+1630	EditStaticText Text	12	Company Name	Company Name	Company Editor Menu
+1631	InfantryStaticTitle Text	17	Infantry Elements	Infantry Elements	Company Editor Menu
+1632	CavalryStaticTitle Text	16	Cavalry Elements	Cavalry Elements	Company Editor Menu
+1633	ArcherElementsTitle Text	15	Archer Elements	Archer Elements	Company Editor Menu
+1634	SpecialtyElementsTitle Text	18	Specialty Elements	Specialty Elements	Company Editor Menu
+1635	SupportElementsTitle Text	16	Support Elements	Support Elements	Company Editor Menu
+1636	HeroElementsTitle Text	13	Hero Elements	Hero Elements	Company Editor Menu
+1637	CaptainStaticText Text	7	Captain	Captain	Company Editor Menu
+1638	SupportStaticText1 Text	7	Support	Support	Company Editor Menu
+1639	FrontlineStaticText Text	10	Front Line	Front Line	Company Editor Menu
+1640	CostStaticTitle Text	12	Company Cost	Company Cost	Company Editor Menu
+1641	GoldUpkeep Text	1	0	0	Company Editor Menu
+1642	GoldUpkeep TooltipText	11	Gold Upkeep	Gold Upkeep	Company Editor Menu
+1643	UpkeepStaticTitle Text	6	Upkeep	Upkeep	Company Editor Menu
+1644	IronUpkeep TooltipText	11	Iron Upkeep	Iron Upkeep	Company Editor Menu
+1645	IronStaticIcon Text	6	&iron.	&iron.	Company Editor Menu
+1646	StoneUpkeep TooltipText	12	Stone Upkeep	Stone Upkeep	Company Editor Menu
+1647	StoneStaticIcon Text	7	&stone.	&stone.	Company Editor Menu
+1648	WoodUpkeep TooltipText	11	Wood Upkeep	Wood Upkeep	Company Editor Menu
+1649	WoodStaticIcon Text	6	&wood.	&wood.	Company Editor Menu
+1650	ManaUpkeep TooltipText	11	Mana Upkeep	Mana Upkeep	Company Editor Menu
+1651	ManaStaticIcon Text	6	&mana.	&mana.	Company Editor Menu
+1652	AttribStaticTitle Text	10	Attributes	Attributes	Company Editor Menu
+1653	AttribRanged TooltipText	19	Ranged Attack Value	Ranged Attack Value	Company Editor Menu
+1654	AttribRangedTitle Text	5	&bow.	&bow.	Company Editor Menu
+1655	AttribMelee TooltipText	18	Melee Attack Value	Melee Attack Value	Company Editor Menu
+1656	AttribMeleeTitle Text	7	&sword.	&sword.	Company Editor Menu
+1657	AttribDefense TooltipText	13	Defense Value	Defense Value	Company Editor Menu
+1658	AttribDefenseTitle Text	8	&shield.	&shield.	Company Editor Menu
+1659	AttribMovement TooltipText	13	Movement Rate	Movement Rate	Company Editor Menu
+1660	AttribMovementTitle Text	6	&boot.	&boot.	Company Editor Menu
+1661	AttribVisualTitle Text	5	&eye.	&eye.	Company Editor Menu
+1662	SelectPreset Caption	11	Load Preset	Load Preset	Company Editor Menu
+1663	SelectPreset String1	22	Load Preset 1 - Unused	Load Preset 1 - Unused	Company Editor Menu
+1664	SelectPreset String2	22	Load Preset 2 - Unused	Load Preset 2 - Unused	Company Editor Menu
+1665	SelectPreset String3	22	Load Preset 3 - Unused	Load Preset 3 - Unused	Company Editor Menu
+1666	SelectPreset String4	22	Load Preset 4 - Unused	Load Preset 4 - Unused	Company Editor Menu
+1667	SelectPreset String5	22	Load Preset 5 - Unused	Load Preset 5 - Unused	Company Editor Menu
+1668	SelectPreset String6	22	Load Preset 6 - Unused	Load Preset 6 - Unused	Company Editor Menu
+1669	SelectPreset String7	22	Load Preset 7 - Unused	Load Preset 7 - Unused	Company Editor Menu
+1670	SelectPreset String8	22	Load Preset 8 - Unused	Load Preset 8 - Unused	Company Editor Menu
+1671	SelectPreset String9	22	Load Preset 9 - Unused	Load Preset 9 - Unused	Company Editor Menu
+1672	SelectPreset String10	22	Load Preset 0 - Unused	Load Preset 0 - Unused	Company Editor Menu
+1673	SetPreset Caption	11	Save Preset	Save Preset	Company Editor Menu
+1674	SetPreset String1	22	Save Preset 1 - Unused	Save Preset 1 - Unused	Company Editor Menu
+1675	SetPreset String2	22	Save Preset 2 - Unused	Save Preset 2 - Unused	Company Editor Menu
+1676	SetPreset String3	22	Save Preset 3 - Unused	Save Preset 3 - Unused	Company Editor Menu
+1677	SetPreset String4	22	Save Preset 4 - Unused	Save Preset 4 - Unused	Company Editor Menu
+1678	SetPreset String5	22	Save Preset 5 - Unused	Save Preset 5 - Unused	Company Editor Menu
+1679	SetPreset String6	22	Save Preset 6 - Unused	Save Preset 6 - Unused	Company Editor Menu
+1680	SetPreset String7	22	Save Preset 7 - Unused	Save Preset 7 - Unused	Company Editor Menu
+1681	SetPreset String8	22	Save Preset 8 - Unused	Save Preset 8 - Unused	Company Editor Menu
+1682	SetPreset String9	22	Save Preset 9 - Unused	Save Preset 9 - Unused	Company Editor Menu
+1683	SetPreset String10	22	Save Preset 0 - Unused	Save Preset 0 - Unused	Company Editor Menu
+# Stripping \DATA\INTERFACEDATA\CONNECTION.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1684	Button1 Text	15	Connection Menu	Connection Menu	Server Connect Screen
+1685	Button11 Text	10	Powered by	Powered by	Server Connect Screen
+1686	Button7 Text	6	Filter	Filter	Server Connect Screen
+1687	Button8 String1	3	LAN	LAN	Server Connect Screen
+1688	Button8 String2	12	Internet All	Internet All	Server Connect Screen
+1689	Button8 String3	17	Internet Scenario	Internet Scenario	Server Connect Screen
+1690	Button8 String4	15	Internet Custom	Internet Custom	Server Connect Screen
+1691	Button8 String5	20	Internet Death Match	Internet Death Match	Server Connect Screen
+1692	Button8 String6	18	Internet Bloodbath	Internet Bloodbath	Server Connect Screen
+1693	Button8 String7	16	Internet Conquer	Internet Conquer	Server Connect Screen
+1694	Button8 String8	15	Internet Gnomes	Internet Gnomes	Server Connect Screen
+1695	ValueBandwidth Text	9	Bandwidth	Bandwidth	Server Connect Screen
+1696	DropDownBandwidth String1	11	Modem (28k)	Modem (28k)	Server Connect Screen
+1697	DropDownBandwidth String2	11	Modem (56k)	Modem (56k)	Server Connect Screen
+1698	DropDownBandwidth String3	4	ISDN	ISDN	Server Connect Screen
+1699	DropDownBandwidth String4	9	Cable/DSL	Cable/DSL	Server Connect Screen
+1700	DropDownBandwidth String5	12	T1 or Better	T1 or Better	Server Connect Screen
+1701	ValuePlayerName Text	4	Name	Name	Server Connect Screen
+1702	ValuePlayerIP Text	10	IP Address	IP Address	Server Connect Screen
+1703	ValuePlayerPort Text	4	Port	Port	Server Connect Screen
+1704	ValueServerName ToolTipText	11	Server Name	Server Name	Server Connect Screen
+1705	ValuePing ToolTipText	4	Ping	Ping	Server Connect Screen
+1706	ValuePlayers ToolTipText	7	Players	Players	Server Connect Screen
+1707	ValueGameType ToolTipText	9	Game Type	Game Type	Server Connect Screen
+1708	ValueMap ToolTipText	3	Map	Map	Server Connect Screen
+1709	ButtonJoin ButtonText	4	Join	Join	Server Connect Screen
+1710	ButtonHost ButtonText	4	Host	Host	Server Connect Screen
+1711	ButtonRefresh ButtonText	7	Refresh	Refresh	Server Connect Screen
+1712	ProgressBar ToolTipText	27	Server List Update Progress	Server List Update Progress	Server Connect Screen
+# Stripping \DATA\INTERFACEDATA\CREDITS.INI...					
+# Stripping \DATA\INTERFACEDATA\CURSORS.INI...					
+# Stripping \DATA\INTERFACEDATA\DEBRIEFING.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1713	MenuTitle Text	18	Mission Debriefing	Mission Debriefing	Debriefing Menu Options
+1714	ButtonReplay ButtonText	14	Replay Mission	Replay Mission	Debriefing Menu Options
+1715	ButtonSave ButtonText	9	Save Film	Save Film	Debriefing Menu Options
+1716	LabelDebriefing Text	10	Debriefing	Debriefing	Debriefing Menu Options
+1717	DebriefingSkip ButtonText	9	Next Page	Next Page	Debriefing Menu Options
+1718	DebriefingRestart ButtonText	18	Restart Debriefing	Restart Debriefing	Debriefing Menu Options
+1719	ScoreTypeOverallRadioLabel Text	14	Overall Scores	Overall Scores	Debriefing Menu Options
+1720	ScoreTypeMilitaryRadioLabel Text	15	Military Scores	Military Scores	Debriefing Menu Options
+1721	ScoreTypeEconomyRadioLabel Text	14	Economy Scores	Economy Scores	Debriefing Menu Options
+1722	ScoreTypePopulationRadioLabel Text	17	Population Scores	Population Scores	Debriefing Menu Options
+1723	ScoreGraphXAxisLabel Text	12	Time (mins.)	Time (mins.)	Debriefing Menu Options
+# Stripping \DATA\INTERFACEDATA\EDITOR_PLAYER_SETTINGS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1724	Button1 Text	15	Player Settings	Player Settings	Editor Player Menu Options
+1725	Button2 ButtonText	2	Ok	Ok	Editor Player Menu Options
+1726	Button4 String1	8	Player 1	Player 1	Editor Player Menu Options
+1727	Button4 String2	8	Player 2	Player 2	Editor Player Menu Options
+1728	Button4 String3	8	Player 3	Player 3	Editor Player Menu Options
+1729	Button4 String4	8	Player 4	Player 4	Editor Player Menu Options
+1730	Button4 String5	8	Player 5	Player 5	Editor Player Menu Options
+1731	Button4 String6	8	Player 6	Player 6	Editor Player Menu Options
+1732	Button4 String7	8	Player 7	Player 7	Editor Player Menu Options
+1733	Button4 String8	8	Player 8	Player 8	Editor Player Menu Options
+1734	KingdomNameValue Text	12	Kingdom Name	Kingdom Name	Editor Player Menu Options
+1735	MultiplayerValue Text	11	Multiplayer	Multiplayer	Editor Player Menu Options
+1736	MultiplayerText String2	7	AI Only	AI Only	Editor Player Menu Options
+1737	PlayersHeroesValue Text	15	Player's Heroes	Player's Heroes	Editor Player Menu Options
+1738	AIPersonalityValue Text	14	AI Personality	AI Personality	Editor Player Menu Options
+1739	EasyAIValue Text	7	Easy AI	Easy AI	Editor Player Menu Options
+1740	MedAIValue Text	9	Medium AI	Medium AI	Editor Player Menu Options
+1741	HardAIValue Text	7	Hard AI	Hard AI	Editor Player Menu Options
+1742	FactionValue Text	7	Faction	Faction	Editor Player Menu Options
+1743	TeamValue Text	4	Team	Team	Editor Player Menu Options
+1744	TeamText String2	6	Team 1	Team 1	Editor Player Menu Options
+1745	TeamText String3	6	Team 2	Team 2	Editor Player Menu Options
+1746	TeamText String4	6	Team 3	Team 3	Editor Player Menu Options
+1747	TeamText String5	6	Team 4	Team 4	Editor Player Menu Options
+1748	MonsterWarValue Text	11	Monster War	Monster War	Editor Player Menu Options
+1749	PoliticalRelationsValue Text	19	Political Relations	Political Relations	Editor Player Menu Options
+1750	LockedCheck0 TooltipText	48	Mark Player unable to change political relations	Mark Player unable to change political relations	Editor Player Menu Options
+1751	Button9 Text	15	Custom Scenario	Custom Scenario	Editor Player Menu Options
+1752	Button11 Text	28	Custom Scenario and Campaign	Custom Scenario and Campaign	Editor Player Menu Options
+1753	Button12 Text	14	Player Economy	Player Economy	Editor Player Menu Options
+# Stripping \DATA\INTERFACEDATA\EDITORGAMESETTINGS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1754	Button1 Text	12	Map Settings	Map Settings	Editor Game Menu Options
+1755	value_map_name Text	8	Map Name	Map Name	Editor Game Menu Options
+1756	value_map_desc Text	15	Map Description	Map Description	Editor Game Menu Options
+1757	value_team_name Text	9	Team Name	Team Name	Editor Game Menu Options
+1758	value_kingdom_list2 Text	16	Kingdoms in Team	Kingdoms in Team	Editor Game Menu Options
+1759	value_company_limit Text	13	Company Limit	Company Limit	Editor Game Menu Options
+1760	value_settlement_limit Text	16	Settlement Limit	Settlement Limit	Editor Game Menu Options
+1761	value_outpost_limit Text	13	Outpost Limit	Outpost Limit	Editor Game Menu Options
+1762	value_allied_victory Text	14	Allied Victory	Allied Victory	Editor Game Menu Options
+1763	dropdown_allied_victory String1	18	Alliance or Single	Alliance or Single	Editor Game Menu Options
+1764	dropdown_allied_victory String2	11	Single Only	Single Only	Editor Game Menu Options
+1765	dropdown_allied_victory String3	13	Alliance Only	Alliance Only	Editor Game Menu Options
+1766	value_use_politics Text	12	Use Politics	Use Politics	Editor Game Menu Options
+1767	value_allow_settlements Text	17	Allow Settlements	Allow Settlements	Editor Game Menu Options
+1768	value_allow_outposts Text	14	Allow Outposts	Allow Outposts	Editor Game Menu Options
+1769	Button6 Text	20	Custom Scenario Play	Custom Scenario Play	Editor Game Menu Options
+1770	Button7 Text	33	Custom Scenario and Campaign Play	Custom Scenario and Campaign Play	Editor Game Menu Options
+# Stripping \DATA\INTERFACEDATA\EXIT_INTERFACE.INI...					
+# Stripping \DATA\INTERFACEDATA\GAME_INTERFACE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1771	ECON_gold ToolTipText	20	Total Gold Resources	Total Gold Resources	Tooltip
+1772	ECON_stone ToolTipText	21	Total Stone Resources	Total Stone Resources	Tooltip
+1773	ECON_wood ToolTipText	20	Total Wood Resources	Total Wood Resources	Tooltip
+1774	ECON_iron ToolTipText	20	Total Iron Resources	Total Iron Resources	Tooltip
+1775	ECON_mana ToolTipText	10	Total Mana	Total Mana	Tooltip
+1776	ECON_company ToolTipText	21	Current/Max Companies	Current/Max Companies	Tooltip
+1777	LeftUpdownWallToggle ToolTipText	12	Remove panel	Remove panel	Tooltip
+1778	LeftSwapPanel ToolTipText	19	Move panel to right	Move panel to right	Tooltip
+1779	RightSwapPanel ToolTipText	18	Move panel to left	Move panel to left	Tooltip
+1780	Button96 ToolTipText	27	Show Control Zones (Ctrl-C)	Show Control Zones (Ctrl-C)	Tooltip
+1781	Button97 ToolTipText	26	Show Supply Zones (Ctrl-S)	Show Supply Zones (Ctrl-S)	Tooltip
+1782	Button98 ToolTipText	30	Show Population Zones (Ctrl-P)	Show Population Zones (Ctrl-P)	Tooltip
+1783	Button82 ToolTipText	4	Menu	Menu	Tooltip
+1784	CompanyRoutButton ToolTipText	4	Rout	Rout	Tooltip
+1785	CompanyRetreatButton ToolTipText	7	Retreat	Retreat	Tooltip
+1786	DetachButton ToolTipText	14	Detach Company	Detach Company	Tooltip
+1787	AttachButton ToolTipText	23	Attach Company to an HQ	Attach Company to an HQ	Tooltip
+1788	CompanySettleButton ToolTipText	6	Settle	Settle	Tooltip
+1789	ReturnButton ToolTipText	12	Company Menu	Company Menu	Tooltip
+1790	BuildOutpostButton ToolTipText	13	Build Outpost	Build Outpost	Tooltip
+1791	BuildMine ToolTipText	10	Build Mine	Build Mine	Tooltip
+1792	MessageLogViewport InactiveTextColor	5	BLACK	BLACK	==
+1793	MessageLogFilterAll ToolTipText	20	Display All Messages	Display All Messages	Tooltip
+1794	MessageLogFilterSettlement ToolTipText	27	Display Settlement Messages	Display Settlement Messages	Tooltip
+1795	MessageLogFilterError ToolTipText	22	Display Error Messages	Display Error Messages	Tooltip
+1796	MessageLogFilterCompany ToolTipText	24	Display Company Messages	Display Company Messages	Tooltip
+1797	MessageLogFilterHero ToolTipText	21	Display Hero Messages	Display Hero Messages	Tooltip
+1798	MessageLogFilterGeneric ToolTipText	24	Display Generic Messages	Display Generic Messages	Tooltip
+1799	MessageLogFilterTrade ToolTipText	25	Display Politics Messages	Display Politics Messages	Tooltip
+1800	MilitiaType ToolTipText	16	Militia Strength	Militia Strength	Tooltip
+1801	Button60 InactiveTextColor	4	GRAY	GRAY	==
+1802	Button63 ToolTipText	34	(#c TG_YELLOW F1#r)City Management	(#c TG_YELLOW F1#r)City Management	Tooltip
+1803	UpgradedComponentSellPrice Text	10	Sell Price	Sell Price	Sell Price Amount
+1804	UpgradedComponentResources Text	9	Resources	Resources	Resource Cost
+1805	UpgradedComponentSellButton ButtonText	4	Sell	Sell	Sell Button
+1806	AvailStaticText Text	18	Available Upgrades	Available Upgrades	Upgrade Options
+1807	UpgradeNo1Portrait TooltipText	16	Upgrade Option 1	Upgrade Option 1	Tooltip
+1808	UpgradeNo1Cost Text	4	Cost	Cost	Cost Amount
+1809	UpgradeNo2Portrait TooltipText	16	Upgrade Option 2	Upgrade Option 2	Tooltip
+1810	UpgradeNo3Portrait TooltipText	16	Upgrade Option 3	Upgrade Option 3	Tooltip
+1811	CompanyLoreTabShowAll ToolTipText	18	Show All Companies	Show All Companies	Tooltip
+1812	CompanyLoreTabShowHeroes ToolTipText	24	Show Only Hero Companies	Show Only Hero Companies	Tooltip
+1813	CompanyLoreTabShowSpecial ToolTipText	27	Show Only Special Companies	Show Only Special Companies	Tooltip
+1814	SettlementLoreTabShowAll ToolTipText	8	Show All	Show All	Tooltip
+1815	SettlementLoreTabShowSettlements ToolTipText	21	Show Only Settlements	Show Only Settlements	Tooltip
+1816	SettlementLoreTabShowOutposts ToolTipText	18	Show Only Outposts	Show Only Outposts	Tooltip
+1817	SettlementLoreTabShowMines ToolTipText	15	Show Only Mines	Show Only Mines	Tooltip
+1818	BuildingGold ToolTipText	21	Local Gold Production	Local Gold Production	Tooltip
+1819	BuildingStone ToolTipText	22	Local Stone Production	Local Stone Production	Tooltip
+1820	BuildingWood ToolTipText	21	Local Wood Production	Local Wood Production	Tooltip
+1821	BuildingIron ToolTipText	21	Local Iron Production	Local Iron Production	Tooltip
+1822	BuildingMana ToolTipText	21	Local Mana Production	Local Mana Production	Tooltip
+1823	RazeSettlement ButtonText	4	Keep	Keep	Raze? Option
+1824	KeepSettlement ButtonText	4	Raze	Raze	Raze? Option
+1825	Button92 Text	56	Select the front of the regiment to lock this formation.	Select the front of the regiment to lock this formation.	Lock Direction Message
+# Stripping \DATA\INTERFACEDATA\GAME_SETTINGS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1826	Button7 Text	6	Player	Player	Button Text
+1827	Button10 Text	15	_______________	_______________	==
+1828	MonsterWar Text	10	MonsterWar	MonsterWar	Button Text
+# Stripping \DATA\INTERFACEDATA\GAMEMENU.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1829	Button2 ButtonText	14	Return To Game	Return To Game	Option Menu
+1830	Button4 ButtonText	4	Save	Save	Option Menu
+1831	Button5 ButtonText	7	Options	Options	Option Menu
+1832	Button7 ButtonText	10	Quit Kohan	Quit Kohan	Option Menu
+1833	Button13 ButtonText	11	Kick Player	Kick Player	Kick Menu
+1834	Button8 ButtonText	5	Pause	Pause	==
+1835	Button9 ButtonText	7	Unpause	Unpause	==
+1836	Button12 Text	15	Game Not Paused	Game Not Paused	==
+# Stripping \DATA\INTERFACEDATA\GENERATORSETTINGS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1837	MenuTitle Text	19	Random Map Settings	Random Map Settings	Map Generator Setting
+1838	Generate ButtonText	8	Generate	Generate	Map Generator Setting
+1839	ValueMapSize Text	8	Map Size	Map Size	Map Generator Setting
+1840	DDMapSize String1	5	64x64	64x64	Map Generator Setting
+1841	DDMapSize String2	5	96x96	96x96	Map Generator Setting
+1842	DDMapSize String3	7	128x128	128x128	Map Generator Setting
+1843	DDMapSize String4	7	192x192	192x192	Map Generator Setting
+1844	DDMapSize String5	7	256x256	256x256	Map Generator Setting
+1845	DDMapPlayers String1	9	2 Players	2 Players	Map Generator Setting
+1846	DDMapPlayers String2	9	3 Players	3 Players	Map Generator Setting
+1847	DDMapPlayers String3	9	4 Players	4 Players	Map Generator Setting
+1848	DDMapPlayers String4	9	5 Players	5 Players	Map Generator Setting
+1849	DDMapPlayers String5	9	6 Players	6 Players	Map Generator Setting
+1850	DDMapPlayers String6	9	7 Players	7 Players	Map Generator Setting
+1851	DDMapPlayers String7	9	8 Players	8 Players	Map Generator Setting
+1852	ValueTerrainPcts Text	19	Terrain Percentages	Terrain Percentages	Map Generator Setting
+1853	ValuePlaceFeatures Text	14	Place Features	Place Features	Map Generator Setting
+1854	ValueMountains Text	9	Mountains	Mountains	Map Generator Setting
+1855	ValueScenarioTitle Text	17	Scenario Settings	Scenario Settings	Map Generator Setting
+1856	ValueGenerateScenario Text	17	Generate Scenario	Generate Scenario	Map Generator Setting
+1857	ValueMines Text	12	Mine Density	Mine Density	Map Generator Setting
+1858	ValueLairs Text	12	Lair Density	Lair Density	Map Generator Setting
+1859	ValueCities Text	20	Neutral City Density	Neutral City Density	Map Generator Setting
+# Stripping \DATA\INTERFACEDATA\GI_BUILDCOMPONENTPANEL.INI...					
+# Stripping \DATA\INTERFACEDATA\GI_CITYMANAGEMENT.INI...					
+# Stripping \DATA\INTERFACEDATA\GI_COMPANYACTIONSCROLL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1860	CompanyGuardButton ToolTipText	5	Guard	Guard	Tooltip
+1861	CompanyStopButton ToolTipText	4	Stop	Stop	Tooltip
+1862	CompanySpecialButton ToolTipText	10	Build Menu	Build Menu	Tooltip
+1863	CompanyFormationBaseMenu ToolTipText	10	Formations	Formations	Tooltip
+1864	CompanyColumnMoveButton ToolTipText	6	Column	Column	Tooltip
+1865	CompanySkirmishMoveButton ToolTipText	8	Skirmish	Skirmish	Tooltip
+1866	CompanyCombatMoveButton ToolTipText	6	Combat	Combat	Tooltip
+# Stripping \DATA\INTERFACEDATA\GI_COMPANYDISPLAY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1867	CompanyLogo ToolTipText	14	Company Banner	Company Banner	Tooltip
+1868	CompanyRangeBonus ToolTipText	11	Range Value	Range Value	Tooltip
+1869	CompanyAttackBonus ToolTipText	12	Attack Value	Attack Value	Tooltip
+1870	CompanyStatusIndicator ToolTipText	14	Company Status	Company Status	Tooltip
+1871	CompanyTerrainIndicator ToolTipText	7	Terrain	Terrain	Tooltip
+1872	CompanyMoraleIndicator ToolTipText	6	Morale	Morale	Tooltip
+# Stripping \DATA\INTERFACEDATA\GI_COMPANYINFOPANEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1873	ValueRank Text	5	Rank:	Rank:	Company Panel Attibutes
+1874	ValueZoneOfControl Text	16	Zone of Control:	Zone of Control:	Company Panel Attibutes
+1875	ValueVisualRange Text	13	Visual Range:	Visual Range:	Company Panel Attibutes
+1876	ValueMorale Text	7	Morale:	Morale:	Company Panel Attibutes
+1877	ValueStatus Text	7	Status:	Status:	Company Panel Attibutes
+1878	CompanyUpkeep ToolTipText	14	Company Upkeep	Company Upkeep	Company Panel Tooltip
+1879	CompanyDisbandButton ToolTipText	21	Disband this company.	Disband this company.	Company Panel Tooltip
+1880	CompanyDisbandButton ButtonText	7	Disband	Disband	Disband Option
+# Stripping \DATA\INTERFACEDATA\GI_HEROINFOPANEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1881	ValueHeroCost Text	11	Awaken Cost	Awaken Cost	Hero Panel Attribute
+1882	HeroWakeButton ToolTipText	31	Click here to awaken this hero.	Click here to awaken this hero.	Hero Tooltip
+1883	HeroWakeButton ButtonText	6	Awaken	Awaken	Hero Panel Attribute
+1884	HeroCommand ToolTipText	24	Set Hero to Command Mode	Set Hero to Command Mode	Hero Tooltip
+1885	HeroCommand ButtonText	7	Command	Command	Hero Panel Attribute
+1886	HeroEngage ToolTipText	23	Set Hero to Engage Mode	Set Hero to Engage Mode	Hero Tooltip
+1887	HeroEngage ButtonText	6	Engage	Engage	Hero Panel Attribute
+# Stripping \DATA\INTERFACEDATA\GI_POLITICSINFOPANEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1888	PoliticsRelationsTitleRelation Text	8	Relation	Relation	Politics Panel Attribute
+1889	PoliticsRelationsTitleOffer Text	5	Offer	Offer	Politics Panel Attribute
+1890	PoliticsRelationsPlayer1Offer ToolTipText	13	Pending Offer	Pending Offer	Politics Panel Tooltip
+1891	PoliticsCurrentPlayerTitle Text	18	Propose Treaty To:	Propose Treaty To:	Politics Panel Attribute
+1892	PoliticsCurrentPlayerOpinion ToolTipText	24	AI's Attitude toward you	AI's Attitude toward you	Politics Panel Tooltip
+1893	PoliticsTributeLabel Text	7	Tribute	Tribute	Politics Panel Attribute
+1894	PoliticsTributeDecreaseButton ButtonText	3	-25	-25	Politics Panel Attribute
+1895	PoliticsTributeIncreaseButton ButtonText	3	+25	+25	Politics Panel Attribute
+1896	PoliticsSendButton ButtonText	4	Send	Send	Politics Panel Attribute
+# Stripping \DATA\INTERFACEDATA\GI_REGIMENTDISPLAY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1897	StaticTitleFront Text	5	Front	Front	Regiment Attribute
+1898	DarkBlueTile1 TooltipText	9	Company 1	Company 1	Regiment Tooltip
+1899	HealthBarCaptain1 TooltipText	4	Unit	Unit	Regiment Tooltip
+1900	DarkBlueTile2 TooltipText	9	Company 2	Company 2	Regiment Tooltip
+1901	DarkBlueTile3 TooltipText	9	Company 3	Company 3	Regiment Tooltip
+1902	DarkBlueTile4 TooltipText	9	Company 4	Company 4	Regiment Tooltip
+1903	DarkBlueTile5 TooltipText	9	Company 5	Company 5	Regiment Tooltip
+1904	DarkBlueTile6 TooltipText	9	Company 6	Company 6	Regiment Tooltip
+# Stripping \DATA\INTERFACEDATA\GI_SETTLEMENTACTIONSCROLL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1905	DisplayComponent1 ToolTipText	11	Component 0	Component 0	Settlement Slot Tooltip
+1906	DisplayComponent2 ToolTipText	11	Component 1	Component 1	Settlement Slot Tooltip
+1907	DisplayComponent3 ToolTipText	11	Component 2	Component 2	Settlement Slot Tooltip
+1908	DisplayComponent4 ToolTipText	11	Component 3	Component 3	Settlement Slot Tooltip
+1909	DisplayComponent5 ToolTipText	11	Component 4	Component 4	Settlement Slot Tooltip
+1910	DisplayComponent6 ToolTipText	11	Component 5	Component 5	Settlement Slot Tooltip
+1911	DisplayComponent7 ToolTipText	11	Component 6	Component 6	Settlement Slot Tooltip
+# Stripping \DATA\INTERFACEDATA\GI_SETTLEMENTDISPLAY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1912	BuildingDescriptionMenu TextOffsetX	1	7	7	==
+1913	BuildingInfo TextOffsetY	1	3	3	==
+1914	BuildBuildingButton ToolTipText	15	"Build	Component"	"Build	Component"	Settlement Display Tooltip
+1915	BuildBuildingCancelButton ToolTipText	12	Cancel Build	Cancel Build	Settlement Display Tooltip
+1916	SellButton ToolTipText	14	Sell Component	Sell Component	Settlement Display Tooltip
+1917	DisplayUpgradeSettlement ToolTipText	30	Upgrade Settlement Description	Upgrade Settlement Description	Settlement Display Tooltip
+# Stripping \DATA\INTERFACEDATA\GI_SETTLEMENTINFOPANEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1918	SettlementInfoStaticType Text	5	Type:	Type:	Settlement Panel Attribute
+1919	SettlementInfoStaticSupply Text	7	Supply:	Supply:	Settlement Panel Attribute
+1920	SettlementInfoStaticMilitia Text	8	Militia:	Militia:	Settlement Panel Attribute
+1921	SettlementInfoGold ToolTipText	15	Gold Production	Gold Production	Settlement Panel Tooltip
+1922	SettlementInfoResources ToolTipText	19	Production / Upkeep	Production / Upkeep	Settlement Panel Tooltip
+1923	SettlementInfoRaze ToolTipText	21	Destroy this building	Destroy this building	Settlement Panel Tooltip
+# Stripping \DATA\INTERFACEDATA\GI_STORYPIECE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1924	StoryPiecePortrait ToolTipText	24	Move map focus to source	Move map focus to source	Story Piece Action
+# Stripping \DATA\INTERFACEDATA\GI_TECHNOLOGYPANEL.INI...					
+# Stripping \DATA\INTERFACEDATA\GI_UNITINFOPANEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1925	UnitAttributesValue Text	11	Attributes:	Attributes:	Unit Panel Attributes
+1926	UnitUpkeepValue Text	7	Upkeep:	Upkeep:	Unit Panel Attributes
+1927	UnitCommand ToolTipText	24	Set Unit to Command Mode	Set Unit to Command Mode	Unit Panel Tooltip
+1928	UnitEngage ToolTipText	23	Set Unit to Engage Mode	Set Unit to Engage Mode	Unit Panel Tooltip
+# Stripping \DATA\INTERFACEDATA\HOST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1929	ValueGameName Text	9	Game Name	Game Name	Multi. Host Attribute
+1930	CheckListGameSpy ToolTipText	31	List server publicly on GameSpy	List server publicly on GameSpy	Multi. Host Tooltip
+1931	ValueCheckListGameSpy Text	6	Public	Public	Multi. Host Attribute
+# Stripping \DATA\INTERFACEDATA\JOIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1932	Button2 ButtonText	7	Testing	Testing	Multi. Connection Attribute
+# Stripping \DATA\INTERFACEDATA\LOAD_SAVE.INI...					
+# Stripping \DATA\INTERFACEDATA\MAIN_MENU.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1933	ButtonEditor ButtonText	6	Editor	Editor	Main Menu Options
+1934	ButtonViewFilms ButtonText	10	View Films	View Films	Main Menu Options
+1935	ButtonCredits ButtonText	7	Credits	Credits	Main Menu Options
+1936	ButtonExit ButtonText	4	Quit	Quit	Main Menu Options
+# Stripping \DATA\INTERFACEDATA\MAP_EDITOR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1937	Button5 Caption	4	File	File	Editor File Menu
+1938	Button5 String3	4	Test	Test	Editor File Menu
+1939	Button5 String4	11	-----------	-----------	Editor File Menu
+1940	Button5 String5	9	Main Menu	Main Menu	Editor File Menu
+1941	Button6 String2	13	Clear Objects	Clear Objects	Editor Map Menu
+1942	Button6 String3	9	Clear Fog	Clear Fog	Editor Map Menu
+1943	Button6 String4	15	Random Scenario	Random Scenario	Editor Map Menu
+1944	Button6 String5	10	Repair Map	Repair Map	Editor Map Menu
+1945	Button6 String6	16	----------------	----------------	Editor Map Menu
+1946	Button6 String8	7	64 x 64	64 x 64	Editor Map Menu
+1947	Button6 String9	7	96 x 96	96 x 96	Editor Map Menu
+1948	Button6 String10	9	128 x 128	128 x 128	Editor Map Menu
+1949	Button6 String11	9	160 x 160	160 x 160	Editor Map Menu
+1950	Button6 String12	9	192 x 192	192 x 192	Editor Map Menu
+1951	Button6 String13	9	256 x 256	256 x 256	Editor Map Menu
+1952	Button9 Caption	4	Show	Show	Edior Show Menu
+1953	Button10 Text	19	Auto Place Features	Auto Place Features	Editor Terrain Option
+1954	Button13 String1	5	Units	Units	Editor Menu
+1955	Button13 String2	6	Heroes	Heroes	Editor Menu
+1956	Button13 String3	9	Buildings	Buildings	Editor Menu
+1957	Button13 String5	8	Features	Features	Editor Menu
+1958	Button13 String6	7	Company	Company	Editor Menu
+1959	Button13 String7	8	Triggers	Triggers	Editor Menu
+1960	OneText Text	3	1x1	1x1	Editor Terrain Option
+1961	ThreeText Text	3	3x3	3x3	Editor Terrain Option
+1962	FiveText Text	3	5x5	5x5	Editor Terrain Option
+1963	Button15 ButtonText	4	Edit	Edit	Editor Menu Option
+1964	Button15 ToolTipText	11	Edit Object	Edit Object	Editor Menu Tooltip
+1965	GlobalCheckValue Text	6	Global	Global	Editor Trigger Option
+1966	SetLocation ButtonText	12	Set Location	Set Location	Editor Trigger Option
+1967	GotoObject ToolTipText	11	Goto Object	Goto Object	Editor Trigger Tooltip
+1968	SetObject ToolTipText	10	Set Object	Set Object	Editor Trigger Tooltip
+1969	GotoLocation ToolTipText	13	Goto Location	Goto Location	Editor Trigger Tooltip
+1970	SetSource ToolTipText	29	Set Selected Object as Source	Set Selected Object as Source	Editor Trigger Tooltip
+1971	SetSource ButtonText	10	Set Source	Set Source	Editor Trigger Option
+1972	GetSource ToolTipText	19	Go To Source Object	Go To Source Object	Editor Trigger Tooltip
+1973	GetSource ButtonText	9	Go Source	Go Source	Editor Trigger Option
+1974	SetTarget ToolTipText	29	Set Selected Object as Target	Set Selected Object as Target	Editor Trigger Tooltip
+1975	SetTarget ButtonText	10	Set Target	Set Target	Editor Trigger Option
+1976	GetTarget ToolTipText	19	Go To Target Object	Go To Target Object	Editor Trigger Tooltip
+1977	GetTarget ButtonText	9	Go Target	Go Target	Editor Trigger Option
+1978	ValueLabel Text	5	Value	Value	Editor Trigger Option
+1979	TriggerDescriptionLabel Text	19	Trigger Description	Trigger Description	Editor Trigger Option
+1980	CAndELabel Text	22	Conditions And Effects	Conditions And Effects	Editor Trigger Option
+1981	NewCondition ButtonText	13	New Condition	New Condition	Editor Trigger Option
+1982	NewEffect ButtonText	10	New Effect	New Effect	Editor Trigger Option
+1983	DeleteConditionEffect ButtonText	15	Delete Selected	Delete Selected	Editor Trigger Option
+1984	DeleteConditionEffect ToolTipText	35	Delete Selected Condition or Effect	Delete Selected Condition or Effect	Editor Trigger Tooltip
+1985	NewTrigger ToolTipText	11	New Trigger	New Trigger	Editor Trigger Tooltip
+1986	DeleteTrigger ToolTipText	14	Delete Trigger	Delete Trigger	Editor Trigger Tooltip
+1987	Button32 TooltipText	53	All conditions must be true before trigger is set off	All conditions must be true before trigger is set off	Editor Trigger Tooltip
+1988	Button63 Text	5	Anded	Anded	Editor Trigger Option
+1989	Button33 TooltipText	41	Allow multiple players to set off trigger	Allow multiple players to set off trigger	Editor Trigger Tooltip
+1990	Button64 Text	8	Multiple	Multiple	Editor Trigger Option
+1991	Button34 TooltipText	37	Allow trigger to be set off repeatedly	Allow trigger to be set of repeatedly	Editor Trigger Tooltip
+1992	Button65 Text	7	Repeats	Repeats	Editor Trigger Option
+1993	Button40 ToolTipText	16	Delete Object(s)	Delete Object(s)	Editor Trigger Tooltip
+1994	Button50 TooltipText	28	Mark trigger as an objective	Mark trigger as an objective	Editor Trigger Tooltip
+1995	Button50 String1	13	Not Objective	Not Objective	Editor Trigger Option
+1996	Button50 String2	9	Objective	Objective	Editor Trigger Option
+1997	Button50 String3	17	Reverse Objective	Reverse Objective	Editor Trigger Option
+1998	Button17 Caption	8	Settings	Settings	Editor Trigger Option
+# Stripping \DATA\INTERFACEDATA\MESSAGE.INI...					
+# Stripping \DATA\INTERFACEDATA\MESSAGE_BOX.INI...					
+# Stripping \DATA\INTERFACEDATA\MULTIPLAYER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+1999	ScenarioKingdomValue Text	7	Kingdom	Kingdom	Multiplayer Menu Settings
+2000	Team1 Text	14	team name here	team name here	Multiplayer Menu Settings
+2001	TeamIndependent Text	20	Independent Kingdoms	Independent Kingdoms	Multiplayer Menu Settings
+2002	TeamObserver Text	9	Observers	Observers	Multiplayer Menu Settings
+2003	Player0_Map Text	4	100%	100%	Multiplayer Menu Settings
+2004	MapName Text	18	Map name goes here	Map name goes here	Multiplayer Menu Settings
+2005	MapSelect ButtonText	10	Select Map	Select Map	Multiplayer Menu Settings
+2006	MapDescription Text	36	description for scenario/custom game	description for scenario/custom game	Multiplayer Menu Settings
+2007	GoalInformationLabel Text	7	Rewards	Rewards	Multiplayer Menu Settings
+2008	LoadMonstersLabel Text	8	Monsters	Monsters	Multiplayer Menu Settings
+2009	SeedHeroesLabel Text	11	Seed Heroes	Seed Heroes	Multiplayer Menu Settings
+2010	SeedTechnologiesLabel Text	17	Seed Technologies	Seed Technologies	Multiplayer Menu Settings
+2011	SeedGoldLabel Text	9	Seed Gold	Seed Gold	Multiplayer Menu Settings
+2012	MainSettingsLabel Text	13	Game Settings	Game Settings	Multiplayer Menu Settings
+2013	DifficultyLevelLabel Text	16	Difficulty Level	Difficulty Level	Multiplayer Menu Settings
+2014	RandomStartLabel Text	18	Randomize Kingdoms	Randomize Kingdoms	Multiplayer Menu Settings
+2015	UsePoliticsLabel Text	9	Diplomacy	Diplomacy	Multiplayer Menu Settings
+2016	UseFogLabel Text	10	Fog of War	Fog of War	Multiplayer Menu Settings
+2017	AllowCheatsLabel Text	12	Allow Cheats	Allow Cheats	Multiplayer Menu Settings
+2018	UseGoldLimitLabel Text	14	Use Gold Limit	Use Gold Limit	Multiplayer Menu Settings
+2019	PlayerSettingsLabel Text	19	Starting Conditions	Starting Conditions	Multiplayer Menu Settings
+2020	StartSettlementConditionsLabel Text	8	Outposts	Outposts	Multiplayer Menu Settings
+2021	MapSettingsLabel Text	18	Victory Conditions	Victory Conditions	Multiplayer Menu Settings
+2022	TargetGoldLabel Text	11	Target Gold	Target Gold	Multiplayer Menu Settings
+2023	TargetCitiesLabel Text	13	Target Cities	Target Cities	Multiplayer Menu Settings
+2024	TargetCityPercentageLabel Text	13	Target City %	Target City %	Multiplayer Menu Settings
+2025	Button3 Text	6	Status	Status	Multiplayer Menu Settings
+2026	LoadGame ButtonText	9	Load Game	Load Game	Multiplayer Menu Settings
+# Stripping \DATA\INTERFACEDATA\MULTIPLAYER_MAP.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2027	MainTitle Text	18	Map Selection Menu	Map Selection Menu	Multi. Custom Map Name
+# Stripping \DATA\INTERFACEDATA\OBJECT_EDITOR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2028	Button1 Text	12	Object No. :	Object No. :	Editor Object Menu
+2029	Button2 Text	12	Object Type:	Object Type:	Editor Object Menu
+2030	Button3 Text	11	Object Info	Object Info	Editor Object Menu
+2031	Button4 Text	9	Base Data	Base Data	Editor Object Menu
+2032	Button5 Text	12	Company Info	Company Info	Editor Object Menu
+2033	Button6 Text	19	Starting Components	Starting Components	Editor Object Menu
+2034	Button7 Text	19	Militia Information	Militia Information	Editor Object Menu
+2035	Button8 Text	13	Building Data	Building Data	Editor Object Menu
+2036	Button18 Text	16	Related Triggers	Related Triggers	Editor Object Menu
+2037	Button10 ButtonText	6	Update	Update	Editor Object Menu
+2038	HealthValue Text	6	Health	Health	Editor Object Menu
+2039	DetectionValue Text	15	Detection Range	Detection Range	Editor Object Menu
+2040	ControlZoneValue Text	12	Control Zone	Control Zone	Editor Object Menu
+2041	GuardZoneValue Text	10	Guard Zone	Guard Zone	Editor Object Menu
+2042	SupplyZoneValue Text	11	Supply Zone	Supply Zone	Editor Object Menu
+2043	MoraleValue Text	14	Current Morale	Current Morale	Editor Object Menu
+2044	DieRateValue Text	8	Die Rate	Die Rate	Editor Object Menu
+2045	MaxMoraleLabel Text	10	Max Morale	Max Morale	Editor Object Menu
+2046	BaseMilitiaValue Text	7	Current	Current	Editor Object Menu
+2047	BaseMilitiaMaxValue Text	3	Max	Max	Editor Object Menu
+2048	BaseGrowthValue Text	19	Growth (per 17 min)	Growth (per 17 min)	Editor Object Menu
+2049	BaseMilitiaCompanySizeValue Text	12	Company Size	Company Size	Editor Object Menu
+2050	BuildingBootyValue Text	11	Booty Value	Booty Value	Editor Object Menu
+2051	BuildingResourceProductionLabel Text	19	Resource Production	Resource Production	Editor Object Menu
+2052	TriggerList Text	19	No Related Triggers	No Related Triggers	Editor Object Menu
+# Stripping \DATA\INTERFACEDATA\OPTIONS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2053	Button4 ButtonText	16	Restore Defaults	Restore Defaults	Option Menu Settings
+2054	ValueGameSpeed Text	10	Game Speed	Game Speed	Option Menu Settings
+2055	ValueHostOnly Text	11	Host Only -	Host Only -	Option Menu Settings
+2056	ValueScrollSpeed Text	12	Scroll Speed	Scroll Speed	Option Menu Settings
+2057	ValueFadeSpeed Text	18	Message Fade Speed	Message Fade Speed	Option Menu Settings
+2058	value_show_all_zos Text	17	Show Supply Zones	Show Supply Zones	Option Menu Settings
+2059	value_show_all_zogs Text	16	Show Guard Zones	Show Guard Zones	Option Menu Settings
+2060	value_show_all_zocs Text	22	Show All Control Zones	Show All Control Zones	Option Menu Settings
+2061	value_show_population_zone Text	21	Show Population Zones	Show Population Zones	Option Menu Settings
+2062	value_show_grid Text	9	Show Grid	Show Grid	Option Menu Settings
+2063	value_show_tooltips Text	13	Show Tooltips	Show Tooltips	Option Menu Settings
+2064	value_show_dmg_numbers Text	19	Show Damage Numbers	Show Damage Numbers	Option Menu Settings
+2065	value_show_confirmation_dialogs Text	20	Confirmation Dialogs	Confirmation Dialogs	Option Menu Settings
+2066	value_show_company_engaged Text	21	Show Engaged Messages	Show Engaged Messages	Option Menu Settings
+2067	value_show_company_routed Text	20	Show Routed Messages	Show Routed Messages	Option Menu Settings
+2068	value_show_treaty Text	15	Treaty Messages	Treaty Messages	Option Menu Settings
+2069	value_show_militia Text	16	Militia Messages	Militia Messages	Option Menu Settings
+2070	Value_VolumeSettings Text	15	Volume Settings	Volume Settings	Option Menu Settings
+2071	Value_Main Text	4	Main	Main	Option Menu Settings
+2072	Value_SFX Text	3	SFX	SFX	Option Menu Settings
+2073	Value_VoiceOver Text	10	Voice Over	Voice Over	Option Menu Settings
+2074	Value_MaxMessages Text	12	Max Messages	Max Messages	Option Menu Settings
+# Stripping \DATA\INTERFACEDATA\RANDOM_MAP.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2075	TextField1 Text	9	Hot & Dry	Hot & Dry	Rand. Map Terrain Settings
+2076	TextField2 String	9	Hot & Wet	Hot & Wet	Rand. Map Terrain Settings
+2077	TextField3 String	9	Temperate	Temperate	Rand. Map Terrain Settings
+2078	TextField4 String	10	Cold & Wet	Cold & Wet	Rand. Map Terrain Settings
+2079	TextField5 String	10	Cold_&_Dry	Cold_&_Dry	Rand. Map Terrain Settings
+2080	TextField6 String	2	1%	1%	
+2081	TextField16 String	7	Clutter	Clutter	Rand. Map Terrain Settings
+2082	TextField18 String	4	Rare	Rare	Rand. Map Terrain Settings
+2083	TextField19 String	6	Sparse	Sparse	Rand. Map Terrain Settings
+2084	TextField20 String	8	Uncommon	Uncommon	Rand. Map Terrain Settings
+2085	TextField21 String	6	Common	Common	Rand. Map Terrain Settings
+2086	TextField22 String	9	Plentiful	Plentiful	Rand. Map Terrain Settings
+# Stripping \DATA\INTERFACEDATA\SINGLE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2087	Button12 Text	24	fill in description here	fill in description here	==
+# Stripping \DATA\INTERFACEDATA\SPLASH_SCREEN.INI...					
+# Stripping \DATA\INTERFACEDATA\VIEW_FILMS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2088	SavedFilmsLabel Text	11	Saved Films	Saved Films	Films Menu
+2089	FilmDescLabel Text	16	Film Description	Film Description	Film Settings
+# Stripping \DATA\INTERFACEDATA\VOTE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2090	TotalLabel Text	10	Total Vote	Total Vote	Kick Menu Messages
+2091	total0 Text	11	0/4 to Kick	0/4 to Kick	Kick Menu Messages
+2092	Disconnect ButtonText	26	Disconnect Lagging Players	Disconnect Lagging Players	Kick Menu Messages
+2093	DisconnectTotal Text	17	0/4 to Disconnect	0/4 to Disconnect	Kick Menu Messages
+# Stripping \DATA\LOCALIZED\CITYNAMES.INI...					
+# Stripping \DATA\LOCALIZED\STRINGS_01.INI...					
+# Stripping \DATA\LOCALIZED\TUTORIAL.INI...					
+# Stripping \DATA\OBJECTDATA\COMPANY.INI...					
+# Stripping \DATA\OBJECTDATA\COMPONENTS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2094	Woodmill Description	46	Provides your kingdom with +6 Wood per minute.	Provides your kingdom with +6 Wood per minute.	Component Description
+2095	Market Description	68	"Sells off 2 Wood, 2 Stone, and 2 Iron per minute to produce 12 gold."	"Sells off 2 Wood, 2 Stone, and 2 Iron per minute to produce 12 gold."	Component Description
+2096	Blacksmith Description	46	Provides your kingdom with +6 Iron per minute.	Provides your kingdom with +6 Iron per minute.	Component Description
+2097	Quarry Description	47	Provides your kingdom with +6 Stone per minute.	Provides your kingdom with +6 Stone per minute.	Component Description
+2098	Temple Description	46	Provides your kingdom with +2 Mana per minute.	Provides your kingdom with +2 Mana per minute.	Component Description
+2099	Barracks Description	76	Trains advanced military elements and lowers the ctiy's chance to surrender.	Trains advanced military elements and lowers the ctiy's chance to surrender.	Component Description
+2100	Wall Description	108	Increases health and militia defense. Also protects components from being destroyed in a siege.	Increases health and militia defense. Also protects components from being destroyed in a siege.	Component Description
+2101	Sawmill ProperName	7	Sawmill	Sawmill	Component Name
+2102	Sawmill Description	113	Advanced saw blades process timber faster than a normal woodmill. Provides your kingdom with +10 Wood per minute.	Advanced saw blades process timber faster than a normal woodmill. Provides your kingdom with +10 Wood per minute.	Component Description
+2103	CarpentryGuild ProperName	15	Carpentry Guild	Carpentry Guild	Component Name
+2104	CarpentryGuild Description	116	"Creates a 50% reduction in commission costs for Footman, Scouts and Archers. Components cost 50% less to build."	"Creates a 50% reduction in commission costs for Footman, Scouts and Archers. Components cost 50% less to build."	Component Description
+2105	TempleOfTheOverseers ProperName	14	Light of Faith	Light of Faith	Component Name
+2106	TempleOfTheOverseers Description	79	Temple now belongs to the Light of Faith religion. Provides the Channeler unit.	Temple now belongs to the Light of Faith religion. Provides the Channeler unit.	Component Description
+2107	WayOfImmortality ProperName	12	Eternal Path	Eternal Path	Component Name
+2108	WayOfImmortality Description	81	Temple now belongs to the Eternal Path religion. Provides the Battle Priest unit.	Temple now belongs to the Eternal Path religion. Provides the Battle Priest unit.	Component Description
+2109	Nightbringers ProperName	12	Nightbringer	Nightbringer	Component Name
+2110	Nightbringers Description	74	Temple now belongs to the Nightbringer religion. Provides the Zealot unit.	Temple now belongs to the Nightbringer religion. Provides the Zealot unit.	Component Description
+2111	Nightbringers2 Description	81	Temple now belongs to the Nightbringer religion. Provides the Shadow Priest unit.	Temple now belongs to the Nightbringer religion. Provides the Shadow Priest unit.	Component Description
+2112	Bazaar ProperName	6	Bazaar	Bazaar	
+2113	Bazaar Description	113	"The bazaar sells more goods than the market. Sells off 5 Wood, 5 Stone, and 5 Iron per minute to produce 30 gold."	"The bazaar sells more goods than the market. Sells off 5 Wood, 5 Stone, and 5 Iron per minute to produce 30 gold."	Component Description
+2114	Bank ProperName	4	Bank	Bank	Component Name
+2115	Bank Description	122	The bank increases the vault size and provides a method of obtaining gold without resources. Provides +15 gold per minute.	The bank increases the vault size and provides a method of obtaining gold without resources. Provides +15 gold per minute.	Component Description
+2116	Factory ProperName	7	Factory	Factory	Component Name
+2117	Factory Description	92	Employs many locals to construct goods and supplies increasing the supply range of the city.	Employs many locals to construct goods and supplies increasing the supply range of the city.	Component Description
+2118	BlastFurnace ProperName	13	Blast Furnace	Blast Furnace	Component Name
+2119	BlastFurnace Description	116	"An upgraded form of blacksmith with a larger, more advanced furnace. Provides your kingdom with +10 Iron per minute."	"An upgraded form of blacksmith with a larger, more advanced furnace. Provides your kingdom with +10 Iron per minute."	Component Description
+2120	ArmoryGuild ProperName	12	Armory Guild	Armory Guild	Component Name
+2121	ArmoryGuild Description	119	"Reduces commission cost for Infantry, Grenadiers, and Dragoons by 50%. Increases militia attack value by +2."	"Reduces commission cost for Infantry, Grenadiers, and Dragoons by 50%. Increases militia attack value by +2."	Component Description
+2122	ManaForge ProperName	10	Mana Forge	Mana Forge	Component Name
+2123	ManaForge Description	81	Forges convert iron to special magical devices that provide mana to your kingdom.	Forges convert iron to special magical devices that provide mana to your kingdom.	Component Description
+2124	MiningPost ProperName	11	Mining Post	Mining Post	Component Name
+2125	MiningPost Description	124	The mining post trains local workers to gather and process stone resources. Provides your kingdom with +10 Stone per minute.	The mining post trains local workers to gather and process stone resources. Provides your kingdom with +10 Stone per minute.	Component Description
+2126	MasonryGuild ProperName	13	Masonry Guild	Masonry Guild	Component Name
+2127	MasonryGuild Description	64	The masonry guild repairs damage done to the city automatically.	The masonry guild repairs damage done to the city automatically.	Component Description
+2128	MageCollege ProperName	12	Mage College	Mage College	Component Name
+2129	MageCollege Description	124	The mage college is an institute of higher learning and much experimentation. Provides your kingdom with +4 Mana per minute.	The mage college is an institute of higher learning and much experimentation. Provides your kingdom with +4 Mana per minute.	Component Description
+2130	AstrologyHall ProperName	14	Astrology Hall	Astrology Hall	Component Name
+2131	AstrologyHall Description	96	The astrology hall houses oracles and scryers. The city's visual range is unaffected by terrain.	The astrology hall houses oracles and scryers. The city's visual range is unaffected by terrain.	Component Description
+2132	WizardTower ProperName	12	Wizard Tower	Wizard Tower	Component Name
+2133	WizardTower Description	117	The wizard tower works to protect the city with magical defenses. City takes 50% damage from all non-magical attacks.	The wizard tower works to protect the city with magical defenses. City takes 50% damage from all non-magical attacks.	Component Description
+2134	Billet ProperName	6	Billet	Billet	Component Name
+2135	Billet Description	125	A billet finds recruits and organizes them. This creates a 25% reduction in commission cost for all companies recruited here.	A billet finds recruits and organizes them. This creates a 25% reduction in commission cost for all companies recruited here.	Component Description
+2136	Garrison ProperName	8	Garrison	Garrison	Component Name
+2137	Garrison Description	123	The garrison houses military personnel to bolster the militia of the city. Adds +4 AV and +2 DV to the settlement's Militia.	The garrison houses military personnel to bolster the militia of the city. Adds +4 AV and +2 DV to the settlement's Militia.	Component Description
+2138	SupplyPost ProperName	11	Supply Post	Supply Post	Component Name
+2139	SupplyPost Description	123	"Regulates and improves a city's supply distribution increasing the city's supply range, which in turn extends visual range."	"Regulates and improves a city's supply distribution increasing the city's supply range, which in turn extends visual range."	Component Description
+2140	WatchTowers ProperName	12	Watch Towers	Watch Towers	Component Name
+2141	WatchTowers Description	92	Adds watch towers to wall. Increases the visual range of the city and adds +4 to militia DV.	Adds watch towers to wall. Increases the visual range of the city and adds +4 to militia DV.	Component Description
+2142	FortifiedWall ProperName	14	Fortified Wall	Fortified Wall	Component Name
+2143	FortifiedWall Description	84	The fortified wall houses additional militia in special bunkers built into the wall.	The fortified wall houses additional militia in special bunkers built into the wall.	Component Description
+2144	TurretedRamparts ProperName	17	Turreted Ramparts	Turreted Ramparts	Component Name
+2145	TurretedRamparts Description	115	"A blend of fortification and watch towers, turreted ramparts increase both the militia and visual range of the city."	"A blend of fortification and watch towers, turreted ramparts increase both the militia and visual range of the city."	Component Description
+2146	WoodMarket ProperName	11	Wood Export	Wood Export	Component Name
+2147	WoodMarket Description	47	Sells off 5 Wood per minute to produce 10 gold.	Sells off 5 Wood per minute to produce 10 gold.	Component Description
+2148	StoneMarket ProperName	12	Stone Export	Stone Export	Component Name
+2149	StoneMarket Description	47	Sells off 5 Stone per minute to produce 5 gold.	Sells off 5 Stone per minute to produce 5 gold.	Component Description
+2150	IronMarket ProperName	11	Iron Export	Iron Export	Component Name
+2151	IronMarket Description	47	Sells off 5 Iron per minute to produce 15 gold.	Sells off 5 Iron per minute to produce 15 gold.	Component Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\ABANDONED_RUINS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2152	ObjectData ProperName	15	Abandoned Ruins	Abandoned Ruins	Building Name
+2153	ObjectData Description	102	"The dust covered, crumbled remains of ancient buildings are all that are left of a once glorious city."	"The dust covered, crumbled remains of ancient buildings are all that are left of a once glorious city."	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\AHRIMAN_CITADEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2154	ObjectData ProperName	17	Ahriman's Citadel	Ahriman's Citadel	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\ANCIENT_RUIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2155	ObjectData ProperName	12	Ancient Ruin	Ancient Ruin	Building Name
+2156	ObjectData Description	88	The crumbled remains of ancient buildings are all that are left of a once glorious city.	The crumbled remains of ancient buildings are all that are left of a once glorious city.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\ASSAULT_FORT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2157	ObjectData ProperName	12	Assault Fort	Assault Fort	Building Name
+2158	ObjectData Description	92	Outposts are used to extend a kingdom's supply range and protect its borders from incursion.	Outposts are used to extend a kingdom's supply range and protect its borders from incursion.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\BANDIT_CAMP.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2159	ObjectData ProperName	14	Mercenary Camp	Mercenary Camp	Building Name
+2160	ObjectData Description	99	A small arrangement of tents and crude defenses that house bandits waiting to prey upon the unwary.	A small arrangement of tents and crude defenses that house bandits waiting to prey upon the unwary.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\BRIGAND_CAMP.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2161	ObjectData ProperName	11	Bandit Camp	Bandit Camp	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\CEYAH_CITADEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2162	ObjectData ProperName	13	Ceyah Citadel	Ceyah Citadel	Building Name
+2163	ObjectData Description	15	Mareten Citadel	Mareten Citadel	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\CEYAH_CITY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2164	ObjectData ProperName	10	Ceyah City	Ceyah City	Building Name
+2165	ObjectData Description	12	Mareten City	Mareten City	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\CEYAH_OUTPOST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2166	ObjectData ProperName	13	Ceyah Outpost	Ceyah Outpost	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\CEYAH_TOWN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2167	ObjectData ProperName	10	Ceyah Town	Ceyah Town	Building Name
+2168	ObjectData Description	12	Mareten Town	Mareten Town	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\CEYAH_VILLAGE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2169	ObjectData ProperName	13	Ceyah Village	Ceyah Village	Building Name
+2170	ObjectData Description	15	Mareten Village	Mareten Village	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\COUNCIL_CITADEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2171	ObjectData ProperName	15	Council Citadel	Council Citadel	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\COUNCIL_CITY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2172	ObjectData ProperName	12	Council City	Council City	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\COUNCIL_OUTPOST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2173	ObjectData ProperName	15	Council Outpost	Council Outpost	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\COUNCIL_TOWN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2174	ObjectData ProperName	12	Council Town	Council Town	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\COUNCIL_VILLAGE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2175	ObjectData ProperName	15	Council Village	Council Village	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\DARK_CHASM.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2176	ObjectData ProperName	10	Dark Chasm	Dark Chasm	Building Name
+2177	ObjectData Description	1	X	X	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\DARK_RIFT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2178	ObjectData ProperName	9	Dark Rift	Dark Rift	Building Name
+2179	ObjectData Description	88	A strange field of dark energies that appears to operate as a portal to some evil realm.	A strange field of dark energies that appears to operate as a portal to some evil realm.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\DRAGON_LAIR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2180	ObjectData ProperName	11	Dragon Lair	Dragon Lair	Building Name
+2181	ObjectData Description	99	"Dark and dangerous looking cavern, home of a powerful dragon and likely to be filled with treasure."	"Dark and dangerous looking cavern, home of a powerful dragon and likely to be filled with treasure."	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\DRAUGA_VILLAGE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2182	ObjectData ProperName	14	Drauga Enclave	Drauga Enclave	Building Name
+2183	ObjectData Description	112	"The crude, but solidly crafted home of the Drauga, a warlike people who respect strength above all other things."	"The crude, but solidly crafted home of the Drauga, a warlike people who respect strength above all other things."	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\GAURI_VILLAGE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2184	ObjectData ProperName	16	Gauri Stronghold	Gauri Stronghold	Building Name
+2185	ObjectData Description	94	The Gauri live in great strongholds carved from solid rock and well fortified against assault.	The Gauri live in great strongholds carved from solid rock and well fortified against assault.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\GOLD_MINE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2186	ObjectData ProperName	12	Gold Deposit	Gold Deposit	Building Name
+2187	ObjectData Description	137	Control of this resource supplies your kingdom with +15 gold per minute. Use an engineering company to construct a mine on this resource.	Control of this resource supplies your kingdom with +15 gold per minute. Use an engineering company to construct a mine on this resource.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\HAROUN_VILLAGE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2188	ObjectData ProperName	16	Haroun Sanctuary	Haroun Sanctuary	Building Name
+2189	ObjectData Description	111	The artistic quality of the Haroun Sanctuary belies its ability to weather a siege as well as any Mareten city.	The artistic quality of the Haroun Sanctuary belies its ability to weather a siege as well as any Mareten city.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\IRON_MINE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2190	ObjectData ProperName	12	Iron Deposit	Iron Deposit	Building Name
+2191	ObjectData Description	137	Control of this resource supplies your kingdom with +10 iron per minute. Use an engineering company to construct a mine on this resource.	Control of this resource supplies your kingdom with +10 iron per minute. Use an engineering company to construct a mine on this resource.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\IRONWOOD_GROVE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2192	ObjectData ProperName	14	Ironwood Grove	Ironwood Grove	Building Name
+2193	ObjectData Description	137	Control of this resource supplies your kingdom with +10 wood per minute. Use an engineering company to construct a mine on this resource.	Control of this resource supplies your kingdom with +10 wood per minute. Use an engineering company to construct a mine on this resource.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\KHALDUNITE_FIELD.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2194	ObjectData ProperName	16	Khaldunite Field	Khaldunite Field	Building Name
+2195	ObjectData Description	136	Control of this resource supplies your kingdom with +5 mana per minute. Use an engineering company to construct a mine on this resource.	Control of this resource supplies your kingdom with +5 mana per minute. Use an engineering company to construct a mine on this resource.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\KHALDUNITE_SPIRE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2196	ObjectData ProperName	16	Khaldunite Spire	Khaldunite Spire	Building Name
+2197	ObjectData Description	137	This ancient device draws magic power from khaldunite deposits deep under the earth. It can be controlled like a mine to provide +8 mana.	This ancient device draws magic power from khaldunite deposits deep under the earth. It can be controlled like a mine to provide +8 mana.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\LOST_TEMPLE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2198	ObjectData ProperName	11	Lost Temple	Lost Temple	Building Name
+2199	ObjectData Description	85	The broken remnants of an ancient Kohan populace can be seen jutting from the ground.	The broken remnants of an ancient Kohan populace can be seen jutting from the ground.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\MARBLE_OUTCROPPING.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2200	ObjectData ProperName	18	Stone Outcropping	Stone Outcropping	Building Name
+2201	ObjectData Description	139	Control of this resource supplies your building with +10 stone per minute. Use an engineering company to construct a mine on this resource.	Control of this resource supplies your building with +10 stone per minute. Use an engineering company to construct a mine on this resource.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\MEGALITH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2202	ObjectData ProperName	8	Megalith	Megalith	Building Name
+2203	ObjectData Description	92	"Strange stones left behind where monuments, cities, and other ancient structures once stood."	"Strange stones left behind where monuments, cities, and other ancient structures once stood."	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\MONOLITH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2204	ObjectData Description	97	All that is left of the ancient structure is a large standing stone inscribed in wind worn runes.	All that is left of the ancient structure is a large standing stone inscribed in wind worn runes.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\MONSTER_GENERATOR1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2205	ObjectData ProperName	14	Strange Portal	Strange Portal	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\MONSTER_GENERATOR2.INI...					
+# Stripping \DATA\OBJECTDATA\BUILDINGS\MONSTER_LAIR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2206	ObjectData ProperName	12	Monster Lair	Monster Lair	Building Name
+2207	ObjectData Description	83	"Dark and dangerous looking cavern, which emanates noxious gases and strange sounds."	"Dark and dangerous looking cavern, which emanates noxious gases and strange sounds."	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\NATIONALIST_CITADEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2208	ObjectData ProperName	19	Nationalist Citadel	Nationalist Citadel	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\NATIONALIST_CITY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2209	ObjectData ProperName	16	Nationalist City	Nationalist City	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\NATIONALIST_OUTPOST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2210	ObjectData ProperName	19	Nationalist Outpost	Nationalist Outpost	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\NATIONALIST_TOWN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2211	ObjectData ProperName	16	Nationalist Town	Nationalist Town	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\NATIONALIST_VILLAGE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2212	ObjectData ProperName	19	Nationalist Village	Nationalist Village	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\NEST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2213	ObjectData ProperName	4	Nest	Nest	Building Name
+2214	ObjectData Description	94	A foul stench wafts heavily from the many holes and rents covering  this mound-like structure.	A foul stench wafts heavily from the many holes and rents covering  this mound-like structure.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\RHAKSHA_HIVE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2215	ObjectData ProperName	12	Rhaksha Hive	Rhaksha Hive	Building Name
+2216	ObjectData Description	139	A great pile of corruption. The musty smell is overwhelming and the bones littering the ground are testament to the danger dwelling within.	A great pile of corruption. The musty smell is overwhelming and the bones littering the ground are testament to the danger dwelling within.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\RHAKSHA_NEST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2217	ObjectData ProperName	12	Rhaksha Nest	Rhaksha Nest	Building Name
+2218	ObjectData Description	129	The foul stench of Rhaksha wafts heavily from the many holes and rents covering their mound-like nest. Best not to get too close.	The foul stench of Rhaksha wafts heavily from the many holes and rents covering their mound-like nest. Best not to get too close.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\ROYALIST_CITADEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2219	ObjectData ProperName	16	Royalist Citadel	Royalist Citadel	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\ROYALIST_CITY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2220	ObjectData ProperName	13	Royalist City	Royalist City	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\ROYALIST_OUTPOST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2221	ObjectData ProperName	16	Royalist Outpost	Royalist Outpost	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\ROYALIST_TOWN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2222	ObjectData ProperName	13	Royalist Town	Royalist Town	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\ROYALIST_VILLAGE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2223	ObjectData ProperName	16	Royalist Village	Royalist Village	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\RUINED_CITY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2224	ObjectData ProperName	11	Ruined City	Ruined City	Building Name
+2225	ObjectData Description	110	"Once a great temple or palace, now this remnant of the greater glory of the Kohan lies decrepit and forgotten."	"Once a great temple or palace, now this remnant of the greater glory of the Kohan lies decrepit and forgotten."	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\RUINED_MONUMENT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2226	ObjectData ProperName	15	Ruined Monument	Ruined Monument	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\SLAAN_LAIR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2227	ObjectData ProperName	10	Slaan Lair	Slaan Lair	Building Name
+2228	ObjectData Description	91	Odd looking mud and stone structures that house the hostile reptile men known as the Slaan.	Odd looking mud and stone structures that house the hostile reptile men known as the Slaan.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\SLAAN_VILLAGE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2229	ObjectData ProperName	13	Slaan Village	Slaan Village	Building Name
+2230	ObjectData Description	98	The Slaan Village is the home of the more intelligent breed of Slaan that live on Dragonbone Isle.	The Slaan Village is the home of the more intelligent breed of Slaan that live on Dragonbone Isle.	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\SPIDER_LAIR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2231	ObjectData ProperName	17	Giant Spider Nest	Giant Spider Nest	Building Name
+2232	ObjectData Description	100	"Massive cocoons of silk pulse with arachnid life, housing the brood of giant eight-legged predators."	"Massive cocoons of silk pulse with arachnid life, housing the brood of giant eight-legged predators."	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\SPREADING_SLAAN_LAIR.INI...					
+# Stripping \DATA\OBJECTDATA\BUILDINGS\STORM_DRAKE_LAIR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2233	ObjectData ProperName	16	Storm Drake Lair	Storm Drake Lair	Building Name
+# Stripping \DATA\OBJECTDATA\BUILDINGS\TEMPLE_RUIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2234	ObjectData ProperName	11	Temple Ruin	Temple Ruin	Building Name
+2235	ObjectData Description	114	"Once a great temple or palace, now this remnant of the greater glory of the Kohan now lies decrepit and forgotten."	"Once a great temple or palace, now this remnant of the greater glory of the Kohan now lies decrepit and forgotten."	Building Description
+# Stripping \DATA\OBJECTDATA\BUILDINGS\YOUNG_DRAKE_LAIR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2236	ObjectData ProperName	17	Young Dragon Lair	Young Dragon Lair	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\1X1_MOUNTAIN1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2237	ObjectData ProperName	14	1x1 Mountain 1	1x1 Mountain 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\1X1_MOUNTAIN2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2238	ObjectData ProperName	14	1x1 Mountain 2	1x1 Mountain 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\1X1_MOUNTAIN3.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2239	ObjectData ProperName	14	1x1 Mountain 3	1x1 Mountain 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\1X1_MOUNTAIN4.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2240	ObjectData ProperName	14	1x1 Mountain 4	1x1 Mountain 4	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\1X1_MOUNTAIN5.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2241	ObjectData ProperName	14	1x1 Mountain 5	1x1 Mountain 5	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\2X2_DSRT_MNT1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2242	ObjectData ProperName	21	2x2 Desert Mountian 1	2x2 Desert Mountian 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\2X2_DSRT_MNT2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2243	ObjectData ProperName	21	2x2 Desert Mountian 2	2x2 Desert Mountian 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\2X2_DSRT_MNT3.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2244	ObjectData ProperName	21	2x2 Desert Mountian 3	2x2 Desert Mountian 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_DSRT_MNT1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2245	ObjectData ProperName	21	3x3 Desert Mountian 1	3x3 Desert Mountian 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_DSRT_MNT2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2246	ObjectData ProperName	21	3x3 Desert Mountian 2	3x3 Desert Mountian 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_DSRT_MNT3.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2247	ObjectData ProperName	21	3x3 Desert Mountian 3	3x3 Desert Mountian 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_EVIL_MOUNTAIN1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2248	ObjectData ProperName	19	3x3 Evil Mountain 1	3x3 Evil Mountain 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_EVIL_MOUNTAIN2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2249	ObjectData ProperName	19	3x3 Evil Mountain 2	3x3 Evil Mountain 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_EVIL_MOUNTAIN3.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2250	ObjectData ProperName	19	3x3 Evil Mountain 3	3x3 Evil Mountain 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_EVIL_MOUNTAIN4.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2251	ObjectData ProperName	19	3x3 Evil Mountain 4	3x3 Evil Mountain 4	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_MOUNTAIN1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2252	ObjectData ProperName	14	3x3 Mountain 1	3x3 Mountain 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_MOUNTAIN2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2253	ObjectData ProperName	14	3x3 Mountain 2	3x3 Mountain 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_MOUNTAIN3.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2254	ObjectData ProperName	14	3x3 Mountain 3	3x3 Mountain 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_MOUNTAIN4.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2255	ObjectData ProperName	14	3x3 Mountain 4	3x3 Mountain 4	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_MOUNTAIN5.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2256	ObjectData ProperName	14	3x3 Mountain 5	3x3 Mountain 5	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\3X3_MOUNTAIN6.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2257	ObjectData ProperName	14	3x3 Mountain 6	3x3 Mountain 6	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\5X5_DSRT_MNT1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2258	ObjectData ProperName	21	5x5 Desert Mountian 1	5x5 Desert Mountian 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\5X5_DSRT_MNT2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2259	ObjectData ProperName	21	5x5 Desert Mountian 2	5x5 Desert Mountian 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\5X5_EVIL_MOUNTAIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2260	ObjectData ProperName	17	5x5 Evil Mountain	5x5 Evil Mountain	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\5X5_MOUNTAIN1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2261	ObjectData ProperName	14	5x5 Mountain 1	5x5 Mountain 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\5X5_MOUNTAIN2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2262	ObjectData ProperName	14	5x5 Mountain 2	5x5 Mountain 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\5X5_MOUNTAIN3.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2263	ObjectData ProperName	14	5x5 Mountain 3	5x5 Mountain 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\ANT_LION.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2264	ObjectData ProperName	8	Ant Lion	Ant Lion	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\BROKEN_SPIRE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2265	ObjectData ProperName	12	Broken Spire	Broken Spire	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\CENTIPEDES.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2266	ObjectData ProperName	16	Centipede Mounds	Centipede Mounds	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\CLIFF.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2267	ObjectData ProperName	5	Cliff	Cliff	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DEAD_PINES_1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2268	ObjectData ProperName	12	Dead Pines 1	Dead Pines 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DEAD_PINES_2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2269	ObjectData ProperName	12	Dead Pines 2	Dead Pines 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DEAD_SHRUB_1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2270	ObjectData ProperName	13	Dead Shrubs 1	Dead Shrubs 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DEAD_SHRUB_2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2271	ObjectData ProperName	13	Dead Shrubs 2	Dead Shrubs 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DEAD_TREE_1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2272	ObjectData ProperName	18	Single Dead Tree 1	Single Dead Tree 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DEAD_TREE_2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2273	ObjectData ProperName	18	Single Dead Tree 2	Single Dead Tree 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_CACTUS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2274	ObjectData ProperName	13	Desert Cactus	Desert Cactus	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_PATCH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2275	ObjectData ProperName	12	Desert Patch	Desert Patch	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_PEEKING_THING.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2276	ObjectData ProperName	20	Desert Peeking Thing	Desert Peeking Thing	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2277	ObjectData ProperName	13	Desert Rock 1	Desert Rock 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK10.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2278	ObjectData ProperName	14	Desert Rock 10	Desert Rock 10	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK11.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2279	ObjectData ProperName	14	Desert Rock 11	Desert Rock 11	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK12.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2280	ObjectData ProperName	14	Desert Rock 12	Desert Rock 12	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK13.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2281	ObjectData ProperName	14	Desert Rock 13	Desert Rock 13	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK14.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2282	ObjectData ProperName	14	Desert Rock 14	Desert Rock 14	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK15.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2283	ObjectData ProperName	14	Desert Rock 15	Desert Rock 15	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK16.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2284	ObjectData ProperName	14	Desert Rock 16	Desert Rock 16	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK3.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2285	ObjectData ProperName	13	Desert Rock 3	Desert Rock 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK4.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2286	ObjectData ProperName	13	Desert Rock 4	Desert Rock 4	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK5.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2287	ObjectData ProperName	13	Desert Rock 5	Desert Rock 5	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK6.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2288	ObjectData ProperName	13	Desert Rock 6	Desert Rock 6	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK7.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2289	ObjectData ProperName	13	Desert Rock 7	Desert Rock 7	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK8.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2290	ObjectData ProperName	13	Desert Rock 8	Desert Rock 8	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_ROCK9.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2291	ObjectData ProperName	13	Desert Rock 9	Desert Rock 9	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERT_SHRUB.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2292	ObjectData ProperName	12	Desert Shrub	Desert Shrub	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\DESERTBONES.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2293	ObjectData ProperName	12	Desert Bones	Desert Bones	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\EVIL_DOODAD01.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2294	ObjectData ProperName	13	Evil doodad 1	Evil doodad 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\EVIL_DOODAD02.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2295	ObjectData ProperName	13	Evil doodad 2	Evil doodad 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\EVIL_DOODAD03.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2296	ObjectData ProperName	13	Evil doodad 3	Evil doodad 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\EVIL_DOODAD04.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2297	ObjectData ProperName	13	Evil Doodad 4	Evil Doodad 4	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\EVIL_DOODAD05.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2298	ObjectData ProperName	13	Evil Doodad 5	Evil Doodad 5	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FLAME_BURST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2299	ObjectData ProperName	11	Flame burst	Flame burst	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FLOWERS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2300	ObjectData ProperName	16	Flowers - purple	Flowers - purple	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FLOWERS_BLUE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2301	ObjectData ProperName	14	Flowers - blue	Flowers - blue	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FLOWERS_RED.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2302	ObjectData ProperName	13	Flowers - red	Flowers - red	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FLOWERS_YELLOW.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2303	ObjectData ProperName	16	Flowers - yellow	Flowers - yellow	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST0.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2304	ObjectData ProperName	14	Forest Trees 1	Forest Trees 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2305	ObjectData ProperName	14	Forest Trees 2	Forest Trees 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2306	ObjectData ProperName	14	Forest Trees 3	Forest Trees 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST3.INI...					
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST4.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2307	ObjectData ProperName	14	Forest Trees 4	Forest Trees 4	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST5.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2308	ObjectData ProperName	14	Forest Trees 5	Forest Trees 5	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST6.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2309	ObjectData ProperName	14	Forest Trees 6	Forest Trees 6	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST7.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2310	ObjectData ProperName	14	Forest Trees 7	Forest Trees 7	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST8.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2311	ObjectData ProperName	14	Forest Trees 8	Forest Trees 8	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST9.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2312	ObjectData ProperName	14	Forest Trees 9	Forest Trees 9	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\FOREST_SKULL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2313	ObjectData ProperName	12	Forest Skull	Forest Skull	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GRASS_DIRT01.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2314	ObjectData ProperName	12	Grass Dirt 1	Grass Dirt 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GRASS_DIRT02.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2315	ObjectData ProperName	12	Grass Dirt 2	Grass Dirt 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GRASS_DIRT03.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2316	ObjectData ProperName	12	Grass Dirt 3	Grass Dirt 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GRASS_PATCH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2317	ObjectData ProperName	11	Grass Patch	Grass Patch	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GRASS_PIT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2318	ObjectData ProperName	9	Grass Pit	Grass Pit	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GRAVE_1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2319	ObjectData ProperName	7	Grave 1	Grave 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GRAVE_2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2320	ObjectData ProperName	7	Grave 2	Grave 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GREEN_TREE1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2321	ObjectData ProperName	13	Green Trees 1	Green Trees 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GREEN_TREE2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2322	ObjectData ProperName	13	Green Trees 2	Green Trees 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GREEN_TREE3.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2323	ObjectData ProperName	13	Green Trees 3	Green Trees 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GREEN_TREE4.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2324	ObjectData ProperName	13	Green Trees 4	Green Trees 4	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GREEN_TREE5.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2325	ObjectData ProperName	13	Green Trees 5	Green Trees 5	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\GROUND_ETCHING.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2326	ObjectData ProperName	14	Ground Etching	Ground Etching	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\JUNGLE_FERN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2327	ObjectData ProperName	11	Jungle Fern	Jungle Fern	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\JUNGLE_TREES1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2328	ObjectData ProperName	14	Jungle Trees 1	Jungle Trees 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\JUNGLE_TREES2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2329	ObjectData ProperName	14	Jungle Trees 2	Jungle Trees 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\LAND_URCHIN_BLUE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2330	ObjectData ProperName	16	Land Urchin Blue	Land Urchin Blue	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\LAND_URCHIN_RED.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2331	ObjectData ProperName	15	Land Urchin Red	Land Urchin Red	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\LAVA_DOODAD01.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2332	ObjectData ProperName	13	Lava doodad 1	Lava doodad 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\LAVA_DOODAD02.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2333	ObjectData ProperName	13	Lava doodad 2	Lava doodad 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\LAVA_DOODAD03.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2334	ObjectData ProperName	13	Lava doodad 3	Lava doodad 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\LAVA_DOODAD04.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2335	ObjectData ProperName	13	Lava doodad 4	Lava doodad 4	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\MAGICAL_SPRING.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2336	ObjectData ProperName	15	Mystical Spring	Mystical Spring	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\MAN_EATING_PLANT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2337	ObjectData ProperName	16	Man Eating Plant	Man Eating Plant	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\MUSHROOMS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2338	ObjectData ProperName	15	Giant Mushrooms	Giant Mushrooms	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\MUSHROOMS2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2339	ObjectData ProperName	16	Giant Mushrooms2	Giant Mushrooms2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\MUSHROOMS3.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2340	ObjectData ProperName	16	Giant Mushrooms3	Giant Mushrooms3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\PEEKING_THING.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2341	ObjectData ProperName	19	Grass Peeking Thing	Grass Peeking Thing	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\SMOOTH_MOUNTAIN1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2342	ObjectData ProperName	10	Big Rock 1	Big Rock 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\SMOOTH_MOUNTAIN10.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2343	ObjectData ProperName	11	Big Rock 10	Big Rock 10	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\SMOOTH_MOUNTAIN2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2344	ObjectData ProperName	10	Big Rock 2	Big Rock 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\SMOOTH_MOUNTAIN4.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2345	ObjectData ProperName	10	Big Rock 4	Big Rock 4	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\SMOOTH_MOUNTAIN5.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2346	ObjectData ProperName	10	Big Rock 5	Big Rock 5	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\SMOOTH_MOUNTAIN6.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2347	ObjectData ProperName	10	Big Rock 6	Big Rock 6	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\SMOOTH_MOUNTAIN7.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2348	ObjectData ProperName	10	Big Rock 7	Big Rock 7	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\SMOOTH_MOUNTAIN9.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2349	ObjectData ProperName	10	Big Rock 9	Big Rock 9	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\SPIKED_ROCKS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2350	ObjectData ProperName	13	Spiky Rocks 1	Spiky Rocks 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\SPIKED_ROCKS2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2351	ObjectData ProperName	13	Spiky Rocks 2	Spiky Rocks 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\START_POSITION.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2352	ObjectData ProperName	14	Start Position	Start Position	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\TREEBUGS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2353	ObjectData ProperName	13	Firefly Trees	Firefly Trees	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\VOLCANO.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2354	ObjectData ProperName	7	Volcano	Volcano	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\VULTURE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2355	ObjectData ProperName	7	Vulture	Vulture	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\VULTURE00.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2356	ObjectData ProperName	9	Vulture00	Vulture00	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\VULTURE01.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2357	ObjectData ProperName	9	Vulture01	Vulture01	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\VULTURE02.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2358	ObjectData ProperName	9	Vulture02	Vulture02	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\VULTURE03.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2359	ObjectData ProperName	9	Vulture03	Vulture03	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\WATER_DOODAD01.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2360	ObjectData ProperName	12	Water Rock 1	Water Rock 1	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\WATER_DOODAD02.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2361	ObjectData ProperName	12	Water Rock 2	Water Rock 2	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\WATER_DOODAD03.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2362	ObjectData ProperName	12	Water Rock 3	Water Rock 3	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\WATER_DOODAD04.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2363	ObjectData ProperName	12	Water Rock 4	Water Rock 4	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\WATER_DOODAD_FACE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2364	ObjectData ProperName	12	Water Statue	Water Statue	Building Name
+# Stripping \DATA\OBJECTDATA\FEATURES\WATERFALLS2.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2365	ObjectData ProperName	9	Waterfall	Waterfall	Building Name
+# Stripping \DATA\OBJECTDATA\HEROES\ADELLON_MAJERE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2366	UnitData Description	407	"Adellon Majere is a mage of great power and ambition. He has been awake for some time now and has been carefully watching the events of the day unfold around him. Whether he will choose to fight for the side that appears to offer the greatest rewards is yet to be known. Those who have met him know how strong he is in the mystical arts and how the strength of his ambition matches all his other talents."	"Adellon Majere is a mage of great power and ambition. He has been awake for some time now and has been carefully watching the events of the day unfold around him. Whether he will choose to fight for the side that appears to offer the greatest rewards is yet to be known. Those who have met him know how strong he is in the mystical arts and how the strength of his ambition matches all his other talents."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\AMON_KOTH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2367	UnitData Description	461	"Amon Koth was not originally condemned as Ceyah Kohan during the initial purge. Instead he self exiled himself, following after some of the other Ceyah Kohan that had been ostracized. He eventually found himself deep underground, separated from all of the other Ceyah Kohan. It was here that he somehow spawned his 'children', the Rhaksha. No one knows how he managed this, or why. He has set himself up as their God and master, and rules over them still today."	"Amon Koth was not originally condemned as Ceyah Kohan during the initial purge. Instead he self exiled himself, following after some of the other Ceyah Kohan that had been ostracized. He eventually found himself deep underground, separated from all of the other Ceyah Kohan. It was here that he somehow spawned his 'children', the Rhaksha. No one knows how he managed this, or why. He has set himself up as their God and master, and rules over them still today."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\BALTHASAR_ASWAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2368	UnitData Description	333	"Balthasar is stern man, one who is always worrying about something. He lives among the Haroun and as such uses his magic-form to fit in. He notes his difference from the mortals by having a small beard, something virtually unheard of among the Haroun. He is a master of fire magic and has gained great respect from other Kohan mages."	"Balthasar is stern man, one who is always worrying about something. He lives among the Haroun and as such uses his magic-form to fit in. He notes his difference from the mortals by having a small beard, something virtually unheard of among the Haroun. He is a master of fire magic and has gained great respect from other Kohan mages."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\CYRA_BLOODSTONE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2369	UnitData Description	301	Arya Shahin is a most confrontational woman. She never takes a back seat on the battlefield and if she has something to say she never hesitates to make her opinion known. Her skills have been focused on battling the Shadow and she has become very intent on proving herself in the approaching conflict.	Arya Shahin is a most confrontational woman. She never takes a back seat on the battlefield and if she has something to say she never hesitates to make her opinion known. Her skills have been focused on battling the Shadow and she has become very intent on proving herself in the approaching conflict.	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\CYRUS_FAKHIR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2370	UnitData Description	300	"Cyrus is a very driven and focused man, intent on learning as much about the mystical arts as possible. He desires knowledge above all else and is very serious about his work. His greatest irritation is that the war between the Dark Master and the Kohan interferes with his ability to study in peace."	"Cyrus is a very driven and focused man, intent on learning as much about the mystical arts as possible. He desires knowledge above all else and is very serious about his work. His greatest irritation is that the war between the Dark Master and the Kohan interferes with his ability to study in peace."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\DARIUS_JAVIDAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2371	UnitData Description	222	"The man known as Darius Javidan has a heavy weight on his shoulders. Though his memories are muddled and he barely understands who he is, he knows in his heart that he has a destiny to fulfill. So much is depending on him."	"The man known as Darius Javidan has a heavy weight on his shoulders. Though his memories are muddled and he barely understands who he is, he knows in his heart that he has a destiny to fulfill. So much is depending on him."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\DOGUN_MOSSK.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2372	UnitData Description	279	Dogun Mossk is a very skilled Kohan whose love for manual crafts had made him invaluable to the Kohan during the rebuilding after the Cataclysm. His skills also made him very good at laying siege to shadow occupied fortresses as well as assisting his own troops in fortification.	Dogun Mossk is a very skilled Kohan whose love for manual crafts had made him invaluable to the Kohan during the rebuilding after the Cataclysm. His skills also made him very good at laying siege to shadow occupied fortresses as well as assisting his own troops in fortification.	Hero Description
+2373	HeroData TranslatedName	11	Dogun Mossk	Dogun Mossk	
+# Stripping \DATA\OBJECTDATA\HEROES\DYLAN_GARWOOD.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2374	UnitData Description	223	No Kohan is more righteous and aloof than Dylan Garwood. He is a man of implacable convictions and impenetrable beliefs. In battle he never backs down before the Shadow and those who do are not worthy of his aid or respect.	No Kohan is more righteous and aloof than Dylan Garwood. He is a man of implacable convictions and impenetrable beliefs. In battle he never backs down before the Shadow and those who do are not worthy of his aid or respect.	Hero Description
+2375	HeroData TranslatedName	13	Dylan Garwood	Dylan Garwood	Hero Name
+# Stripping \DATA\OBJECTDATA\HEROES\EBEN_BARUCH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2376	UnitData Description	262	"Eben loves nature. He likes nothing better than traveling across the land, sleeping under the stars, and foraging for his dinner. He is believed to be one of the originators of the Ranger society that helped hold back the minions of shadow during the Cataclysms."	"Eben loves nature. He likes nothing better than traveling across the land, sleeping under the stars, and foraging for his dinner. He is believed to be one of the originators of the Ranger society that helped hold back the minions of shadow during the Cataclysms."	Hero Description
+2377	HeroData TranslatedName	11	Eben Baruch	Eben Baruch	Hero Name
+# Stripping \DATA\OBJECTDATA\HEROES\ETHAN_DELROBA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2378	UnitData Description	276	Ethan is a light-hearted Kohan who would rather be attending a social function than engaging in battle. This doesn't mean he is weak though. Ethan is a very skilled warrior with tactical knowledge few other Kohan can match. He always seems to find the advantage during battle.	Ethan is a light-hearted Kohan who would rather be attending a social function than engaging in battle. This doesn't mean he is weak though. Ethan is a very skilled warrior with tactical knowledge few other Kohan can match. He always seems to find the advantage during battle.	Hero Description
+2379	HeroData TranslatedName	13	Ethan Delroba	Ethan Delroba	Hero Name
+# Stripping \DATA\OBJECTDATA\HEROES\GARADUN_PAYNE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2380	UnitData Description	278	"Garadun Payne is a monster of a man. Even though he spends his time exclusively in a form somewhere between normal and war form, he is a large, strong, and tough as any warform Kohan. He is fearless in battle, willing to accept any challenge no matter how powerful the opponent."	"Garadun Payne is a monster of a man. Even though he spends his time exclusively in a form somewhere between normal and war form, he is a large, strong, and tough as any warform Kohan. He is fearless in battle, willing to accept any challenge no matter how powerful the opponent."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\GAROJ'MOK.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2381	UnitData Description	93	Garoj'mok is the leader of the Drauga tribes and got there by killing the last tribal leader.	Garoj'mok is the leader of the Drauga tribes and got there by killing the last tribal leader.	Hero Description
+2382	HeroData TranslatedName	9	Garoj'mok	Garoj'mok	Hero Name
+# Stripping \DATA\OBJECTDATA\HEROES\GHALEN_MORDECAI.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2383	UnitData Description	314	"Ghalen is a hard man, one who has dedicated his life to battle and the improvement of his physical abilities. He is nearly unbeatable in single combat, so well trained in the art of melee as he is. He awaits the day he can get his revenge on Sijansur, the Ceyah whose army defeated him during the second Cataclysm."	"Ghalen is a hard man, one who has dedicated his life to battle and the improvement of his physical abilities. He is nearly unbeatable in single combat, so well trained in the art of melee as he is. He awaits the day he can get his revenge on Sijansur, the Ceyah whose army defeated him during the second Cataclysm."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\GIDEON_XARR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2384	UnitData Description	311	"Gideon is a brutish warrior who cares for nothing but victory. Awakened by Shohn Maht and seduced by the temptations of the Dark Master, Gideon has become a loyal general ready to destroy all who oppose Shohn Maht's will. His prowess in battle is nothing compared to the brutality he exhibits against his enemy."	"Gideon is a brutish warrior who cares for nothing but victory. Awakened by Shohn Maht and seduced by the temptations of the Dark Master, Gideon has become a loyal general ready to destroy all who oppose Shohn Maht's will. His prowess in battle is nothing compared to the brutality he exhibits against his enemy."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\JAMSHEED_AVISHAI.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2385	UnitData Description	293	"The man known as Jamsheed Javidan is a tower of strength, standing taller than any man he has met, the image he presents is daunting in the least. Wearing gilded and ornate armor he strikes fear into the hearts of his enemies when they see him charge forth astride his massive warhorse, Blaze."	"The man known as Jamsheed Javidan is a tower of strength, standing taller than any man he has met, the image he presents is daunting in the least. Wearing gilded and ornate armor he strikes fear into the hearts of his enemies when they see him charge forth astride his massive warhorse, Blaze."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\JASMIN_SHAHIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2386	UnitData Description	222	"Roxanna Javidan is a high ranking member of House Javidan. She is also quite powerful, capable of blessing her allies and searing her enemies with mystic flames. She is related to Darius, but in what manner is not certain."	"Roxanna Javidan is a high ranking member of House Javidan. She is also quite powerful, capable of blessing her allies and searing her enemies with mystic flames. She is related to Darius, but in what manner is not certain."	Hero Description
+2387	HeroData TranslatedName	15	Roxanna Javidan	Roxanna Javidan	Hero Name
+# Stripping \DATA\OBJECTDATA\HEROES\JENSINE_ILJARA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2388	UnitData Description	253	"Amber is a woman of sensible actions. She likes to carefully plan out every course of action and is always aware of every conceivable consequence. A sorceress of great power, she is a dangerous adversary when she decides to commit to a course of action."	"Amber is a woman of sensible actions. She likes to carefully plan out every course of action and is always aware of every conceivable consequence. A sorceress of great power, she is a dangerous adversary when she decides to commit to a course of action."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\JEVON_DARKMIRE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2389	UnitData Description	298	Javon is fascinated by the political intrigue of the mortal governments. There are so many complex interactions between mortal kingdoms that Javon cannot think of anything more interesting. He spends much of his time posing as a Mareten and trying to get involved in many kingdoms' internal affairs.	Javon is fascinated by the political intrigue of the mortal governments. There are so many complex interactions between mortal kingdoms that Javon cannot think of anything more interesting. He spends much of his time posing as a Mareten and trying to get involved in many kingdoms' internal affairs.	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\KENDRA_LANGSTON.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2390	UnitData Description	274	"Although her loyalties are to the Nationalist faction, Kendra revels in the feudal politics of the Royalists, much like Javon Shahin. She dresses like mortal royalty in deep blues and purples. She is often prone to traveling from kingdom to kingdom, learning all she can about mortal politics and the type of people they produce."	"Although her loyalties are to the Nationalist faction, Kendra revels in the feudal politics of the Royalists, much like Javon Shahin. She dresses like mortal royalty in deep blues and purples. She is often prone to traveling from kingdom to kingdom, learning all she can about mortal politics and the type of people they produce."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\KYRAN_DELROBA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2391	UnitData Description	228	"Kyran is a very practical person, one who always knows his limitations and works hard at finding ways to combat them. He is well trained in the arts of battle, and is well known for his tactical strategies for defeating archers."	"Kyran is a very practical person, one who always knows his limitations and works hard at finding ways to combat them. He is well trained in the arts of battle, and is well known for his tactical strategies for defeating archers."	Hero Description
+2392	HeroData TranslatedName	13	Kyran Delroba	Kyran Delroba	Hero Name
+# Stripping \DATA\OBJECTDATA\HEROES\LAILA_ASWAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2393	UnitData Description	207	"Ilyana Aswan is a brash and impetuous Kohan who relies on no one but herself. She gets very defensive when she requires help and would never admit to being unable to deal with any problem, no matter how dire."	"Ilyana Aswan is a brash and impetuous Kohan who relies on no one but herself. She gets very defensive when she requires help and would never admit to being unable to deal with any problem, no matter how dire."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\LAZARUS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2394	UnitData Description	328	"Lazarus is a man wholly dedicated to the power of the Shadow and its connection to the Dark Master. He secretly believes that the Dark Master is a herald for a greater power, one that rules the realm of the Shadow. It is this greater power who he feels will one day take control of Khaldun and make him its most favored servant."	"Lazarus is a man wholly dedicated to the power of the Shadow and its connection to the Dark Master. He secretly believes that the Dark Master is a herald for a greater power, one that rules the realm of the Shadow. It is this greater power who he feels will one day take control of Khaldun and make him its most favored servant."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\LYSSA_FREELAND.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2395	UnitData Description	400	"Lyssa Edan is a natural beauty who shuns all forms of artificial ornament. Not that she has ever needed any. She was well known during the days of the Second Kohan Dynasty as a free spirit who often shocked the other Kohan by dressing in scandalous clothing and speaking her mind. As could be expected, she did not see eye to eye with the Council leaders who still spoke of the conservative old ways."	"Lyssa Edan is a natural beauty who shuns all forms of artificial ornament. Not that she has ever needed any. She was well known during the days of the Second Kohan Dynasty as a free spirit who often shocked the other Kohan by dressing in scandalous clothing and speaking her mind. As could be expected, she did not see eye to eye with the Council leaders who still spoke of the conservative old ways."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\MELCHIOR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2396	UnitData Description	234	"Melchior is a brutal huntmaster for the Shadow. He serves his Dark Master with precision and utter loyalty. No one alive knows for sure who he was before the Cataclysms, and he always wears a dark iron mask that protects his identity."	"Melchior is a brutal huntmaster for the Shadow. He serves his Dark Master with precision and utter loyalty. No one alive knows for sure who he was before the Cataclysms, and he always wears a dark iron mask that protects his identity."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\MOGGOK.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2397	UnitData Description	282	Moggok loves nothing better than a good fight. He spends all of his time studying combat tactics and practicing with his massive Khaldunite Hammer. Wearing Gauri armor and living among them has allowed Moggok to adapt his form providing him with the famed Gauri resistance to magic.	Moggok loves nothing better than a good fight. He spends all of his time studying combat tactics and practicing with his massive Khaldunite Hammer. Wearing Gauri armor and living among them has allowed Moggok to adapt his form providing him with the famed Gauri resistance to magic.	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\NAAVA_DAISHAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2398	UnitData Description	289	Naava Daishan is a priestess dedicated to the will of the Creator. She is privy to many spiritual powers and secrets that few other Kohan can conceive of. Her knowledge of the Shadow and its minions is without equal and there is no better Kohan to have on your side when confronting evil.	Naava Daishan is a priestess dedicated to the will of the Creator. She is privy to many spiritual powers and secrets that few other Kohan can conceive of. Her knowledge of the Shadow and its minions is without equal and there is no better Kohan to have on your side when confronting evil.	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\PRAXUS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2399	UnitData Description	263	"Praxus is a very logical man, one who weighs every option and never lets emotion cloud his judgement. Unless he can be systematically shown that compassion and the path of righteousness is superior to the Dark Master's plan, he will not be swayed from the Shadow."	"Praxus is a very logical man, one who weighs every option and never lets emotion cloud his judgement. Unless he can be systematically shown that compassion and the path of righteousness is superior to the Dark Master's plan, he will not be swayed from the Shadow."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\QASIM_MAJERE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2400	UnitData Description	224	Qasim is a proud warrior who has been preparing for the final battle with the Dark Master ever since he was awakened. Devoting himself to the powers of the Creator he has gained many spiritual powers to aid him in his quest.	Qasim is a proud warrior who has been preparing for the final battle with the Dark Master ever since he was awakened. Devoting himself to the powers of the Creator he has gained many spiritual powers to aid him in his quest.	Hero Description
+2401	HeroData TranslatedName	12	Qasim Majere	Qasim Majere	Hero Name
+# Stripping \DATA\OBJECTDATA\HEROES\RAVYN_DUNN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2402	UnitData Description	308	"Leila is a regal looking Kohan with long, dark hair and piercing hazel eyes. A Priestess of the Creator, she wields powers channeled from the heavens in her crusade to reunite the Kohan and bring peace back to Khaldun. She has been awakened for some time now, but still cannot remember much of her past life."	"Leila is a regal looking Kohan with long, dark hair and piercing hazel eyes. A Priestess of the Creator, she wields powers channeled from the heavens in her crusade to reunite the Kohan and bring peace back to Khaldun. She has been awakened for some time now, but still cannot remember much of her past life."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\RUARC_VARAGOTH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2403	UnitData Description	313	"Ruarc awoke among the Drauga people and developed a strong affinity with them. Using the Kohan war form exclusively, he quickly rose through the ranks of Drauga society, besting all of the mortal warriors in personal challenges. He rides a Drauga beast that he named Yshai, which means smoke in the Drauga tongue."	"Ruarc awoke among the Drauga people and developed a strong affinity with them. Using the Kohan war form exclusively, he quickly rose through the ranks of Drauga society, besting all of the mortal warriors in personal challenges. He rides a Drauga beast that he named Yshai, which means smoke in the Drauga tongue."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\SADIRA_BAHHRUM.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2404	UnitData Description	306	"Sadira is a very driven woman, intent on destroying the shadow in any way possible. She will not rest until the Dark Master and his shadow minions have been driven from the face of Khaldun and peace returns to the Kohan. To further this cause, she has learned to channel both mystical and spiritual powers."	"Sadira is a very driven woman, intent on destroying the shadow in any way possible. She will not rest until the Dark Master and his shadow minions have been driven from the face of Khaldun and peace returns to the Kohan. To further this cause, she has learned to channel both mystical and spiritual powers."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\SAMMAN OSAHYR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2405	UnitData Description	306	Samman is a thoughtful and intelligent leader. He wears light armor and always looks like he is reflecting deeply upon some problem that plagues him. He prefers to command light cavalry as he knows the tactics of cavalry well. Samman wields a khaldunite spear from the back of a horse as swift as the wind.	Samman is a thoughtful and intelligent leader. He wears light armor and always looks like he is reflecting deeply upon some problem that plagues him. He prefers to command light cavalry as he knows the tactics of cavalry well. Samman wields a khaldunite spear from the back of a horse as swift as the wind.	Hero Description
+2406	HeroData TranslatedName	12	Samman Ravid	Samman Ravid	Hero Name
+# Stripping \DATA\OBJECTDATA\HEROES\SAR_LASHKAR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2407	UnitData Description	649	"Sar Lashkar was a virtually unknown, lesser member of Kohan society. He had little influence and little power. The Cataclysm was his big chance to gain power. It did not work, of course, and he was banished with the rest of the Ceyah. Sar Lashkar spent the rest of his days wandering in the far south, across barren, frozen lands. The bitter cold matched his bitter heart and Sar Lashkar became more brutal and violent with each passing year. He appears in a Kohan war-form that has been taken to the extreme. He is very large, very hairy, and possesses great strength. He uses his strength to prey upon all the weaker creatures that cross his path."	"Sar Lashkar was a virtually unknown, lesser member of Kohan society. He had little influence and little power. The Cataclysm was his big chance to gain power. It did not work, of course, and he was banished with the rest of the Ceyah. Sar Lashkar spent the rest of his days wandering in the far south, across barren, frozen lands. The bitter cold matched his bitter heart and Sar Lashkar became more brutal and violent with each passing year. He appears in a Kohan war-form that has been taken to the extreme. He is very large, very hairy, and possesses great strength. He uses his strength to prey upon all the weaker creatures that cross his path."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\SARAI_JAVIDAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2408	UnitData Description	321	"Sarai was well known in Kohan society for her compassionate ways and desire for peace above all things. She has been forced to aid in the battle against the Shadow, but she despises her involvement in any combat. Even so, she understands the necessity of the situation and is willing to do her best to protect her troops."	"Sarai was well known in Kohan society for her compassionate ways and desire for peace above all things. She has been forced to aid in the battle against the Shadow, but she despises her involvement in any combat. Even so, she understands the necessity of the situation and is willing to do her best to protect her troops."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\SELVANA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2409	UnitData Description	307	"Selvana is the only Kohan who is thought to match Vulgari in desire for power and wealth. She is far more subtle about it though, preferring to manipulate others into giving her what she wants rather than confront her obstacles directly. In the opinion of many, this makes her the more dangerous of the two."	"Selvana is the only Kohan who is thought to match Vulgari in desire for power and wealth. She is far more subtle about it though, preferring to manipulate others into giving her what she wants rather than confront her obstacles directly. In the opinion of many, this makes her the more dangerous of the two."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\SETH_ASWAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2410	UnitData Description	224	"Seth Aswan enjoyed living a fairly carefree existance among the Haroun people, then the shadow of the Dark Master began to fall upon their land. He has taken to his Ranger ways of old to combat the threat of the Dark Master."	"Seth Aswan enjoyed living a fairly carefree existance among the Haroun people, then the shadow of the Dark Master began to fall upon their land. He has taken to his Ranger ways of old to combat the threat of the Dark Master."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\SHAMAEL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2411	UnitData Description	319	"Shamael is a cruel creature of darkness. Few of the other Ceyah can even stand to be near him. In appearance he seems to have found a way to blend the war and magic forms into one, having aspects of both. He uses this blend to a terrifying degree of efficiency harassing his enemy with both physical and mystical might."	"Shamael is a cruel creature of darkness. Few of the other Ceyah can even stand to be near him. In appearance he seems to have found a way to blend the war and magic forms into one, having aspects of both. He uses this blend to a terrifying degree of efficiency harassing his enemy with both physical and mystical might."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\SHOHN_MAHT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2412	UnitData Description	927	One of the true Ceyah Kohan who broke from the High Council on the Day of Betrayal. Shohn Maht was a lesser council member who idolized Ceyadev and strove to be as strong and influential as her. When Ceyadev broke from the council Shohn Maht followed without hesitation. He embraced his banishment, convincing himself that he was superior to the rest of the Kohan. He followed Ceyadev for a short time, then broke away when it became apparent that Ceyadev only desired isolation. Shohn Maht desired power and decided that the mortals would be the perfect subjects. He managed to survive the next cataclysm and learned as much as he could about Ahriman and his plans. He then founded the religion known as the Nightbringers. Using his new power and influence he pledged himself to Ahriman's cause, ruling his kingdom as a tyrant. He is a master of dark magic and much of his kingdom is protected with hordes of the walking dead.	One of the true Ceyah Kohan who broke from the High Council on the Day of Betrayal. Shohn Maht was a lesser council member who idolized Ceyadev and strove to be as strong and influential as her. When Ceyadev broke from the council Shohn Maht followed without hesitation. He embraced his banishment, convincing himself that he was superior to the rest of the Kohan. He followed Ceyadev for a short time, then broke away when it became apparent that Ceyadev only desired isolation. Shohn Maht desired power and decided that the mortals would be the perfect subjects. He managed to survive the next cataclysm and learned as much as he could about Ahriman and his plans. He then founded the religion known as the Nightbringers. Using his new power and influence he pledged himself to Ahriman's cause, ruling his kingdom as a tyrant. He is a master of dark magic and much of his kingdom is protected with hordes of the walking dead.	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\SIJANSUR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2413	UnitData Description	395	"Sijansur is a powerful general of the Ceyah forces. He was horrifically scarred in battle by magical forces, resulting in a terrible disfigurement his immortal body could not heal. He now wears a demonic-looking mask that has never been removed since the day he first placed it over his face. He is well known for his relentlessness in pursuing his enemies after they have broken from the field."	"Sijansur is a powerful general of the Ceyah forces. He was horrifically scarred in battle by magical forces, resulting in a terrible disfigurement his immortal body could not heal. He now wears a demonic-looking mask that has never been removed since the day he first placed it over his face. He is well known for his relentlessness in pursuing his enemies after they have broken from the field."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\SYRIUS_MAESUN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2414	UnitData Description	354	"Thaddeus Maesun is a very serious man. Humor is rarely allowed to touch upon his face. Awakened recently he has instantly rededicated his whole being to the destruction of anything linked to the Shadow. Unfortunately for creatures of shadow, Thaddeus is trained in the holy arts of the paladin, making him a perfect weapon to set against the Dark Master."	"Thaddeus Maesun is a very serious man. Humor is rarely allowed to touch upon his face. Awakened recently he has instantly rededicated his whole being to the destruction of anything linked to the Shadow. Unfortunately for creatures of shadow, Thaddeus is trained in the holy arts of the paladin, making him a perfect weapon to set against the Dark Master."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\THAIN_FOWLER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2415	UnitData Description	270	Thain Farouk is a very angry man. His face is seldom seen without a scowl decorating it. He is well known for his superior tactics when fighting archer companies and his ability to channel his anger in a way that focuses his efforts in a manner no other Kohan can match.	Thain Farouk is a very angry man. His face is seldom seen without a scowl decorating it. He is well known for his superior tactics when fighting archer companies and his ability to channel his anger in a way that focuses his efforts in a manner no other Kohan can match.	Hero Description
+2416	HeroData TranslatedName	12	Thain Farouk	Thain Farouk	Hero Name
+# Stripping \DATA\OBJECTDATA\HEROES\THE_HUNTER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2417	UnitData Description	362	"The Hunter is a rather mysterious Kohan, wearing a deep hooded cloak and a mask over his eyes. He keeps to himself, but appears to be determined to fight the Dark Master and his minions. His secrecy makes is hard for others to trust him though, and he is fine with that. So long as he gets done what he sets out to do, it matters little what others think of him."	"The Hunter is a rather mysterious Kohan, wearing a deep hooded cloak and a mask over his eyes. He keeps to himself, but appears to be determined to fight the Dark Master and his minions. His secrecy makes is hard for others to trust him though, and he is fine with that. So long as he gets done what he sets out to do, it matters little what others think of him."	Hero Description
+2418	HeroData TranslatedName	10	The Hunter	The Hunter	Hero Name
+# Stripping \DATA\OBJECTDATA\HEROES\VARGUS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2419	UnitData Description	276	"Vargus is another war-form kohan, only he has taken the form to extremes, becoming more animalistic and brutish than even the Drauga. Somewhat dumb-witted for a Kohan he is nonetheless a most dangerous opponent. Many have underestimated him and paid the price for their folly."	"Vargus is another war-form kohan, only he has taken the form to extremes, becoming more animalistic and brutish than even the Drauga. Somewhat dumb-witted for a Kohan he is nonetheless a most dangerous opponent. Many have underestimated him and paid the price for their folly."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\VASHTI.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2420	UnitData Description	244	"Once the faithful wife of Darius Javidan, Vashti was instrumental in the downfall of the Kohan and the catalyst of the first Great Cataclysm. She took the name Vashti and fled Kohan society to dedicate her immortal existance to the Dark Master."	"Once the faithful wife of Darius Javidan, Vashti was instrumental in the downfall of the Kohan and the catalyst of the first Great Cataclysm. She took the name Vashti and fled Kohan society to dedicate her immortal existance to the Dark Master."	Hero Description
+# Stripping \DATA\OBJECTDATA\HEROES\VULGARI.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2421	UnitData Description	279	"Vulgari is a dangerous Ceyah mage, one that knows no limits to his greed and avarice. He will let no one, not even the Dark Master, stand in his way when he decides he wants something. Many of the other Ceyah deal with him very carefully so as not to be perceived as an obstacle."	"Vulgari is a dangerous Ceyah mage, one that knows no limits to his greed and avarice. He will let no one, not even the Dark Master, stand in his way when he decides he wants something. Many of the other Ceyah deal with him very carefully so as not to be perceived as an obstacle."	Hero Description
+# Stripping \DATA\OBJECTDATA\PROJECTILES\ARROW.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2422	ObjectData ProperName	5	Arrow	Arrow	Projectile Name
+# Stripping \DATA\OBJECTDATA\PROJECTILES\CATAPULT_SHOT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2423	ObjectData ProperName	18	Catapult Shot Test	Catapult Shot Test	Projectile Name
+# Stripping \DATA\OBJECTDATA\PROJECTILES\DRAGON_BREATH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2424	ObjectData ProperName	13	Dragon Breath	Dragon Breath	Projectile Name
+# Stripping \DATA\OBJECTDATA\PROJECTILES\DRAKE_LIGHTNING.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2425	ObjectData ProperName	14	Lightning Bolt	Lightning Bolt	Projectile Name
+# Stripping \DATA\OBJECTDATA\PROJECTILES\DREADFIRE.INI...					
+# Stripping \DATA\OBJECTDATA\PROJECTILES\FIREBALL.INI...					
+# Stripping \DATA\OBJECTDATA\PROJECTILES\FLAMEARROW.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2426	ObjectData ProperName	12	Ranger Arrow	Ranger Arrow	Projectile Name
+# Stripping \DATA\OBJECTDATA\PROJECTILES\LIGHTNING.INI...					
+# Stripping \DATA\OBJECTDATA\PROJECTILES\METEOR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2427	ObjectData ProperName	6	Meteor	Meteor	Projectile Name
+# Stripping \DATA\OBJECTDATA\PROJECTILES\POISONSPIT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2428	ObjectData ProperName	12	Slaan Poison	Slaan Poison	Projectile Name
+# Stripping \DATA\OBJECTDATA\PROJECTILES\SHADOW_BREATHE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2429	ObjectData ProperName	13	Shadow Breath	Shadow Breath	Projectile Name
+# Stripping \DATA\OBJECTDATA\PROJECTILES\SHARDS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2430	ObjectData ProperName	11	Test Shards	Test Shards	Projectile Name
+# Stripping \DATA\OBJECTDATA\PROJECTILES\SPELL_ARROW.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2431	ObjectData ProperName	15	Invisible Arrow	Invisible Arrow	Projectile Name
+# Stripping \DATA\OBJECTDATA\PROJECTILES\WEB.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2432	ObjectData ProperName	14	Spider Webbing	Spider Webbing	Projectile Name
+# Stripping \DATA\OBJECTDATA\UNITS\AMON_KOTH'S_CHOSEN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2433	ObjectData ProperName	10	The Chosen	The Chosen	Unit Name
+2434	UnitData Description	104	"Twice as large as a normal Rhaksha, the Chosen of Amon Koth are picked from the most deadly Hivemasters."	"Twice as large as a normal Rhaksha, the Chosen of Amon Koth are picked from the most deadly Hivemasters."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\ARCHER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2435	ObjectData ProperName	6	Bowman	Bowman	Unit Name
+2436	UnitData Description	101	Bowmen fire volleys of deadly arrows at their targets. They are particularly useful against infantry.	Bowmen fire volleys of deadly arrows at their targets. They are particularly useful against infantry.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\ARCHER_MILITIA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2437	ObjectData ProperName	14	Archer Militia	Archer Militia	Unit Name
+2438	UnitData Description	100	Archer militia support their infantry comrades by firing volleys of deadly arrows at their targets.	Archer militia support their infantry comrades by firing volleys of deadly arrows at their targets.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\ARCHMAGE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2439	UnitData Description	165	The powerful Archmage is capable of wielding both priestly powers and arcane magic. He is both inspiring to the troops and assists in healing them outside of combat.	The powerful Archmage is capable of wielding both priestly powers and arcane magic. He is both inspiring to the troops and assists in healing them outside of combat.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\AVATAR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2440	UnitData Description	195	"Avatars are the ultimate holy warriors, destined to battle the shadow in every form it takes. They radiate auras that make men brave and increase their strength when battling creatures of shadow."	"Avatars are the ultimate holy warriors, destined to battle the shadow in every form it takes. They radiate auras that make men brave and increase their strength when battling creatures of shadow."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\BATTLE_PRIEST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2441	ObjectData ProperName	13	Battle Priest	Battle Priest	Unit Name
+2442	UnitData Description	110	The battle priest is trained to combat the shadow. They inspire their company to face the shadow without fear.	The battle priest is trained to combat the shadow. They inspire their company to face the shadow without fear.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\BRIGAND.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2443	ObjectData ProperName	7	Brigand	Brigand	Unit Name
+2444	UnitData Description	96	Brigands are nothing more than mercenary scoundrels who prey upon the weak when not campaigning.	Brigands are nothing more than mercenary scoundrels who prey upon the weak when not campaigning.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\CAPTAIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2445	UnitData Description	74	The captain is the fighting warrior trained to lead a company into battle.	The captain is the fighting warrior trained to lead a company into battle.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\CAVALIER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2446	UnitData Description	130	Cavaliers are the elite cavalry elements of the Kohan. They are more dangerous than normal dragoons and wield Khaldunite weaponry.	Cavaliers are the elite cavalry elements of the Kohan. They are more dangerous than normal dragoons and wield Khaldunite weaponry.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\CAVALRY_CAPTAIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2447	ObjectData ProperName	15	Cavalry Captain	Cavalry Captain	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\CHANNELER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2448	ObjectData ProperName	9	Channeler	Channeler	Unit Name
+2449	UnitData Description	130	Channelers are a type of priest that specialize in healing their troops en masse. They also help heal wounded troops out of combat.	Channelers are a type of priest that specialize in healing their troops en masse. They also help heal wounded troops out of combat.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\CITY_MILITIA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2450	ObjectData ProperName	16	Infantry Militia	Infantry Militia	Unit Name
+2451	UnitData Description	79	Infantry Militia are the better trained troops that defend cities and citadels.	Infantry Militia are the better trained troops that defend cities and citadels.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\CLERIC.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2452	ObjectData ProperName	6	Cleric	Cleric	Unit Name
+2453	UnitData Description	146	Clerics are basic priests that heal individual units and cast protection spells for the company. They also help heal wounded troops out of combat.	Clerics are basic priests that heal individual units and cast protection spells for the company. They also help heal wounded troops out of combat.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\CONJUROR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2454	UnitData Description	236	"Conjurors have delved into the dark side of summoning, able to summon creatures of shadow to fight for them. Outside of combat they use small nature spirits to aid in scouting their surroundings, increasing their company's visual range."	"Conjurors have delved into the dark side of summoning, able to summon creatures of shadow to fight for them. Outside of combat they use small nature spirits to aid in scouting their surroundings, increasing their company's visual range."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\CREATURE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2455	ObjectData ProperName	8	Creature	Creature	Unit Name
+2456	UnitData Description	73	"Foul creatures of unknown origin, these beasts are violent and dangerous."	"Foul creatures of unknown origin, these beasts are violent and dangerous."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\DAEVAI.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2457	ObjectData ProperName	8	Ceyahdev	Ceyahdev	Unit Name
+2458	UnitData Description	665	"Ceyahdev was one of the first Kohan Council members to turn her back on the rest of the council. She was a powerful and respected leader in the council, many other Kohan looked up to her. Many council members felt that her dissention had the greatest impact on the society's inability to counter the first cataclysm. She has grown more and more embittered over her role in the cataclysm and feels betrayed from all sides. She trusts no one and prefers total isolation over any form of contact with living creatures. To this end she has deformed into a shadowy, demonic beast that lives deep within a dark chasm. She destroys all creatures that wander near her lair."	"Ceyahdev was one of the first Kohan Council members to turn her back on the rest of the council. She was a powerful and respected leader in the council, many other Kohan looked up to her. Many council members felt that her dissention had the greatest impact on the society's inability to counter the first cataclysm. She has grown more and more embittered over her role in the cataclysm and feels betrayed from all sides. She trusts no one and prefers total isolation over any form of contact with living creatures. To this end she has deformed into a shadowy, demonic beast that lives deep within a dark chasm. She destroys all creatures that wander near her lair."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\DARK_WOLF.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2459	ObjectData ProperName	9	Dark Wolf	Dark Wolf	Unit Name
+2460	UnitData Description	99	"The hunting beasts of the Great Master, dark wolves search out his enemies and tear them to shreds."	"The hunting beasts of the Great Master, dark wolves search out his enemies and tear them to shreds."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\DEVOUT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2461	UnitData Description	233	"These priestesses have been so warped by their channeling of dark powers that they have become insane fanatics, capable of channeling terrifying spells. Their lust for death is infectious, bleeding over to the troops they travel with."	"These priestesses have been so warped by their channeling of dark powers that they have become insane fanatics, capable of channeling terrifying spells. Their lust for death is infectious, bleeding over to the troops they travel with."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\DRAGOON.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2462	ObjectData ProperName	7	Dragoon	Dragoon	Unit Name
+2463	UnitData Description	101	"Dragoons are the heavy cavalry elements of the Mareten. They are well armored, and even better armed."	"Dragoons are the heavy cavalry elements of the Mareten. They are well armored, and even better armed."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\DRAUGA_BEASTRIDER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2464	ObjectData ProperName	11	Beast Rider	Beast Rider	Unit Name
+2465	UnitData Description	84	"Riding their great warbeasts, the Drauga Beastriders make powerful cavalry elements."	"Riding their great warbeasts, the Drauga Beastriders make powerful cavalry elements."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\DRAUGA_BERSERKER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2466	ObjectData ProperName	9	Berserker	Berserker	Unit Name
+2467	UnitData Description	82	"The main troops of the Drauga, Berserkers are as dangerous as they are courageous."	"The main troops of the Drauga, Berserkers are as dangerous as they are courageous."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\DRAUGA_MILITIA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2468	ObjectData ProperName	14	Drauga Militia	Drauga Militia	Unit Name
+2469	UnitData Description	79	The Drauga Militia are weaker berserkers that defend their village from attack.	The Drauga Militia are weaker berserkers that defend their village from attack.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\DREADLORD.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2470	ObjectData ProperName	9	Dreadlord	Dreadlord	Unit Name
+2471	UnitData Description	196	"Dreadlords are the epitome of evil wrapped in a warrior's flesh. They revel in slaughter and enjoy nothing more than causing pain, inciting their troops to press the attack when the enemy falters."	"Dreadlords are the epitome of evil wrapped in a warrior's flesh. They revel in slaughter and enjoy nothing more than causing pain, inciting their troops to press the attack when the enemy falters."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\ELEMENTAL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2472	ObjectData ProperName	9	Elemental	Elemental	Unit Name
+2473	UnitData Description	179	"Elementals are powerful creatures of pure magic, born from rock and fire. They stun their foes with shockwaves sent through the ground and crush them with their massive fists."	"Elementals are powerful creatures of pure magic, born from rock and fire. They stun their foes with shockwaves sent through the ground and crush them with their massive fists."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\ELITE_ARCHER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2474	ObjectData ProperName	12	Elite Bowman	Elite Bowman	Unit Name
+2475	UnitData Description	101	"The archery forces of the Kohan, elite bowmen wield powerful bows that fire khaldunite tipped arrows."	"The archery forces of the Kohan, elite bowmen wield powerful bows that fire khaldunite tipped arrows."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\ENCHANTER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2476	UnitData Description	151	Enchanters are the masters of spell manipulation. They can both protect their own troops from magical attack and make spells more effective on enemies.	Enchanters are the masters of spell manipulation. They can both protect their own troops from magical attack and make spells more effective on enemies.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\ENGINEER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2477	ObjectData ProperName	8	Engineer	Engineer	Unit Name
+2478	UnitData Description	121	"Engineers are elite laborers, able to fulfill various roles in one's army, from sieging to repairing damaged settlements."	"Engineers are elite laborers, able to fulfill various roles in one's army, from sieging to repairing damaged settlements."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\FIRE_DRAGON.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2479	ObjectData ProperName	10	Fire Drake	Fire Drake	Unit Name
+2480	UnitData Description	137	Fire Dragons are amazingly powerful beasts of mystical wonder. No one knows where they came from or what purpose they follow  on Khaldun.	Fire Dragons are amazingly powerful beasts of mystical wonder. No one knows where they came from or what purpose they follow  on Khaldun.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\FOOTMAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2481	UnitData Description	97	"The basic Mareten infantry element, Footmen have inexpensive upkeep and are flexible in deployment."	"The basic Mareten infantry element, Footmen have inexpensive upkeep and are flexible in deployment."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\GAURI_ANVIL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2482	ObjectData ProperName	11	Gauri Anvil	Gauri Anvil	Unit Name
+2483	UnitData Description	122	The Gauri Anvils are the infantry teams designed to hold the enemy in check until the Hammers can sweep in and crush them.	The Gauri Anvils are the infantry teams designed to hold the enemy in check until the Hammers can sweep in and crush them.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\GAURI_HAMMER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2484	ObjectData ProperName	12	Gauri Hammer	Gauri Hammer	Unit Name
+2485	UnitData Description	81	Gauri Hammers are the powerful cavalry elements that complement the Gauri Anvils.	Gauri Hammers are the powerful cavalry elements that complement the Gauri Anvils.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\GAURI_MILITIA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2486	ObjectData ProperName	13	Gauri Militia	Gauri Militia	Unit Name
+2487	UnitData Description	92	The Gauri Militia are the warriors trained to safeguard the Gauri Stronghold against attack.	The Gauri Militia are the warriors trained to safeguard the Gauri Stronghold against attack.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\GIANT_SPIDER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2488	ObjectData ProperName	12	Giant Spider	Giant Spider	Unit Name
+2489	UnitData Description	103	"Mutated by stray magicks and the taint of the Cataclysms, these horrors have appeared all over Khaldun."	"Mutated by stray magicks and the taint of the Cataclysms, these horrors have appeared all over Khaldun."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\GOLEM.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2490	ObjectData ProperName	5	Golem	Golem	Unit Name
+2491	UnitData Description	143	Golems are weaker cousins of the Elemental. They are produced en masse by wizardry guilds to create mindless warriors that feel no pain or fear.	Golems are weaker cousins of the Elemental. They are produced en masse by wizardry guilds to create mindless warriors that feel no pain or fear.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\GRENADIER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2492	ObjectData ProperName	9	Grenadier	Grenadier	Unit Name
+2493	UnitData Description	113	"Grenadiers are the elite heavy infantry elements of the Mareten. They are slow, but heavily armored and powerful."	"Grenadiers are the elite heavy infantry elements of the Mareten. They are slow, but heavily armored and powerful."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\HAROUN_ARCHER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2494	ObjectData ProperName	11	Rainbringer	Rainbringer	Unit Name
+2495	UnitData Description	106	"The Rainbringers are deadly Haroun bowmen, firing powerful bows and wearing special arrow resistant armor."	"The Rainbringers are deadly Haroun bowmen, firing powerful bows and wearing special arrow resistant armor."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\HAROUN_MILITIA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2496	ObjectData ProperName	14	Haroun Militia	Haroun Militia	Unit Name
+2497	UnitData Description	78	Haroun Militia are bowmen dedicated to protect the Haroun Village from attack.	Haroun Militia are bowmen dedicated to protect the Haroun Village from attack.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\INFANTRY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2498	ObjectData ProperName	8	Infantry	Infantry	Unit Name
+2499	UnitData Description	88	"Infantry are the common foot troops of the Mareten, balancing speed, attack and defense."	"Infantry are the common foot troops of the Mareten, balancing speed, attack and defense."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\LICH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2500	UnitData Description	258	"The lich is a special form of Wraith, even more terrifying in power and capacity for evil. They have an innate ability to see beyond normal reality, increasing their awareness of their surroundings and enabling their company to increase its zone of control."	"The lich is a special form of Wraith, even more terrifying in power and capacity for evil. They have an innate ability to see beyond normal reality, increasing their awareness of their surroundings and enabling their company to increase its zone of control."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\NECROMANCER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2501	ObjectData ProperName	11	Necromancer	Necromancer	Unit Name
+2502	UnitData Description	191	"The foul Necromancer is capable of summoning up the very corpses of the dead to do battle for him. He is also known for poisoning the air around his enemies, rendering them weak and helpless."	"The foul Necromancer is capable of summoning up the very corpses of the dead to do battle for him. He is also known for poisoning the air around his enemies, rendering them weak and helpless."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\PALADIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2503	ObjectData ProperName	7	Paladin	Paladin	Unit Name
+2504	UnitData Description	208	"Paladins are powerful warriors of faith, prepared to lay down their lives in the fight against the shadow. They radiate auras that make men brave and increase their strength when battling creatures of shadow."	"Paladins are powerful warriors of faith, prepared to lay down their lives in the fight against the shadow. They radiate auras that make men brave and increase their strength when battling creatures of shadow."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\PATHFINDER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2505	UnitData Description	208	"Pathfinders are specially trained, elite members of the secret Ranger society. Their skills in the wilderness allow their company to move unhindered by difficult terrain and extend the company's visual range."	"Pathfinders are specially trained, elite members of the secret Ranger society. Their skills in the wilderness allow their company to move unhindered by difficult terrain and extend the company's visual range."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\PROPHET.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2506	ObjectData ProperName	7	Prophet	Prophet	Unit Name
+2507	UnitData Description	267	"The virtually insane priests of the Great Master, Prophets are known for their spells that drain the life of their enemies and paralyze them through tremendous assaults of pain and fear. Their lust for death is infectious, bleeding over to the troops they travel with."	"The virtually insane priests of the Great Master, Prophets are known for their spells that drain the life of their enemies and paralyze them through tremendous assaults of pain and fear. Their lust for death is infectious, bleeding over to the troops they travel with."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\RANGER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2508	ObjectData ProperName	6	Ranger	Ranger	Unit Name
+2509	UnitData Description	234	Rangers are members of a secret group of warriors who wield mystical weapons that work as bow and blade. Their skills in the wilderness allow their company to move unhindered by difficult terrain and extend the company's visual range.	Rangers are members of a secret group of warriors who wield mystical weapons that work as bow and blade. Their skills in the wilderness allow their company to move unhindered by difficult terrain and extend the company's visual range.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\REAVER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2510	UnitData Description	102	Evil magicks have summoned forth skeletal warriors to wreak havoc upon the enemies of the Dark Master.	Evil magicks have summoned forth skeletal warriors to wreak havoc upon the enemies of the Dark Master.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\RHAKSHA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2511	UnitData Description	92	"Foul creatures of unknown origin, Rhaksha have swarmed over Khaldun defiling all they touch."	"Foul creatures of unknown origin, Rhaksha have swarmed over Khaldun defiling all they touch."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\RHAKSHA_HIVEMASTER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2512	ObjectData ProperName	18	Rhaksha Hivemaster	Rhaksha Hivemaster	Unit Name
+2513	UnitData Description	103	"Twice as large as a normal Rhaksha, Hivemasters rule over the larger colonies that occasionally appear."	"Twice as large as a normal Rhaksha, Hivemasters rule over the larger colonies that occasionally appear."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\RHAKSHA_HUNTER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2514	ObjectData ProperName	14	Rhaksha Hunter	Rhaksha Hunter	Unit Name
+2515	UnitData Description	134	"Stronger and more deadly than their fellow Rhaksha, the hunters are used by Amon Koth to hunt down and slaughter those who oppose him."	"Stronger and more deadly than their fellow Rhaksha, the hunters are used by Amon Koth to hunt down and slaughter those who oppose him."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\RHAKSHA_LEADER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2516	ObjectData ProperName	18	Rhaksha Huntmaster	Rhaksha Huntmaster	Unit Name
+2517	UnitData Description	135	"Nearly as dangerous as Amon Koth's Chosen, Huntmasters are powerful creatures who drive the Rhaksha Hunters forward in pursuit of prey."	"Nearly as dangerous as Amon Koth's Chosen, Huntmasters are powerful creatures who drive the Rhaksha Hunters forward in pursuit of prey."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\RHAKSHA_SLAVE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2518	UnitData Description	79	These violent creatures have been enslaved to be used as fodder in mortal wars.	These violent creatures have been enslaved to be used as fodder in mortal wars.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SCOUT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2519	UnitData Description	89	"Built for speed and reconnaissance, Scouts are the light cavalry elements of the Mareten."	"Built for speed and reconnaissance, Scouts are the light cavalry elements of the Mareten."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SETTLER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2520	ObjectData ProperName	7	Settler	Settler	Unit Name
+2521	UnitData Description	108	Settlers are the men and women who forge through unknown paths to build new villages to support the kingdom.	Settlers are the men and women who forge through unknown paths to build new villages to support the kingdom.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SHADELING.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2522	ObjectData ProperName	9	Shadeling	Shadeling	Unit Name
+2523	UnitData Description	88	"Small and vicious, Shadelings are the embodiment of spite among the creatures of shadow."	"Small and vicious, Shadelings are the embodiment of spite among the creatures of shadow."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SHADELING_SCOUT.INI...					
+# Stripping \DATA\OBJECTDATA\UNITS\SHADOW_BEAST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2524	ObjectData ProperName	12	Shadow Beast	Shadow Beast	Unit Name
+2525	UnitData Description	115	"Shadow Beasts are demonic creatures, fearsome in appearance and strength. They are the cavalry of the Great Master."	"Shadow Beasts are demonic creatures, fearsome in appearance and strength. They are the cavalry of the Great Master."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SHADOW_CAPTAIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2526	ObjectData ProperName	14	Shadow Captain	Shadow Captain	Unit Name
+2527	UnitData Description	101	Shadow Captains are highly intelligent shadow demons capable of leading lesser creatures into battle.	Shadow Captains are highly intelligent shadow demons capable of leading lesser creatures into battle.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SHADOW_DEMON.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2528	ObjectData ProperName	12	Shadow Demon	Shadow Demon	Unit Name
+2529	UnitData Description	264	Shadow Demons are dangerous creatures from the realm of the shadow. They are able to summon other shadow forces to fight along side them and are difficult to destroy in personal combat. 	Shadow Demons are dangerous creatures from the realm of the shadow. They are able to summon other shadow forces to fight along side them and are difficult to destroy in personal combat. 	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SHADOW_DEVIL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2530	UnitData Description	134	Shadow Demons are dangerous creatures from the realm of the shadow. They are able to summon other shadow forces to fight along side them.	Shadow Demons are dangerous creatures from the realm of the shadow. They are able to summon other shadow forces to fight along side them.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SHADOW_LORD.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2531	ObjectData ProperName	11	Shadow Lord	Shadow Lord	Unit Name
+2532	UnitData Description	192	Shadow Lords are the most dangerous of all shadow creatures. They are capable of summoning other shadow creatures to fight along side of them. Though they are dangerous enough without minions.	Shadow Lords are the most dangerous of all shadow creatures. They are capable of summoning other shadow creatures to fight along side of them. Though they are dangerous enough without minions.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SHADOW_MONSTER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2533	UnitData Description	73	"Shadow Beasts are demonic creatures, fearsome in appearance and strength."	"Shadow Beasts are demonic creatures, fearsome in appearance and strength."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SHADOW_PRIEST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2534	ObjectData ProperName	13	Shadow Priest	Shadow Priest	Unit Name
+2535	UnitData Description	298	"Shadow Priests are dedicated to the evil of the shadow, capable of casting spells that bless their troops with demonic fury and stun their enemy with sheer pain. They also have the ability to deaden their troops' reaction to fear and pain, causing them to fight without concern for themselves."	"Shadow Priests are dedicated to the evil of the shadow, capable of casting spells that bless their troops with demonic fury and stun their enemy with sheer pain. They also have the ability to deaden their troops' reaction to fear and pain, causing them to fight without concern for themselves."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SHOCK_TROOPER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2536	UnitData Description	104	No ground troop is more deadly than the Kohan Elite Guard. Few can stand before them on the field of battle.	No ground troop is more deadly than the Kohan Elite Guard. Few can stand before them on the field of battle.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SKELETON.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2537	ObjectData ProperName	16	Skeleton Warrior	Skeleton Warrior	Unit Name
+# Stripping \DATA\OBJECTDATA\UNITS\SLAAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2538	UnitData Description	126	The Slaan are a strange race of reptile-men that occupy abandoned cities and ancient ruins in addition to their mud-hut lairs.	The Slaan are a strange race of reptile-men that occupy abandoned cities and ancient ruins in addition to their mud-hut lairs.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SLAAN_CHAMPION.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2539	ObjectData ProperName	8	Champion	Champion	Unit Name
+2540	UnitData Description	110	The Slaan Champion is the strongest and most deadly of Slaan that fight for the Slaan Villages of Dragonbone Isle.	The Slaan Champion is the strongest and most deadly of Slaan that fight for the Slaan Villages of Dragonbone Isle.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SLAAN_MILITIA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2541	ObjectData ProperName	13	Slaan Militia	Slaan Militia	Unit Name
+2542	UnitData Description	96	The Slaan Militia are special breed of Slaan that protect the Slaan Villages of Dragonbone Isle.	The Slaan Militia are special breed of Slaan that protect the Slaan Villages of Dragonbone Isle.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SORCERESS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2543	ObjectData ProperName	9	Sorceress	Sorceress	Unit Name
+2544	UnitData Description	209	The Sorceress is the ultimate ice queen. She is capable of surrounding herself in icy winds and freezing her foes solid with blasts of frost. Their displays of raw power also serve to inspire their own troops.	The Sorceress is the ultimate ice queen. She is capable of surrounding herself in icy winds and freezing her foes solid with blasts of frost. Their displays of raw power also serve to inspire their own troops.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\STORM_DRAKE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2545	ObjectData ProperName	11	Storm Drake	Storm Drake	Unit Name
+2546	UnitData Description	121	The powerful Storm Drake rides the storms of Khaldun calling down the fires of the sky to destroy everything in its path.	The powerful Storm Drake rides the storms of Khaldun calling down the fires of the sky to destroy everything in its path.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\SUMMONER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2547	ObjectData ProperName	8	Summoner	Summoner	Unit Name
+2548	UnitData Description	269	"Summoners are the masters of conjuring up beings under their control. They are able to summon a huge elemental beast to battle their enemies. Outside of combat they use small nature spirits to aid in scouting their surroundings, increasing their company's visual range."	"Summoners are the masters of conjuring up beings under their control. They are able to summon a huge elemental beast to battle their enemies. Outside of combat they use small nature spirits to aid in scouting their surroundings, increasing their company's visual range."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\THIMURGH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2549	ObjectData ProperName	7	Simurgh	Simurgh	Unit Name
+2550	UnitData Description	608	"Simurgh is one of the most vile of all the Ceyah Kohan, one of the few that had fallen so far as to commit murder upon his fellow Kohan during the confusion of the first Cataclysm. He has become so twisted that he has forgotten what it was like to be a normal member of Kohan society. All he sees in himself anymore is a monster, and a monster he has become. Simurgh has mutated into a huge beast with the general shape of a dragon, but many aspects of an insect or spider. He has six limbs and his body is covered in slimy, segmented armor. Most frightening of all, Simurgh has developed a taste for fresh blood."	"Simurgh is one of the most vile of all the Ceyah Kohan, one of the few that had fallen so far as to commit murder upon his fellow Kohan during the confusion of the first Cataclysm. He has become so twisted that he has forgotten what it was like to be a normal member of Kohan society. All he sees in himself anymore is a monster, and a monster he has become. Simurgh has mutated into a huge beast with the general shape of a dragon, but many aspects of an insect or spider. He has six limbs and his body is covered in slimy, segmented armor. Most frightening of all, Simurgh has developed a taste for fresh blood."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\UNDEAD.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2551	ObjectData ProperName	6	Undead	Undead	Unit Name
+2552	UnitData Description	100	Evil magicks have reanimated the skeletal remains of mortal beings to create these twisted monsters.	Evil magicks have reanimated the skeletal remains of mortal beings to create these twisted monsters.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\UNDEAD_ARCHER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2553	ObjectData ProperName	8	Bone Bow	Bone Bow	Unit Name
+2554	UnitData Description	114	These undead archers fire powerful crossbow bolts at their targets. They are particularly useful against infantry.	These undead archers fire powerful crossbow bolts at their targets. They are particularly useful against infantry.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\UNDEAD_CAPTAIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2555	ObjectData ProperName	14	Undead Captain	Undead Captain	Unit Name
+2556	UnitData Description	88	The undead captain is the unholy monster created to lead the forces of evil into battle.	The undead captain is the unholy monster created to lead the forces of evil into battle.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\VILLAGE_MILITIA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2557	UnitData Description	71	Militia are combat elements that defend villages and towns from sieges.	Militia are combat elements that defend villages and towns from sieges.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\VOID_BEAST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2558	ObjectData ProperName	10	Void Beast	Void Beast	Unit Name
+2559	UnitData Description	197	Void Beasts are horrific creatures similar to the Shadow Beasts. They come from deep within a subterranean realm in the Shadow dimension. Special magicks are required to summon forth these horrors.	Void Beasts are horrific creatures similar to the Shadow Beasts. They come from deep within a subterranean realm in the Shadow dimension. Special magicks are required to summon forth these horrors.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\WARLOCK.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2560	UnitData Description	197	The enigmatic warlock is privy to strange and powerful magics. They first weaken their enemies then destroy them with great torrents of flame. Their very presence inhibits the magic of enemy mages.	The enigmatic warlock is privy to strange and powerful magics. They first weaken their enemies then destroy them with great torrents of flame. Their very presence inhibits the magic of enemy mages.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\WARMAGE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2561	ObjectData ProperName	8	Magician	Magician	Unit Name
+2562	UnitData Description	200	"Magicians are the masters of fire, throwing churning blasts at their enemies and wrapping themselves in protective sheaths of flame. Their displays of raw power also serve to inspire their own troops."	"Magicians are the masters of fire, throwing churning blasts at their enemies and wrapping themselves in protective sheaths of flame. Their displays of raw power also serve to inspire their own troops."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\WINDRIDER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2563	ObjectData ProperName	9	Windrider	Windrider	Unit Name
+2564	UnitData Description	152	Haroun Windriders are the swiftest and most maneuverable of the cavalry elements. Entering battle astride their agile steeds and wielding powerful bows.	Haroun Windriders are the swiftest and most maneuverable of the cavalry elements. Entering battle astride their agile steeds and wielding powerful bows.	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\WIZARD.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2565	ObjectData ProperName	6	Wizard	Wizard	Unit Name
+2566	UnitData Description	212	"Wizards are the lords of the storm. They can smite their enemy from a distance with demoralizing bolts of lightning. During combat, they stir up powerful winds that interfere with the arrows of attacking archers."	"Wizards are the lords of the storm. They can smite their enemy from a distance with demoralizing bolts of lightning. During combat, they stir up powerful winds that interfere with the arrows of attacking archers."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\WRAITH.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2567	UnitData Description	275	"Wraiths are truly horrific creatures. These undead shadow mages are capable of wielding the awesome darkfire element. They have an innate ability to see beyond normal reality, increasing their awareness of their surroundings and enabling their company to increase its zone of control."	"Wraiths are truly horrific creatures. These undead shadow mages are capable of wielding the awesome darkfire element. They have an innate ability to see beyond normal reality, increasing their awareness of their surroundings and enabling their company to increase its zone of control."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\YOUNG_DRAGON.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2568	ObjectData ProperName	12	Young Dragon	Young Dragon	Unit Name
+2569	UnitData Description	145	"Young fire drakes have begun to appear around Khaldun. They are smaller versions of their flame-spouting parents, though not nearly as dangerous."	"Young fire drakes have begun to appear around Khaldun. They are smaller versions of their flame-spouting parents, though not nearly as dangerous."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\ZEALOT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2570	ObjectData ProperName	6	Zealot	Zealot	Unit Name
+2571	UnitData Description	210	"Nationalist priests so dedicated to their cause they are willing to channel shadow energy to gain an advantage. They encourage their troops to act without mercy, increasing their attacks when an enemy retreats."	"Nationalist priests so dedicated to their cause they are willing to channel shadow energy to gain an advantage. They encourage their troops to act without mercy, increasing their attacks when an enemy retreats."	Unit Description
+# Stripping \DATA\OBJECTDATA\UNITS\ZOMBIE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2572	ObjectData ProperName	6	Zombie	Zombie	Unit Name
+2573	UnitData Description	100	"Torn from the grave to serve the powers of evil, Zombies are the undead infantry of the Dark Master."	"Torn from the grave to serve the powers of evil, Zombies are the undead infantry of the Dark Master."	Unit Description
+# Stripping \DATA\PRESETS\FOOTMAN_ARCHER_SUPPORT.INI...					
+# Stripping \DATA\PRESETS\HOLY_AVENGERS.INI...					
+# Stripping \DATA\PRESETS\SHADOW_COMPANY.INI...					
+# Stripping \DATA\SAIDATA\SAIPOLITICSSETTINGS.INI...					
+# Stripping \DATA\SCENARIODATA\SCENARIO.INI...					
+# Stripping \DATA\TERRAINDATA\CLIMATES.INI...					
+# Stripping \DATA\TERRAINDATA\MAP.INI...					
+# Stripping \DATA\TERRAINDATA\TERRAIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2574	Evil Propername	7	Corrupt	Corrupt	Terrain Name
+2575	Forest2 ProperName	13	Forest	Forest	Terrain Name
+2576	DesertMountain Propername	15	Desert Mountain	Desert Mountain	Terrain Name
+# Stripping \SAI\CHAMBERLAIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2577	GeneralSettings name	5	Midas	Midas	AI Name
+2578	GeneralSettings description	39	"Loyal and friendly, influenced by gold."	"Loyal and friendly, influenced by gold."	AI Description
+# Stripping \SAI\CRAZY_IVAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2579	GeneralSettings name	10	Crazy Eben	Crazy Eben	AI Name
+2580	GeneralSettings description	38	Crazy Eben does a lot of random things	Crazy Eben does a lot of random things	AI Description
+# Stripping \SAI\DARIUS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2581	GeneralSettings name	6	Darius	Darius	AI Name
+2582	GeneralSettings description	42	Darius I ruled Persia from 522 to 486 B.C.	Darius I ruled Persia from 522 to 486 B.C.	AI Description
+# Stripping \SAI\DEFAULT.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2583	GeneralSettings name	7	Tluafed	Tluafed	AI Name
+2584	GeneralSettings description	23	The default SAI profile	The default SAI profile	AI Description
+# Stripping \SAI\GHANDI.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2585	GeneralSettings name	9	Hammurabi	Hammurabi	AI Name
+2586	GeneralSettings description	53	Hammurabi likes to make peace treaties and alliances.	Hammurabi likes to make peace treaties and alliances.	AI Description
+# Stripping \SAI\GHENGIS_KHAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2587	GeneralSettings name	4	Khan	Khan	AI Name
+2588	GeneralSettings description	98	"Ghengis Khan is an aggressive leader, proud, militaristic and vengeful.  Oh, and he likes horsies."	"Ghengis Khan is an aggressive leader, proud, militaristic and vengeful.  Oh, and he likes horsies."	AI Description
+# Stripping \SAI\HANNIBAL.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2589	GeneralSettings name	8	Hannibal	Hannibal	AI Name
+2590	GeneralSettings description	112	Hannibal of Carthage kicked the Roman Empire's backside all over the Mediterrean Basin. Archers... likes archers	Hannibal of Carthage kicked the Roman Empire's backside all over the Mediterrean Basin. Archers... likes archers	AI Description
+# Stripping \SAI\LEE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2591	GeneralSettings name	6	Xerxes	Xerxes	AI Name
+2592	GeneralSettings description	25	Xerxes I (485 - 465 B.C.)	Xerxes I (485 - 465 B.C.)	AI Description
+# Stripping \SAI\MERLIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2593	GeneralSettings name	14	Nebuchadrezzar	Nebuchadrezzar	AI Name
+2594	GeneralSettings description	252	"Nebuchadrezzar II (Babylonia 605 - 562 B.C.) likes diplomacy, but only as a means to an end, like world domination.  He likes mages, but doesn't trust clerics.  He also is fond of heavily armored knights, both on horse and on foot (Dragoons/Grenadiers)"	"Nebuchadrezzar II (Babylonia 605 - 562 B.C.) likes diplomacy, but only as a means to an end, like world domination.  He likes mages, but doesn't trust clerics.  He also is fond of heavily armored knights, both on horse and on foot (Dragoons/Grenadiers)"	AI Description
+# Stripping \SAI\NAPOLEAN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2595	GeneralSettings name	11	Mithridates	Mithridates	AI Name
+2596	GeneralSettings description	111	Mithridates I ruled the Arsacid Parthians between 171 and 138 B.C. Likes Religious units = Temples and healers.	Mithridates I ruled the Arsacid Parthians between 171 and 138 B.C. Likes Religious units = Temples and healers.	AI Description
+# Stripping \SAI\RENLY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2597	GeneralSettings name	6	Sargon	Sargon	AI Name
+2598	GeneralSettings description	150	"Sargon II (Assyria, 721 - 705 B.C.) A knight's knight.  Well, at least a jousting knight's knight.  His idea of war is a tournament on a grander scale"	"Sargon II (Assyria, 721 - 705 B.C.) A knight's knight.  Well, at least a jousting knight's knight.  His idea of war is a tournament on a grander scale"	AI Description
+# Stripping \SAI\STALIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2599	GeneralSettings name	5	Cyrus	Cyrus	AI Name
+2600	GeneralSettings description	205	"Cyrus II (Persia, 559 - 530 B.C.) believes in LOTS of infantry and crushing all in his path, enemy and ally alike.  It is tough to stay on his good side, he can be rather random and changes his mind easily"	"Cyrus II (Persia, 559 - 530 B.C.) believes in LOTS of infantry and crushing all in his path, enemy and ally alike.  It is tough to stay on his good side, he can be rather random and changes his mind easily"	AI Description
+# Stripping \SAI\TROY.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+2601	GeneralSettings name	9	Artabanus	Artabanus	AI Name
+2602	GeneralSettings description	53	Artabanus likes settlers...lots and lots of settlers!	Artabanus likes settlers...lots and lots of settlers!	AI Description
+# Stripping \SAVE\_PANIC.TGM...					
+#					
+"# Found 2603 strings (2603 new strings), beginning string insertion..."					
+#					
+# Inserting Remap Defines...					
+#					
+# Stripper done.					

--- a/TGX Files/Data/LOCALIZED/STRINGS_05.INI
+++ b/TGX Files/Data/LOCALIZED/STRINGS_05.INI
@@ -1,0 +1,382 @@
+# Language = English ; change this to the name of the language being localized to
+# String Stripper v2.7 (c)2001 TimeGate Studios
+# Compiled - Jun 12 2001 17:05:01
+# Run - 6/12/2001 6:19:00 PM
+# Loaded 2603 strings from c:\PAT\Map Editor\Data\Localized\Strings_01.ini.
+# Loaded 351 strings from c:\PAT\Map Editor\Data\Localized\Strings_02.ini.
+# Loaded 65 strings from c:\PAT\Map Editor\Data\Localized\Strings_03.ini.
+# Loaded 663 strings from c:\PAT\Map Editor\Data\Localized\Strings_04.ini.
+# Change ""Localized Text"" column to a string that approximates the meaning of the ""Source Text"" string"
+# 
+# Any text may be added to ""Comment"" column, this is used only for the translator's notes, will not be visible in game"
+# 
+# Save intermediate changes in Excel format, but final ""Strings_01.ini"" file must be in tab-delimited format"
+# 
+# Do not insert new columns
+# 
+# New rows may be inserted, but only for comment purposes, any rows starting with '#' will be ignored as comments"					
+# 					
+# Scanning 'C:\PAT\MAP EDITOR\' for source files to strip...					
+# Stripping \DATA\BONUS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3682	ATTACK_BONUS_TO_NONSHADOW name1	9	Lightbane	Lightbane	
+3683	ATTACK_BONUS_TO_NONSHADOW name2	10	Eosophobia	Eosophobia	
+3684	ATTACK_BONUS_TO_NONSHADOW Description2	49	Decreases attacks against shadow elements by %+d.	Decreases attacks against shadow elements by %+d.	
+3685	RELOAD_TIME_BONUS name1	5	Tired	Tired	
+3686	RELOAD_TIME_BONUS name2	5	Haste	Haste	
+3687	RELOAD_TIME_BONUS Description1	49	Increases attack recovery time to %d%% of normal.	Increases attack recovery time to %d%% of normal.	
+3688	RELOAD_TIME_BONUS Description2	49	Decreases attack recovery time to %d%% of normal.	Decreases attack recovery time to %d%% of normal.	
+# Stripping \DATA\INTERFACEDATA\COMPANY_EDITOR.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3689	SelectPreset ToolTipText	36	(#c TG_YELLOW ###r) Load Preset Slot	(#c TG_YELLOW ###r) Load Preset Slot	
+3690	SetPreset ToolTipText	59	(#c TG_YELLOW Ctrl-###r) Save Current Layout in Preset Slot	(#c TG_YELLOW Ctrl-###r) Save Current Layout in Preset Slot	
+# Stripping \DATA\INTERFACEDATA\DOWNLOAD.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3691	Button1 Text	11	Downloading	Downloading	
+# Stripping \DATA\INTERFACEDATA\GAME_INTERFACE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3692	Button42 ToolTipText	16	Upgrade Building	Upgrade Building	
+3693	Button43 ToolTipText	14	Cancel Upgrade	Cancel Upgrade	
+# Stripping \DATA\INTERFACEDATA\GENERATORSETTINGS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3694	ClimatesValue Text	8	Climates	Climates	
+# Stripping \DATA\INTERFACEDATA\HOST.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3695	ValueGamePassword Text	8	Password	Password	
+# Stripping \DATA\INTERFACEDATA\MULTIPLAYER.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3696	Button5 ToolTipText	20	Change the Game Info	Change the Game Info	
+3697	Button5 ButtonText	9	Game Info	Game Info	
+# Stripping \DATA\INTERFACEDATA\OPTIONS.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3698	value_unit_acknowledgements Text	21	Unit Acknowledgements	Unit Acknowledgements	
+3699	value_reverse_stereo Text	14	Reverse Stereo	Reverse Stereo	
+3700	value_chat_sounds Text	11	Chat Sounds	Chat Sounds	
+# Stripping \DATA\OBJECTDATA\PROJECTILES\ERUPTION_PROJECTILE.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3701	ObjectData ProperName	15	Ground Eruption	Ground Eruption	
+# Stripping \DATA\OBJECTDATA\UNITS\SHADOW_MILITIA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3702	ObjectData ProperName	14	Shadow Militia	Shadow Militia	
+# Stripping \DATA\OBJECTDATA\UNITS\UNDEAD_MILITIA.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3703	ObjectData ProperName	14	Undead Militia	Undead Militia	
+# Stripping \DATA\TERRAINDATA\TERRAIN.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3704	Expansion1 ProperName	11	Snow Forest	Snow Forest	
+3705	Expansion2Mountain Propername	13	Snow Mountain	Snow Mountain	
+# Stripping \MAPS\ARMAGEDDON.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3706	Trigger		Drauga Village - Moggok	Drauga Village - Moggok	trigger description - no localization necessary
+3707	Trigger		Royalist Town - Gold	Royalist Town - Gold	trigger description - no localization necessary
+3708	Trigger		Neutral Citadel - Ilyana and Archmage	Neutral Citadel - Ilyana and Archmage	trigger description - no localization necessary
+3709	Trigger		Ruin 5 - Ruarc Varagoth and WSB	Ruin 5 - Ruarc Varagoth and WSB	trigger description - no localization necessary
+3710	Trigger		Ruin 4 - Enchanter and Magic Arrow	Ruin 4 - Enchanter and Magic Arrow	trigger description - no localization necessary
+3711	Trigger		Monlith 1 - The Hunter	Monlith 1 - The Hunter	trigger description - no localization necessary
+3712	Trigger		Rhaksha Hive - Thaddeus Maesun	Rhaksha Hive - Thaddeus Maesun	trigger description - no localization necessary
+3713	Trigger		ruin 3 - gold	ruin 3 - gold	trigger description - no localization necessary
+3714	Trigger		ruin 2 - conjuror tech	ruin 2 - conjuror tech	trigger description - no localization necessary
+3715	Trigger		ruin 1 - Sarai Marusek	ruin 1 - Sarai Marusek	trigger description - no localization necessary
+3716	Trigger		bandit camp east	bandit camp east	trigger description - no localization necessary
+3717	Trigger		bandit camp west	bandit camp west	trigger description - no localization necessary
+3718	Trigger		STRING_3615	STRING_3615	trigger description - no localization necessary
+# Stripping \MAPS\CROP_CIRCLE.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3719	Trigger		Rhaksha Nest - WS Blades	Rhaksha Nest - WS Blades	trigger description - no localization necessary
+3720	Trigger		Slaan Lair - Eban Baruch	Slaan Lair - Eban Baruch	trigger description - no localization necessary
+3721	Trigger		Spider Lair - Warlock	Spider Lair - Warlock	trigger description - no localization necessary
+3722	Trigger		Bandit Camp - Archmage	Bandit Camp - Archmage	trigger description - no localization necessary
+3723	Trigger		Slaan Lair - Healing Potion	Slaan Lair - Healing Potion	trigger description - no localization necessary
+3724	Trigger		Monolith - Ironwood Bow	Monolith - Ironwood Bow	trigger description - no localization necessary
+3725	Trigger		Rhaksha Hive - Seth Aswan	Rhaksha Hive - Seth Aswan	trigger description - no localization necessary
+3726	Trigger		Ruins 2 - Holy Blades	Ruins 2 - Holy Blades	trigger description - no localization necessary
+3727	Trigger		Spider Lair - Rhaksha Slave	Spider Lair - Rhaksha Slave	trigger description - no localization necessary
+3728	Trigger		Ruins 1 - Leila Javidan	Ruins 1 - Leila Javidan	trigger description - no localization necessary
+3729	Trigger		Dragon Lair - Garadun Payne	Dragon Lair - Garadun Payne	trigger description - no localization necessary
+3730	Trigger		Dragon Lair - Dragon Dust	Dragon Lair - Dragon Dust	trigger description - no localization necessary
+3731	Trigger		Dragon Lair - Kendra Langston	Dragon Lair - Kendra Langston	trigger description - no localization necessary
+3732	Trigger		Dragon Lair - Dragonscale	Dragon Lair - Dragonscale	trigger description - no localization necessary
+3733	Trigger		Dragon Lair - Dylan Garwood	Dragon Lair - Dylan Garwood	trigger description - no localization necessary
+# Stripping \MAPS\DRAGON_BREEDERS.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3734	Trigger		Haroun Village - Khaldunite Arrow	Haroun Village - Khaldunite Arrow	trigger description - no localization necessary
+3735	Trigger		Council City - Archmage	Council City - Archmage	trigger description - no localization necessary
+3736	Trigger		Ceyah Village - Bone Reaver	Ceyah Village - Bone Reaver	trigger description - no localization necessary
+3737	Trigger		Gauri Village - WS Blades	Gauri Village - WS Blades	trigger description - no localization necessary
+3738	Trigger		Nationalist Village - Enchanted Leather	Nationalist Village - Enchanted Leather	trigger description - no localization necessary
+3739	Trigger		Drauga Village - Potion of Strength	Drauga Village - Potion of Strength	trigger description - no localization necessary
+3740	Trigger		STRING_3622	STRING_3622	trigger description - no localization necessary
+# Stripping \MAPS\DRAGON_HUNT.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3741	Trigger		STRING_3625	STRING_3625	trigger description - no localization necessary
+3742	Trigger		Gauri - Silk Armor	Gauri - Silk Armor	trigger description - no localization necessary
+3743	Trigger		Ruins 2 - Sarai Marusek	Ruins 2 - Sarai Marusek	trigger description - no localization necessary
+3744	Trigger		Ruins - Gold	Ruins - Gold	trigger description - no localization necessary
+3745	Trigger		Rhaksha Nest - Potion Strength	Rhaksha Nest - Potion Strength	trigger description - no localization necessary
+3746	Trigger		Bandit camp - Lazarus	Bandit camp - Lazarus	trigger description - no localization necessary
+3747	Trigger		Slaan Lair - Counter Magic	Slaan Lair - Counter Magic	trigger description - no localization necessary
+3748	Trigger		Nationalist - Gold	Nationalist - Gold	trigger description - no localization necessary
+3749	Trigger		Nationalist - Kendra Langston	Nationalist - Kendra Langston	trigger description - no localization necessary
+3750	Trigger		Drauga - Magic Blade	Drauga - Magic Blade	trigger description - no localization necessary
+3751	Trigger		Monolith - Gold	Monolith - Gold	trigger description - no localization necessary
+3752	Trigger		Spider Lair - Eben Baruch	Spider Lair - Eben Baruch	trigger description - no localization necessary
+# Stripping \MAPS\GUARD_FORCE.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3753	Trigger		Spider Lair - Golem Warriors	Spider Lair - Golem Warriors	trigger description - no localization necessary
+3754	Trigger		STRING_3637	STRING_3637	trigger description - no localization necessary
+3755	Trigger		Council - Counter Magic	Council - Counter Magic	trigger description - no localization necessary
+3756	Trigger		Drauga - Kendra Langston	Drauga - Kendra Langston	trigger description - no localization necessary
+3757	Trigger		Drauga - Cyrus Naadev	Drauga - Cyrus Naadev	trigger description - no localization necessary
+# Stripping \MAPS\PASSAGES.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3758	Trigger		Spider lair - Leila	Spider lair - Leila	trigger description - no localization necessary
+3759	Trigger		Spider lair - Dogun	Spider lair - Dogun	trigger description - no localization necessary
+3760	Trigger		Bandit Camp - Warlock	Bandit Camp - Warlock	trigger description - no localization necessary
+3761	Trigger		Bandit Camp - Khaldunite Spear	Bandit Camp - Khaldunite Spear	trigger description - no localization necessary
+3762	Trigger		Royalist - Gold	Royalist - Gold	trigger description - no localization necessary
+3763	Trigger		Royalist - Ethan	Royalist - Ethan	trigger description - no localization necessary
+3764	Trigger		Council - Balthasar	Council - Balthasar	trigger description - no localization necessary
+3765	Trigger		Ruins 2- Gold	Ruins 2- Gold	trigger description - no localization necessary
+# Stripping \MAPS\RHAKSHA_HERD.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3766	Trigger		STRING_3654	STRING_3654	trigger description - no localization necessary
+# Stripping \MAPS\THE_FORD.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3767	Trigger		STRING_3663	STRING_3663	trigger description - no localization necessary
+# Stripping \MAPS\THE_NEXUS.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3768	Trigger		Nationalist - Holy Blades	Nationalist - Holy Blades	trigger description - no localization necessary
+3769	Trigger		STRING_3667	STRING_3667	trigger description - no localization necessary
+3770	Trigger		STRING_3666	STRING_3666	trigger description - no localization necessary
+3771	Trigger		SAI Build Units On	SAI Build Units On	trigger description - no localization necessary
+3772	Trigger		SAI Build Units Off	SAI Build Units Off	trigger description - no localization necessary
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM1.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3773	Trigger		STRING_3678	STRING_3678	trigger description - no localization necessary
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM10.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3774	Trigger		Jurai declares war	Jurai declares war	trigger description - no localization necessary
+3775	Trigger		Jurai is now allied	Jurai is now allied	trigger description - no localization necessary
+3776	Trigger		Visiting Neutral Jurai	Visiting Neutral Jurai	trigger description - no localization necessary
+3777	Trigger		Visiting allied Jurai	Visiting allied Jurai	trigger description - no localization necessary
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM11.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3778	Trigger		Sijansur found	Sijansur found	trigger description - no localization necessary
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM14.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3779	Trigger		activate Aanslyss story	activate Aanslyss story	trigger description - no localization necessary
+3780	Trigger		activate Yksslaar story	activate Yksslaar story	trigger description - no localization necessary
+3781	Trigger		activate Sslyn story	activate Sslyn story	trigger description - no localization necessary
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM16.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3782	Trigger		top spire	top spire	trigger description - no localization necessary
+3783	Trigger		right spire	right spire	trigger description - no localization necessary
+3784	Trigger		left spire	left spire	trigger description - no localization necessary
+3785	Trigger		Release citadel defense	Release citadel defense	trigger description - no localization necessary
+3786	Trigger		Citadel Defense	Citadel Defense	trigger description - no localization necessary
+3787	Trigger		Ceyah technology	Ceyah technology	trigger description - no localization necessary
+3788	Trigger		bottom left spire	bottom left spire	trigger description - no localization necessary
+3789	Trigger		bottom right spire	bottom right spire	trigger description - no localization necessary
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM4.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3790	Trigger		sai ignore zombies	sai ignore zombies	trigger description - no localization necessary
+# Stripping \MAPS\CYCLE OF DESTRUCTION\CDM6.TGM...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3791	Trigger		Has 5 outposts	Has 5 outposts	trigger description - no localization necessary
+3792	Trigger		Bring Roxanna to the Dark Rift.	Bring Roxanna to the Dark Rift.	Objective
+3793	Trigger		Selvana found	Selvana found	trigger description - no localization necessary
+# Stripping \SOURCE\TERRAIN\TGTERRAINTYPE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3794	g_terrain_name	10	Expansion1	Expansion1	not used - no localization necessary
+3795	g_terrain_name	18	Expansion2Mountain	Expansion2Mountain	not used - no localization necessary
+# Stripping \SOURCE\SAI\TGSAIPLAYER.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3796	Unknown	45	SAI %d has too much in military - rearranging	SAI %d has too much in military - rearranging	internal logging - no localization necessary
+3797	Unknown	52	"player %d outpost %d loc %.1f,%.1f inf %.1f val %.1f"	"player %d outpost %d loc %.1f,%.1f inf %.1f val %.1f"	internal logging - no localization necessary
+# Stripping \SOURCE\OBJECT\OBJECTQUEUE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3798	Error	35	Object %s ID %d is no longer valid.	Object %s ID %d is no longer valid.	error message
+# Stripping \SOURCE\NETWORK\CLIENT.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3799	Unknown	24	Game requires a password	Game requires a password	
+3800	Unknown	16	Invalid password	Invalid password	
+3801	Unknown	20	Incorrect mods	Incorrect mods	
+3802	Error	104	"Incorrect mods, you must be using these and only these mods to play in this host's game.\n\n"	"Incorrect mods, you must be using these and only these mods to play in this host's game.\n\n"	
+3803	Error	74	You must be playing with no mods enabled to join this host's game.\n	You must be playing with no mods enabled to join this host's game.\n	
+3804	Warning	48	To view this film you must run with no mods	To view this film you must run with no mods	
+3805	Warning	60	To view this film you must have the following mod:\n%s	To view this film you must have the following mod:\n%s	
+3806	Warning	70	To view this film you must have the following mods in order:\n%s	To view this film you must have the following mods in order:\n%s	
+3807	Message	42	That faction is not available in the demo.	That faction is not available in the demo.	
+3808	Unknown	11	 was banned	 was banned	[player name] was banned.
+3809	Unknown	29	You were banned from the game	You were banned from the game	
+3810	Message	23	Game name changed to %s	Game name changed to %s	
+3811	Message	28	Host changed game name to %s	Host changed game name to %s	
+3812	Message	32	%s tried to join but was banned.	%s tried to join but was banned.	
+3813	Message	39	%s tried to join but was banned (as %s).	%s tried to join but was banned (as %s).	
+3814	Message	6	Type 	Type 	
+3815	Message	19	 to remove the ban.	 to remove the ban.	"[Type ""/unban X""] to remove the ban."
+3816	Message	11	%s unbanned	%s unbanned	
+3817	Message	30	%s unbanned (was banned as %s)	%s unbanned (was banned as %s)	
+# Stripping \SOURCE\NETWORK\GAMESPY.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3818	Unknown	34	There is a new patch available: %s	There is a new patch available: %s	
+3819	Unknown	5	 (%s)	 (%s)	do not localize
+3820	Unknown	17	. Available at %s	. Available at %s	will be preceded by prior 2 strings
+# Stripping \SOURCE\INTERFACE\DATAMAP.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3821	Unknown	65	%s\n\nAttack: %.0f+%.0f\nDefense: %.0f+%.0f\nMax Hit Points: %.0f	%s\n\nAttack: %.0f+%.0f\nDefense: %.0f+%.0f\nMax Hit Points: %.0f	
+3822	Unknown	32	%s\nSell Price: %.0f\nUpkeep: %s	%s\nSell Price: %.0f\nUpkeep: %s	
+3823	Unknown	25	Upgrade to %s\nCost: %d%c	Upgrade to %s\nCost: %d%c	
+# Stripping \SOURCE\INTERFACE\TGCAMPAIGNINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3824	Warning	114	WARNING: This campaign requires an expansion that has not been loaded. Attempting to play will result in problems.	WARNING: This campaign requires an expansion that has not been loaded. Attempting to play will result in problems.	
+3825	Warning	71	WARNING: This campaign was not designed to be played with an expansion.	WARNING: This campaign was not designed to be played with an expansion.	
+# Stripping \SOURCE\INTERFACE\TGCONNECTIONINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3826	Unknown	8	Download	Download	
+3827	Warning	39	Could not find valid download location.	Could not find valid download location.	
+3828	Unknown	13	clear servers	clear servers	internal logging - no localization necessary
+3829	Unknown	14	update servers	update servers	internal logging - no localization necessary
+3830	Unknown	39	browser finished - removing old servers	browser finished - removing old servers	internal logging - no localization necessary
+3831	Unknown	38	not seen server %s:%d index %d list %d	not seen server %s:%d index %d list %d	internal logging - no localization necessary
+3832	Unknown	33	fix server %s:%d index %d list %d	fix server %s:%d index %d list %d	internal logging - no localization necessary
+3833	Unknown	34	post server %s:%d index %d list %d	post server %s:%d index %d list %d	internal logging - no localization necessary
+3834	Unknown	20	clearing server list	clearing server list	internal logging - no localization necessary
+3835	Unknown	20	%s #x 490 %s or %s%%	%s #x 490 %s or %s%%	only 'or' is to be localized - retain format
+3836	Unknown	22	check add server %s:%d	check add server %s:%d	internal logging - no localization necessary
+3837	Unknown	43	sorting match server %s:%d index %d list %d	sorting match server %s:%d index %d list %d	internal logging - no localization necessary
+3838	Unknown	29	server %s:%d index %d list %d	server %s:%d index %d list %d	internal logging - no localization necessary
+# Stripping \SOURCE\INTERFACE\TGGAMEMENU.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3839	Unknown	5	Leave	Leave	
+# Stripping \SOURCE\INTERFACE\TGGENERATORSETTINGS.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3840	Unknown	10	Rainforest	Rainforest	
+3841	Unknown	9	Woodlands	Woodlands	
+3842	Unknown	6	Arctic	Arctic	
+# Stripping \SOURCE\INTERFACE\TGJOININTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3843	Unknown	15	Enter Password:	Enter Password:	
+# Stripping \SOURCE\INTERFACE\TGMAINMENU.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3844	Unknown	55	Enter the CD Key from your Kohan: Ahriman's Gift CD-ROM	Enter the CD Key from your Kohan: Ahriman's Gift CD-ROM	
+# Stripping \SOURCE\INTERFACE\TGMAPSELECT.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3845	Unknown	22	Team Deathmatch Play: 	Team Deathmatch Play: 	
+3846	Unknown	5	Teams	Teams	
+3847	Unknown	59	Select Use Scenario Settings to play a Team Deathmatch map.	Select Use Scenario Settings to play a Team Deathmatch map.	
+# Stripping \SOURCE\INTERFACE\TGMULTIPLAYERINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3848	Unknown	7	Ban %s?	Ban %s?	
+3849	Message	39	Only the original host may ban players.	Only the original host may ban players.	
+3850	Unknown	3	Ban	Ban	
+# Stripping \SOURCE\INTERFACE\TGVIEWFILMSINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3851	Unknown	85	The film was recorded in a different game version and may not play back successfully.	The film was recorded in a different game version and may not play back successfully.	
+3852	Unknown	58	This film was recorded with a different version of %s (%s)	This film was recorded with a different version of %s (%s)	
+3853	Warning	103	Could not playback file %s. Your copy of %s is not the version that was used when the film was recorded	Could not playback file %s. Your copy of %s is not the version that was used when the film was recorded	
+3854	Warning	30	Could not playback file %s: %s	Could not playback file %s: %s	
+# Stripping \SOURCE\INTERFACE\TGDOWNLOADINTERFACE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3855	Unknown	17	Download Complete	Download Complete	
+3856	Unknown	14	Downloading %s	Downloading %s	
+3857	Warning	20	File transfer failed	File transfer failed	
+3858	Unknown	29	You have aborted the transfer	You have aborted the transfer	
+3859	Unknown	5	Retry	Retry	
+3860	Unknown	32	Download site appears to be busy	Download site appears to be busy	
+# Stripping \SOURCE\GAMEDATA\OBJECTTYPE.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3861	Unknown	6	cleric	cleric	
+# Stripping \SOURCE\GAME\CAMPAIGN.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3862	Unknown	13	Demo Scenario	Demo Scenario	
+3863	Unknown	14	Basic Tutorial	Basic Tutorial	
+3864	Unknown	30	Cycle of Destruction - %s - %s	Cycle of Destruction - %s - %s	
+# Stripping \SOURCE\GAME\TGGAME.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3865	Warning	26	Could not load object %s\n	Could not load object %s\n	
+3866	Warning	41	Could not load %s: category has changed\n	Could not load %s: category has changed\n	special case error - no localization necessary
+3867	Warning	38	Could not load %s: class has changed\n	Could not load %s: class has changed\n	special case error - no localization necessary
+3868	Unknown	15	%s have routed!	%s have routed!	
+# Stripping \SOURCE\GAME\QUEST\TGTRIGGERCONDITION.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3869	Unknown	20	Object Owned by Ally	Object Owned by Ally	
+# Stripping \SOURCE\GAME\QUEST\TGTRIGGEREFFECT.CPP...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3870	Unknown	19	Set Player X Ally Y	Set Player X Ally Y	retain 'X' and 'Y' (represents player numbers)
+3871	Unknown	20	Set Player X Peace Y	Set Player X Peace Y	retain 'X' and 'Y' (represents player numbers)
+3872	Unknown	18	Set Player X War Y	Set Player X War Y	retain 'X' and 'Y' (represents player numbers)
+3873	Unknown	33	Amulet Effect is missing hero: %s	Amulet Effect is missing hero: %s	
+# Stripping \ADDITIONAL STRINGS\MAPNAMES.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3874	Localize9 BuildingName	7	Bantega	Bantega	
+3875	Localize29 BuildingName	10	Blacksands	Blacksands	
+3876	Localize30 BuildingName	11	Spirit Keep	Spirit Keep	
+3877	Localize31 BuildingName	7	Rochran	Rochran	
+3878	Localize31 BuildingName	8	Varevice	Varevice	
+3879	Localize31 BuildingName	10	Nath Rakan	Nath Rakan	
+3880	Localize31 BuildingName	7	Gorakan	Gorakan	
+3881	Localize31 BuildingName	8	Khamdoor	Khamdoor	
+3882	Localize31 BuildingName	10	Thulramjur	Thulramjur	
+3883	Localize37 KingdomName	16	West Ceyah Horde	West Ceyah Horde
+3884	Localize37 KingdomName	17	West Council Club	West Council Club
+3885	Localize37 KingdomName	20	West Nationalist Mob	West Nationalist Mob
+3886	Localize37 KingdomName	19	East Royalist Posse	East Royalist Posse
+3887	Localize37 KingdomName	15	East Ceyah Gang	East Ceyah Gang
+3888	Localize37 KingdomName	20	East Council Commune	East Council Commune
+3889	Localize43 BuildingName	7	Glatoph	Glatoph
+3890	Localize43 BuildingName	7	Caendor	Caendor
+3891	Localize43 BuildingName	7	Undoorn	Undoorn
+3892	Localize43 BuildingName	7	Vhaaren	Vhaaren
+3893	Localize43 BuildingName	9	Jah Valan	Jah Valan
+3894	Localize43 BuildingName	12	Nath Narroth	Nath Narroth
+3895	Localize43 BuildingName	7	Tharoph	Tharoph
+3896	Localize43 BuildingName	11	Hath Vanjur	Hath Vanjur
+3897	Localize51 CompanyName	12	8th Infantry	8th Infantry
+3898	Localize51 CompanyName	16	4th Bone Reavers	4th Bone Reavers
+3899	Localize51 CompanyName	14	4th Grenadiers	4th Grenadiers	
+3900	Localize51 CompanyName	11	5th Footmen	5th Footmen	
+3901	Localize51 CompanyName	12	9th Infantry	9th Infantry	
+3902	Localize51 CompanyName	13	10th Infantry	10th Infantry	
+3903	Localize59 BuildingName	10	Maj Ramjur	Maj Ramjur	
+3904	Localize60 BuildingName	10	Black Camp	Black Camp	
+3905	Localize60 BuildingName	17	Isrel's Sanctuary	Isrel's Sanctuary	
+3906	Localize60 BuildingName	13	Aephir's Rock	Aephir's Rock	
+# Stripping \ADDITIONAL STRINGS\MAPNAMES1.INI...					
+# String ID	Type	Constraints	Source Text	Localized Text	Comment
+3907	Localize11 BuildingName	5	Asaka	Asaka	
+3908	Localize11 BuildingName	8	Kamadaki	Kamadaki	
+3909	Localize17 CompanyName	14	4th Shadelings	4th Shadelings	
+3910	Localize17 CompanyName	14	5th Shadelings	5th Shadelings	
+3911	Localize17 CompanyName	18	18th Shadow Beasts	18th Shadow Beasts	
+3912	Localize17 BuildingName	15	Ghorthog's Post	Ghorthog's Post	
+3913	Localize17 CompanyName	18	19th Shadow Beasts	19th Shadow Beasts
+3914	Localize17 CompanyName	18	20th Shadow Beasts	20th Shadow Beasts
+3915	Localize17 CompanyName	18	21st Shadow Beasts	21st Shadow Beasts
+3916	Localize17 KingdomName	7	Slaanri	Slaanri
+3917	Localize19 CompanyName	13	5th Engineers	5th Engineers
+3918	Localize19 BuildingName	18	Black Cat's Crouch	Black Cat's Crouch
+3919	Localize19 CompanyName	13	5th Bone Bows	5th Bone Bows
+3920	Localize19 KingdomName	7	Ahriman	Ahriman
+3921	Localize21 BuildingName	10	Black Nest	Black Nest
+3922	Localize21 BuildingName	14	Black Wolf Den	Black Wolf Den
+3923	Localize24 CompanyName	19	4th Rhaksha Hunters	4th Rhaksha Hunters
+3924	Localize24 CompanyName	16	4th Elite Bowmen	4th Elite Bowmen
+3925	Localize24 CompanyName	15	7th Void Beasts	7th Void Beasts
+3926	Localize24 KingdomName	14	Valthrak Tribe	Valthrak Tribe
+3927	Localize27 KingdomName	14	Splinter Group	Splinter Group
+3928	Localize28 CompanyName	11	7th Zombies	7th Zombies
+3929	Localize28 CompanyName	11	8th Zombies	8th Zombies
+3930	Localize28 CompanyName	11	9th Zombies	9th Zombies
+3931	Localize28 CompanyName	12	10th Zombies	10th Zombies
+3932	Localize28 KingdomName	11	Evil Tyrant	Evil Tyrant
+3933	Localize29 BuildingName	10	Ravenswood	Ravenswood
+3934	Localize29 BuildingName	17	Abandoned Village	Abandoned Village
+3935	Localize29 CompanyName	16	4th Rainbringers	4th Rainbringers
+3936	Localize37 CompanyName	15	3rd The Chosens	3rd The Chosens
+#				
+"# Found 3937 strings (255 new strings), beginning string insertion..."				
+#				
+# Inserting Remap Defines...				
+#				
+# Stripper done.				


### PR DESCRIPTION
### _Changelog:_

This change unfortunately means that the mod will not play nice with other language versions of the game, besides the English version. However, since many of our custom spells, names and descriptions are not using the localizations - it was always going to be awkward to use for other language versions of the game anyway.

Bonus.ini is included for editing purposes, so the available bonuses that can be used to customise units can be easily found.

Strings 01 and 05 have an error for the Lightbane/Eosophobia bonus, in which the description says it works against shadow units. This is, in fact, the complete opposite, as it works for all non-shadow and _does not_ work against shadow. The bonus is the mirror of Shadowbane which you see on a lot of units and functions similarly to Unholy damage. The mechanic works correctly in game and the problem is only with the description, so my assumption is this was an oversight.
Expect to see Lightbane used more often as a mechanic to increase Ceyah hero's (and possibly unit's) effectiveness without giving them more anti-Ceyah effectiveness as well.