### PR TITLE
Melchior Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
@@ -65,11 +65,14 @@ ATTACK_BONUS_TO_NONSHADOW      = 2
 
 [Level1]
 MaxHitPoints		=	700
+Defense             =   10
 
 [SpellData1]
 
 [Attack0Data1]
-Damage			=	42
+Damage			=	56
+Projectile		=   Dreadfire
+DamageType		=	MAGIC
 
 [Attack1Data1]
 Damage			=	38
@@ -77,8 +80,8 @@ Damage			=	38
 [ElementBonus1]
 
 [SupportBonus1]
-VISUAL_RANGE_BONUS	= 1.2
 IGNORE_TERRAIN_BONUS		= 1
+ATTACK_BONUS_TO_NONSHADOW      = 2
 
 [Level2]
 MaxHitPoints		=	860

--- a/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
@@ -110,7 +110,7 @@ MaxHitPoints		=	1020
 [SpellData3]
 
 [Attack0Data3]
-Damage			=	56
+Damage			=	64
 
 [Attack1Data3]
 Damage			=	42

--- a/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
@@ -37,14 +37,15 @@ Description = STRING_2396_Melchior_is_a_brutal_huntmaster_for_the_Shadow__He_ser
 
 [Attack1]
 AttackTime		=	1			;seconds(float) seconds per animation cycle
-Projectile		=   flamearrow
+Projectile		=   Dreadfire
 DamagePoint		=	0.6			;seconds(float) at what point (percentage) in attack animation to apply damage/shoot projectile
 ReloadTime		=	3			;seconds(float)
 AttackRange		=	6			;tiles (float)
 AttackType		=	PROJECTILE			;enumeration list(int)
 Damage			=	52		;number (float)
-DamageType		=	NORMAL
+DamageType		=	MAGIC
 Sound1			=	Game\ranger_fire.wav
+AreaRadius		=	1
 
 [Attack2]
 AttackTime		=	1			;seconds(float) seconds per animation cycle
@@ -71,13 +72,12 @@ Defense             =   10
 
 [Attack0Data1]
 Damage			=	56
-Projectile		=   Dreadfire
-DamageType		=	MAGIC
 
 [Attack1Data1]
 Damage			=	38
 
 [ElementBonus1]
+ATTACK_BONUS_TO_ROUTED  =   4
 
 [SupportBonus1]
 IGNORE_TERRAIN_BONUS		= 1
@@ -85,22 +85,20 @@ ATTACK_BONUS_TO_NONSHADOW      = 2
 
 [Level2]
 MaxHitPoints		=	860
-Defense			=	10
 
 [SpellData2]
 
 [Attack0Data2]
-Damage			=	48
+Damage			=	52
 
 [Attack1Data2]
 Damage			=	40
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_MAGIC	= .85
 
 [SupportBonus2]
-VISUAL_RANGE_BONUS	= 1.3
 IGNORE_TERRAIN_BONUS		= 1
+ATTACK_BONUS_TO_NONSHADOW      = 4
 
 [Level3]
 Defense			=	12

--- a/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
@@ -37,13 +37,13 @@ Description = STRING_2396_Melchior_is_a_brutal_huntmaster_for_the_Shadow__He_ser
 
 [Attack1]
 AttackTime		=	1			;seconds(float) seconds per animation cycle
-Projectile		=   Dreadfire
+Projectile		=   flamearrow
 DamagePoint		=	0.6			;seconds(float) at what point (percentage) in attack animation to apply damage/shoot projectile
-ReloadTime		=	1			;seconds(float)
+ReloadTime		=	3			;seconds(float)
 AttackRange		=	6			;tiles (float)
 AttackType		=	PROJECTILE			;enumeration list(int)
-Damage			=	40		;number (float)
-DamageType		=	MAGIC
+Damage			=	52		;number (float)
+DamageType		=	NORMAL
 Sound1			=	Game\ranger_fire.wav
 
 [Attack2]
@@ -57,9 +57,11 @@ DamageType		=	MAGIC
 Sound1			=	Game\ranger_attack.wav
 
 [ElementBonus]
+IGNORE_TERRAIN_BONUS    =   1
+ATTACK_BONUS_TO_ROUTED  =   4
 
 [SupportBonus]
-VISUAL_RANGE_BONUS	= 1.1
+ATTACK_BONUS_TO_NONSHADOW      = 2
 
 [Level1]
 MaxHitPoints		=	700

--- a/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
@@ -42,7 +42,7 @@ DamagePoint		=	0.6			;seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	3			;seconds(float)
 AttackRange		=	6			;tiles (float)
 AttackType		=	PROJECTILE			;enumeration list(int)
-Damage			=	52		;number (float)
+Damage			=	50		;number (float)
 DamageType		=	MAGIC
 Sound1			=	Game\ranger_fire.wav
 AreaRadius		=	1
@@ -62,7 +62,7 @@ IGNORE_TERRAIN_BONUS    =   1
 ATTACK_BONUS_TO_ROUTED  =   4
 
 [SupportBonus]
-ATTACK_BONUS_TO_NONSHADOW      = 2
+VISUAL_RANGE_BONUS      =   1.1
 
 [Level1]
 MaxHitPoints		=	700
@@ -71,7 +71,7 @@ Defense             =   10
 [SpellData1]
 
 [Attack0Data1]
-Damage			=	56
+Damage			=	54
 
 [Attack1Data1]
 Damage			=	38
@@ -82,6 +82,7 @@ ATTACK_BONUS_TO_ROUTED  =   4
 [SupportBonus1]
 IGNORE_TERRAIN_BONUS		= 1
 ATTACK_BONUS_TO_NONSHADOW      = 2
+VISUAL_RANGE_BONUS      =   1.2
 
 [Level2]
 MaxHitPoints		=	860
@@ -89,7 +90,7 @@ MaxHitPoints		=	860
 [SpellData2]
 
 [Attack0Data2]
-Damage			=	52
+Damage			=	60
 
 [Attack1Data2]
 Damage			=	40
@@ -97,8 +98,10 @@ Damage			=	40
 [ElementBonus2]
 
 [SupportBonus2]
+MOVEMENT_BONUS          =   1.1
 IGNORE_TERRAIN_BONUS		= 1
 ATTACK_BONUS_TO_NONSHADOW      = 4
+VISUAL_RANGE_BONUS      =   1.25
 
 [Level3]
 Defense			=	12
@@ -115,9 +118,10 @@ Damage			=	42
 [ElementBonus3]
 
 [SupportBonus3]
-MOVEMENT_BONUS                  =   1.1
+MOVEMENT_BONUS                  =   1.15
 IGNORE_TERRAIN_BONUS		    =   1
 ATTACK_BONUS_TO_NONSHADOW       =   4
+VISUAL_RANGE_BONUS      =   1.3
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
@@ -107,17 +107,17 @@ MaxHitPoints		=	1020
 [SpellData3]
 
 [Attack0Data3]
-Damage			=	52
+Damage			=	56
 
 [Attack1Data3]
 Damage			=	42
 
 [ElementBonus3]
-DAMAGE_TAKEN_FROM_MAGIC	= .75
 
 [SupportBonus3]
-VISUAL_RANGE_BONUS	= 1.4
-IGNORE_TERRAIN_BONUS		= 1
+MOVEMENT_BONUS                  =   1.1
+IGNORE_TERRAIN_BONUS		    =   1
+ATTACK_BONUS_TO_NONSHADOW       =   4
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MELCHIOR.INI
@@ -23,11 +23,6 @@ SelectionSound2		=	Game\m_hero7_select_evil.wav
 CommandSound1		=	Game\m_hero7_command2.wav
 CommandSound2		=	Game\m_hero7_command_evil.wav
 
-[ElementBonus]
-
-[SupportBonus]
-VISUAL_RANGE_BONUS	= 1.1
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Ranger_icon.tgr
@@ -39,10 +34,6 @@ WalkDistance		=   	0.77		;tiles (float) how far does unit move in one animation 
 ResupplyRate	=	10			; health / second (float)
 CombatValue		= 15
 Description = STRING_2396_Melchior_is_a_brutal_huntmaster_for_the_Shadow__He_serves_his_Dark_Master_with_precision_and_utter_loyalty__No_one_alive_knows_for_sure_who_he_was_before_the_Cataclysms__and_he_always_wears_a_dark_iron_mask_that_protects_his_identity_
-
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0031_Melchior
 
 [Attack1]
 AttackTime		=	1			;seconds(float) seconds per animation cycle
@@ -65,16 +56,15 @@ Damage			=	34		;number (float)
 DamageType		=	MAGIC
 Sound1			=	Game\ranger_attack.wav
 
+[ElementBonus]
+
+[SupportBonus]
+VISUAL_RANGE_BONUS	= 1.1
+
 [Level1]
 MaxHitPoints		=	700
 
-[Level2]
-MaxHitPoints		=	860
-Defense			=	10
-
-[Level3]
-Defense			=	12
-MaxHitPoints		=	1020
+[SpellData1]
 
 [Attack0Data1]
 Damage			=	42
@@ -82,29 +72,23 @@ Damage			=	42
 [Attack1Data1]
 Damage			=	38
 
-[Attack0Data2]
-Damage			=	48
-
-[Attack1Data2]
-Damage			=	40
-
-[Attack0Data3]
-Damage			=	52
-
-[Attack1Data3]
-Damage			=	42
-
-[SpellData1]
-
-[SpellData2]
-
-[SpellData3]
-
 [ElementBonus1]
 
 [SupportBonus1]
 VISUAL_RANGE_BONUS	= 1.2
 IGNORE_TERRAIN_BONUS		= 1
+
+[Level2]
+MaxHitPoints		=	860
+Defense			=	10
+
+[SpellData2]
+
+[Attack0Data2]
+Damage			=	48
+
+[Attack1Data2]
+Damage			=	40
 
 [ElementBonus2]
 DAMAGE_TAKEN_FROM_MAGIC	= .85
@@ -113,9 +97,25 @@ DAMAGE_TAKEN_FROM_MAGIC	= .85
 VISUAL_RANGE_BONUS	= 1.3
 IGNORE_TERRAIN_BONUS		= 1
 
+[Level3]
+Defense			=	12
+MaxHitPoints		=	1020
+
+[SpellData3]
+
+[Attack0Data3]
+Damage			=	52
+
+[Attack1Data3]
+Damage			=	42
+
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_MAGIC	= .75
 
 [SupportBonus3]
 VISUAL_RANGE_BONUS	= 1.4
 IGNORE_TERRAIN_BONUS		= 1
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0031_Melchior


### PR DESCRIPTION
### _Changelog:_

### All levels:

	Decreased Attack Rate from 75% to  37% 

### Awakened:

	Increased AV from  40 to 50 
	
	Added Trailblazing (Personal)
	Added   Blood Lust +4 (Personal)

### Enlightened:
	
	Increased DV from 8 to 10 
	Increased AV from 42 to 54 
	
	Added   Blood Lust +4(Personal)
	
	Added   Trailblazing(Provided)
	Added   Lightbane +2(Provided)
	
### Restored:
	
	Increased AV from 48 to 60 
	
	Added   Blood Lust +4 (Personal)
	
	Added   Trailblazing(Provided)
	Added   Lightbane+4(Provided)
	Decreased Recon from 130% to 125%(Provided)

### Ascended:

	Increased AV from 52 to 64
	
	 
	Added   Blood Lust +4 (Personal)
	
	Added Trailblazing(Provided)
	Added Lightbane+4(Provided)
	Added Movementspeed 115%(Provided)
	Decreased Recon from 140% to 130%(Provided)
