### PR TITLE
Caleb Eshkol Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/CALEB_ESHKOL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/CALEB_ESHKOL.INI
@@ -4,7 +4,7 @@ Class			=   2
 Sprite          =   units\crossbowman.tgr
 BoundingRadius  =   0.25
 RotTime         =   30
-MaxHitPoints    =   510
+MaxHitPoints    =   540
 CostGold        =   0
 BuildTime       =   5
 DetectionRadius =   100
@@ -27,99 +27,101 @@ CommandSound3   =   Game\agm_hero1_command3.wav
 
 
 [UnitData]
-Type=HERO
-Icon=Portraits\Unit Icons\crossbowman_icon.tgr
-Portrait=Portraits\Heroes\Caleb_Eshkol_portrait.tgr
-DieTime=1
-IdleTime=2
-MovementRate=34
-WalkDistance=0.72
-ResupplyRate=10
-CombatValue=15
-Description=STRING_4688_A_crack_shot_with_his_crossbow__Caleb_is_a_bit_of_a_rebel_among_the_generally_stuffy_Council_Kohan__Considered_by_many_to_be_somewhat_of_an_annoyance__he_does_what_he_pleases__when_he_pleases__Particularly_when_he_feels_it_is_in_the_interest_of_all_the_Kohan__even_if_his_brethren_don_t_see_it_that_way_
+Type            =   HERO
+Icon            =   Portraits\Unit Icons\crossbowman_icon.tgr
+Portrait        =   Portraits\Heroes\Caleb_Eshkol_portrait.tgr
+DieTime         =   1
+IdleTime        =   2
+MovementRate    =   34
+WalkDistance    =   0.72
+ResupplyRate    =   10
+CombatValue     =   15
+Description     =   STRING_4688_A_crack_shot_with_his_crossbow__Caleb_is_a_bit_of_a_rebel_among_the_generally_stuffy_Council_Kohan__Considered_by_many_to_be_somewhat_of_an_annoyance__he_does_what_he_pleases__when_he_pleases__Particularly_when_he_feels_it_is_in_the_interest_of_all_the_Kohan__even_if_his_brethren_don_t_see_it_that_way_
 
 
 [Attack1]
-Sound1=Game\crossbowman_attack.wav
-AttackTime=1
-Projectile=arrow
-DamagePoint=0.6
-ReloadTime=3
-AttackRange=7
-AttackType=PROJECTILE
-Damage=60
-DamageType=NORMAL
+Sound1          =   Game\crossbowman_attack.wav
+AttackTime      =   1
+Projectile      =   arrow
+DamagePoint     =   0.6
+ReloadTime      =   3
+AttackRange     =   7
+AttackType      =   PROJECTILE
+Damage          =   60
+DamageType      =   NORMAL
 
 [Attack2]
-Sound1=Game\archer_sword1.wav
-Sound2=Game\sword2.wav
-AttackTime=1
-Projectile=0
-DamagePoint=0.6
-ReloadTime=0.5
-AttackRange=0.75
-AttackType=MELEE
-Damage=26
-DamageType=NORMAL
+Sound1          =   Game\archer_sword1.wav
+Sound2          =   Game\sword2.wav
+AttackTime      =   1
+Projectile      =   0
+DamagePoint     =   0.6
+ReloadTime      =   0.5
+AttackRange     =   0.75
+AttackType      =   MELEE
+Damage          =   38
+DamageType      =   NORMAL
 
 [ElementBonus]
-DEFENSE_BONUS_VS_ARCHER=6
+DEFENSE_BONUS_VS_ARCHER     =   4
 
 [SupportBonus]
-VISUAL_RANGE_BONUS=1.1
+ENTRENCHMENT_RATE_BONUS     =   1.25
+MORALE_LOSS_RATE_BONUS      =   0.9
+VISUAL_RANGE_BONUS          =   1.1
 
 
 [Level1]
-MaxHitPoints=640
+MaxHitPoints        =   680
 
 [Attack0Data1]
-Damage=64
+Damage              =64
 
 [Attack1Data1]
-Damage=28
+Damage              =   28
 
 [ElementBonus1]
-DEFENSE_BONUS_VS_ARCHER=10
+DEFENSE_BONUS_VS_ARCHER     =   10
 
 [SupportBonus1]
-VISUAL_RANGE_BONUS=1.1
+VISUAL_RANGE_BONUS      =   1.1
 
 
 [Level2]
-MaxHitPoints=790
+MaxHitPoints        =   790
 
 [Attack0Data2]
-Damage=70
+Damage          =   70
 
 [Attack1Data2]
-Damage=32
+Damage          =   32
 
 [ElementBonus2]
-DEFENSE_BONUS_VS_ARCHER=14
+DEFENSE_BONUS_VS_ARCHER     =   14
 
 [SupportBonus2]
-VISUAL_RANGE_BONUS=1.2
+VISUAL_RANGE_BONUS      =   1.2
 
 
 [Level3]
-MaxHitPoints=930
+MaxHitPoints        =   930
 
 [Attack0Data3]
-Damage=76
+Damage              =   76
 
 [Attack1Data3]
-Damage=36
+Damage              =   36
 
 [ElementBonus3]
-DEFENSE_BONUS_VS_ARCHER=18
+DEFENSE_BONUS_VS_ARCHER     =   18
 
 [SupportBonus3]
-VISUAL_RANGE_BONUS=1.2
+VISUAL_RANGE_BONUS      =   1.2
 
 
 [HeroData]
-AwakenCost=50
-TranslatedName=STRING_4689_Caleb_Eshkol
+AwakenCost          =   50
+TranslatedName      =   STRING_4689_Caleb_Eshkol
 
 
 

--- a/TGX Files/Data/ObjectData/Heroes/CALEB_ESHKOL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/CALEB_ESHKOL.INI
@@ -91,19 +91,22 @@ VISUAL_RANGE_BONUS      =   1.2
 
 
 [Level2]
-MaxHitPoints        =   790
+MaxHitPoints        =   820
 
 [Attack0Data2]
 Damage          =   70
 
 [Attack1Data2]
-Damage          =   32
+Damage          =   50
 
 [ElementBonus2]
-DEFENSE_BONUS_VS_ARCHER     =   14
+DEFENSE_BONUS_VS_ARCHER     =   8
 
 [SupportBonus2]
-VISUAL_RANGE_BONUS      =   1.2
+ZONE_OF_CONTROL_BONUS       =   1.15
+ENTRENCHMENT_RATE_BONUS     =   1.25
+MORALE_LOSS_RATE_BONUS      =   0.75
+VISUAL_RANGE_BONUS      =   1.3
 
 
 [Level3]

--- a/TGX Files/Data/ObjectData/Heroes/CALEB_ESHKOL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/CALEB_ESHKOL.INI
@@ -75,16 +75,19 @@ VISUAL_RANGE_BONUS          =   1.1
 MaxHitPoints        =   680
 
 [Attack0Data1]
-Damage              =64
+Damage              =   64
 
 [Attack1Data1]
-Damage              =   28
+Damage              =   42
 
 [ElementBonus1]
-DEFENSE_BONUS_VS_ARCHER     =   10
+DEFENSE_BONUS_VS_ARCHER     =   6
 
 [SupportBonus1]
-VISUAL_RANGE_BONUS      =   1.1
+ZONE_OF_CONTROL_BONUS       =   1.1
+ENTRENCHMENT_RATE_BONUS     =   1.25
+MORALE_LOSS_RATE_BONUS      =   0.85
+VISUAL_RANGE_BONUS      =   1.2
 
 
 [Level2]

--- a/TGX Files/Data/ObjectData/Heroes/CALEB_ESHKOL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/CALEB_ESHKOL.INI
@@ -18,12 +18,12 @@ Land            =   1
 Water           =   0
 
 DeathSound1     =   Game\archer_death.wav
-SelectionSound1 =   Game\agm_hero1_select1.wav
-SelectionSound2 =   Game\agm_hero1_select2.wav
-SelectionSound3 =   Game\agm_hero1_select3.wav
-CommandSound1   =   Game\agm_hero1_command1.wav
-CommandSound2   =   Game\agm_hero1_command2.wav
-CommandSound3   =   Game\agm_hero1_command3.wav
+SelectionSound1 =   Game\agm_hero5_select1.wav
+SelectionSound2 =   Game\agm_hero5_select2.wav
+SelectionSound3 =   Game\agm_hero5_select3.wav
+CommandSound1   =   Game\agm_hero5_command1.wav
+CommandSound2   =   Game\agm_hero5_command2.wav
+CommandSound3   =   Game\agm_hero5_command3.wav
 
 
 [UnitData]

--- a/TGX Files/Data/ObjectData/Heroes/CALEB_ESHKOL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/CALEB_ESHKOL.INI
@@ -110,19 +110,22 @@ VISUAL_RANGE_BONUS      =   1.3
 
 
 [Level3]
-MaxHitPoints        =   930
+MaxHitPoints        =   960
 
 [Attack0Data3]
 Damage              =   76
 
 [Attack1Data3]
-Damage              =   36
+Damage              =   56
 
 [ElementBonus3]
-DEFENSE_BONUS_VS_ARCHER     =   18
+DEFENSE_BONUS_VS_ARCHER     =   12
 
 [SupportBonus3]
-VISUAL_RANGE_BONUS      =   1.2
+ZONE_OF_CONTROL_BONUS       =   1.2
+ENTRENCHMENT_RATE_BONUS     =   1.25
+MORALE_LOSS_RATE_BONUS      =   0.75
+VISUAL_RANGE_BONUS      =   1.4
 
 
 [HeroData]


### PR DESCRIPTION
### _Changelog:_

### Awakened 

	Increased HP from 510 540 
	Increased Melee AV from 26 to 38 
	
	Decreased Archer Resistant from 6 to 4  (Personal)
	
	Added Courageous 90%  (Provided)
	Added Slow Entrenchment 125%   (Provided)

### Enlightened 

	Increased HP HP from 640 to 680   
	Increased Melee AV  from 28 to 42 
	
	Decreased Archer Resistant from 10 to 6  (Personal)
	
	Increased Recon from 110% to 120%  (Provided)
	Added Courageous 85%  (Provided)
	Added Dominion 110%  (Provided)
	Added Slow Entrenchment 125%  (Provided)

### Restored  

	Increased HP HP from 790 to 820   
	Increased Melee AV from 32 to 50  
	
	Decreased Archer Resistant from 14 to  8 (Personal)
	
	Increased Recon from 120% to 130% (Provided)
	Added Courageous 75%  (Provided)
	Added Dominion 115%  (Provided)
	Added Slow Entrenchment 125%  (Provided)
  
### Ascended

	Increased HP HP from 930 to 960   
	Increased Melee AVfrom 36 to 56  
	
	Decreased Archer Resistance from 18 to 12  (Personal)
	
	Increased Recon from 120% to 140%  
	Added Courageous 75%  
	Added Dominion 120%  
	Added Slow Entrenchment 125%  
