### PR TITLE
Divsha Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/DIVSHA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DIVSHA.INI
@@ -84,22 +84,24 @@ VISUAL_RANGE_BONUS                                  =   1.2
 ZONE_OF_CONTROL_BONUS                               =   .85
 
 [Level2]
-MaxHitPoints                                        =   845
+MaxHitPoints                                        =   800
+Defense                                             =   10
 
 [SpellData2]
 Spell0                                              =   Haste
 
 [Attack0Data2]
-DamageType                                          =   MAGIC
+Damage                                              =   44
+DamageType                                          =   VORPAL
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_MAGIC                             =   .9
+DAMAGE_TAKEN_FROM_MAGIC                             =   .75
 DAMAGE_TAKEN_FROM_RANGED                            =   .5
 
 [SupportBonus2]
-VISUAL_RANGE_BONUS                                  =   1.3
-ZONE_OF_CONTROL_BONUS                               =   .9
-RELOAD_TIME_BONUS                                   =   .83
+MOVEMENT_BONUS                                      =   1.1
+VISUAL_RANGE_BONUS                                  =   1.25
+ZONE_OF_CONTROL_BONUS                               =   .85
 
 [Level3]
 MaxHitPoints                                        =   1100

--- a/TGX Files/Data/ObjectData/Heroes/DIVSHA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DIVSHA.INI
@@ -88,7 +88,6 @@ MaxHitPoints                                        =   800
 Defense                                             =   10
 
 [SpellData2]
-Spell0                                              =   Haste
 
 [Attack0Data2]
 Damage                                              =   44
@@ -108,14 +107,11 @@ MaxHitPoints                                        =   900
 Defense                                             =   12
 
 [SpellData3]
-Spell0                                              =   Haste
 
 [Attack0Data3]
 Damage                                              =   50
 
 [ElementBonus3]
-DAMAGE_TAKEN_FROM_MAGIC                             =   .75
-DAMAGE_TAKEN_FROM_RANGED                            =   .5
 
 [SupportBonus3]
 MOVEMENT_BONUS                                      =   1.2

--- a/TGX Files/Data/ObjectData/Heroes/DIVSHA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DIVSHA.INI
@@ -66,20 +66,22 @@ VISUAL_RANGE_BONUS                                  =   1.15
 ZONE_OF_CONTROL_BONUS                               =   .85
 
 [Level1]
-MaxHitPoints                                        =   650
+MaxHitPoints                                        =   660
+Defense                                             =   9
 
 [SpellData1]
 Spell0                                              =   Haste
 
 [Attack0Data1]
-Damage                                              =   44
+Damage                                              =   42
 
 [ElementBonus1]
+DAMAGE_TAKEN_FROM_MAGIC                             =   0.85
 DAMAGE_TAKEN_FROM_RANGED                            =   .5
 
 [SupportBonus1]
 VISUAL_RANGE_BONUS                                  =   1.2
-ZONE_OF_CONTROL_BONUS                               =   .8
+ZONE_OF_CONTROL_BONUS                               =   .85
 
 [Level2]
 MaxHitPoints                                        =   845

--- a/TGX Files/Data/ObjectData/Heroes/DIVSHA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DIVSHA.INI
@@ -4,11 +4,11 @@ Class                                               =   2
 Sprite                                              =   units\female_hero.tgr
 BoundingRadius                                      =   0.25
 RotTime                                             =   30
-MaxHitPoints                                        =   500
+MaxHitPoints                                        =   510
 CostGold                                            =   0
 BuildTime                                           =   5
 DetectionRadius                                     =   100
-Defense                                             =   10
+Defense                                             =   8
 Faction                                             =   Ceyah
 
 Moveable                                            =   1
@@ -45,10 +45,10 @@ ManaRegenerationRate                                =   2
 Sound1                                              =   Game\sword1.wav
 AttackTime                                          =   1
 DamagePoint                                         =   0.4
-ReloadTime                                          =   0.5
+ReloadTime                                          =   0.36
 AttackRange                                         =   0.75
 AttackType                                          =   MELEE
-Damage                                              =   38
+Damage                                              =   40
 DamageType                                          =   MAGIC
 
 [Attack2]
@@ -58,11 +58,12 @@ ReloadTime                                          =   3
 AttackType                                          =   CAST
 
 [ElementBonus]
+DAMAGE_TAKEN_FROM_MAGIC                             =   0.9
 DAMAGE_TAKEN_FROM_RANGED                            =   .5
 
 [SupportBonus]
 VISUAL_RANGE_BONUS                                  =   1.15
-ZONE_OF_CONTROL_BONUS                               =   .75
+ZONE_OF_CONTROL_BONUS                               =   .85
 
 [Level1]
 MaxHitPoints                                        =   650

--- a/TGX Files/Data/ObjectData/Heroes/DIVSHA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DIVSHA.INI
@@ -104,7 +104,8 @@ VISUAL_RANGE_BONUS                                  =   1.25
 ZONE_OF_CONTROL_BONUS                               =   .85
 
 [Level3]
-MaxHitPoints                                        =   1100
+MaxHitPoints                                        =   900
+Defense                                             =   12
 
 [SpellData3]
 Spell0                                              =   Haste
@@ -117,8 +118,9 @@ DAMAGE_TAKEN_FROM_MAGIC                             =   .75
 DAMAGE_TAKEN_FROM_RANGED                            =   .5
 
 [SupportBonus3]
-VISUAL_RANGE_BONUS                                  =   1.35
-RELOAD_TIME_BONUS                                   =   .73
+MOVEMENT_BONUS                                      =   1.2
+VISUAL_RANGE_BONUS                                  =   1.30
+ZONE_OF_CONTROL_BONUS                               =   .85
 
 [HeroData]
 AwakenCost                                          =   50


### PR DESCRIPTION
### _Changelog:_

### All levels:
Increased Attack Speed from 100% to 110%

### Awakened 

	Increased HP from  500 to 510
	Decreased DV from 10 to 8
	Increased AV from 38 to 40 Magic
	
	Added Magic Resistance 90% (Personal)
	
	Recon 115% (Provided)
	Decreased Poor Control from 75% to 85% (Provided)

### Enlightened

	Increased HP from 650 to 660 
	Decreased DV from 10 to 9
	Decreased AV from 44 to 42
	
	
	Added Magic Resistance 85% (Personal)
	
	Decreased Poor Control from 80% to 85% (Provided)

### Restored

	Decreased HP from 845 to 800 
	Damage type changed to Vorpal
	
	Spell Haste. (0.75 Reload time)
	
	Increased Magic Resistant from 90% to 75% (Personal)
	
	Decreased Recon from 130% to 125% (Provided)
	Decreased Poor Control from 90% to 85% (Provided)
	Added Movement Speed 110% (Provided)
	Removed Haste Bonus 83% (Provided)

### Ascended

	Decreased HP from 1100 to 900 
	Increased DV from 10 to 12
	
	Spell Haste (0.75 Reload Speed)
	
	Personal
	
	Provided
	Decreased Recon  from 135% to 130% (Provided)
	Added Poor Control 85% (Provided)
	Added Movement Speed 120% (Provided)
	Removed Haste Bonus 73%
