### PR TITLE
Moggok rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/MOGGOK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MOGGOK.INI
@@ -59,23 +59,23 @@ DAMAGE_TAKEN_FROM_RANGED            =   .5
 IMMUNITY_TO_ENCHANTMENT             =   1
 
 [SupportBonus]
-ENTRENCHMENT_RATE_BONUS             =   .66
 MORALE_BONUS                        =   2
+ENTRENCHMENT_RATE_BONUS             =   .66
 
 [Level1]
-MaxHitPoints                        =   840
+MaxHitPoints                        =   900
+Defense                             =   13
 
 [Attack0Data1]
-Damage                              =   50
+Damage                              =   54
 
 [SpellData1]
 
 [ElementBonus1]
-DAMAGE_TAKEN_FROM_MAGIC             =   .7
-DAMAGE_TAKEN_FROM_RANGED            =   .5
-IMMUNITY_TO_ENCHANTMENT             =   1
 
 [SupportBonus1]
+ZONE_OF_CONTROL_BONUS               =   1.1
+MORALE_BONUS                        =   4
 ENTRENCHMENT_RATE_BONUS             =   .75
 
 [Level2]

--- a/TGX Files/Data/ObjectData/Heroes/MOGGOK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MOGGOK.INI
@@ -4,11 +4,11 @@ Class                               =   2
 Sprite                              =   units\Gauri_Hammer.tgr
 BoundingRadius                      =   0.25
 RotTime                             =   30
-MaxHitPoints                        =   640
+MaxHitPoints                        =   650
 CostGold                            =   0
 BuildTime                           =   5
 DetectionRadius                     =   100
-Defense                             =   10
+Defense                             =   12
 Faction                             =   Nationalist
 
 Moveable                            =   1
@@ -42,7 +42,7 @@ DamagePoint                         =   0.6
 ReloadTime                          =   0.5
 AttackRange                         =   0.75
 AttackType                          =   MELEE
-Damage                              =   46
+Damage                              =   50
 DamageType                          =   Khaldunite
 
 [Attack2]
@@ -59,7 +59,8 @@ DAMAGE_TAKEN_FROM_RANGED            =   .5
 IMMUNITY_TO_ENCHANTMENT             =   1
 
 [SupportBonus]
-ENTRENCHMENT_RATE_BONUS             =   .8
+ENTRENCHMENT_RATE_BONUS             =   .66
+MORALE_BONUS                        =   2
 
 [Level1]
 MaxHitPoints                        =   840

--- a/TGX Files/Data/ObjectData/Heroes/MOGGOK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MOGGOK.INI
@@ -79,19 +79,20 @@ MORALE_BONUS                        =   4
 ENTRENCHMENT_RATE_BONUS             =   .75
 
 [Level2]
-MaxHitPoints                        =   1040
+MaxHitPoints                        =   1150
+Defense                             =   14
 
 [Attack0Data2]
+Damage                              =   60
 
 [SpellData2]
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_MAGIC             =   .6
-DAMAGE_TAKEN_FROM_RANGED            =   .5
-IMMUNITY_TO_ENCHANTMENT             =   1
 
 [SupportBonus2]
-ENTRENCHMENT_RATE_BONUS             =   .7
+ZONE_OF_CONTROL_BONUS               =   1.15
+MORALE_BONUS                        =   6
+ENTRENCHMENT_RATE_BONUS             =   .5
 
 [Level3]
 MaxHitPoints=1240

--- a/TGX Files/Data/ObjectData/Heroes/MOGGOK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MOGGOK.INI
@@ -95,22 +95,20 @@ MORALE_BONUS                        =   6
 ENTRENCHMENT_RATE_BONUS             =   .5
 
 [Level3]
-MaxHitPoints=1240
-Defense                             =   12
+MaxHitPoints                        =   1400
+Defense                             =   16
 
 [Attack0Data3]
-Damage                              =   54
+Damage                              =   72
 
 [SpellData3]
 
 [ElementBonus3]
-DAMAGE_TAKEN_FROM_MAGIC             =   .5
-DAMAGE_TAKEN_FROM_RANGED            =   .5
-IMMUNITY_TO_ENCHANTMENT             =   1
 
 [SupportBonus3]
-DAMAGE_TAKEN_FROM_MAGIC             =   .8
-ENTRENCHMENT_RATE_BONUS             =   .6
+ZONE_OF_CONTROL_BONUS               =   1.25
+MORALE_BONUS                        =   8
+ENTRENCHMENT_RATE_BONUS             =   .5
 
 [HeroData]
 AwakenCost                          =   50


### PR DESCRIPTION
### _Changelog:_

### Awakened
	Increased HP from 640 to 650 
	Increased DV from 10 to 12
	Increased AV from 46 to 50
	 
	Increased Rapid Entrenching from 80% to 66% (Provided)
	Added Bravery +2 (Provided)

### Enlightened
	Increased HP from 840 to 900 
	Increased DV from 10 to 13
	Increased AV from 50 to 54 
	
	Decreased Magic Resistant from 70% to 75% (Personal)
	
	Added Dominion 110% (Provided)
	Increased Rapid Entrenching from 75% to 50% (Provided)
	Added Bravery +4 (Provided)
	
### Restored
	Increased HP from 1040 to 1150 
	Increased DV from 10 to 14
	Increased AV from 50 to 60
	
	Decreased Magic Resistant from 60% to 75% (Personal)
	
	Added Dominion 115% (Provided)
	Increased Rapid Entrenching from 70% to 50% (Provided)
	Added Bravery +6 (Provided)
	
### Ascended
	Increased HP from 1240 to 1400 
	Increased DV from 12 to 16
	Increased AV from 54 to 72
	
	Decreased Magic Resistant from 50% to 75% (Personal)
	
	Added Dominion 125% (Provided)
	Increased Rapid Entrenching from 60% to 50%  (Provided)
	Added Bravery 8 (Provided)
	Removed Magic Resistant 80% (Provided)
