### PR TITLE
Lucius ajam rework & Valor+SpiritOfBattle fix

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
@@ -4,11 +4,11 @@ Class                   =   2
 Sprite                  =   units\shock_trooper.tgr
 BoundingRadius          =   0.25
 RotTime                 =   30
-MaxHitPoints            =   530
+MaxHitPoints            =   540
 CostGold                =   0
 BuildTime               =   5
 DetectionRadius         =   100
-Defense                 =   8
+Defense                 =   10
 Faction                 =   Royalist
 
 Moveable                =   1
@@ -38,10 +38,9 @@ CombatValue             =   15.0
 Description             =   His confidants know that when Lucius commits himself to something, he considers it an irrevokable pledge to give everything he can to make it happen. It is this trait that makes him a staunch ally and an implacable foe.  A angry scar cutting across his face, haunted sky-blue eyes, and grim nature conceal a man who was once handsome, jovial, and a leading member of the Council.  Lucius broke from the rest of House Ajam and joined the Royalist cause in the Sixth Age when his wife Lydian was killed and her amulet captured by the Ceyah. He became a tireless and bitter foe of the Ceyah, and to this day he searches for his wife's amulet. ;'
 
 [SpellData]
-MaxMana                 =   60
-ManaRegenerationRate    =   3
+MaxMana                 =   50
+ManaRegenerationRate    =   2
 Spell0                  =   Courage
-Spell1                  =   Recovery
 
 [Attack1]
 Sound1                  =Game\elite_guard_attack.wav
@@ -51,7 +50,7 @@ DamagePoint             =0.5
 ReloadTime              =0.5
 AttackRange             =0.75
 AttackType              =Melee
-Damage                  =36
+Damage                  =46
 DamageType              =Khaldunite
 MoraleDamage            =0
 MoraleDamageType        =Normal
@@ -67,8 +66,12 @@ MoraleDamageType        =   Normal
 Animation		        = 	0		;animations are backwards
 
 [ElementBonus]
+DEFENSE_BONUS_VS_ANY    =   2
+DAMAGE_TAKEN_FROM_RANGED    =   0.5
 
 [SupportBonus]
+DAMAGE_TAKEN_FROM_MAGIC =   0.9
+ATTACK_BONUS_TO_SHADOW  -   2
 ATTACK_BONUS_TO_ROUTED  =   -4
 
 [Level1]

--- a/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
@@ -111,22 +111,21 @@ ATTACK_BONUS_TO_SHADOW  =   4
 ATTACK_BONUS_TO_ROUTED  =   -4
 
 [Level3]
-MaxHitPoints            =   800
+MaxHitPoints            =   900
 
 [SpellData3]
-Spell0                  =   Spirit of Battle
 
 [Attack0Data3]
-Damage                  =   44
 
 [ElementBonus3]
+IMMUNITY_TO_ENCHANTMENT =   1
 DEFENSE_BONUS_VS_ANY    =   10
+DAMAGE_TAKEN_FROM_RANGED    =   0.5
 
 [SupportBonus3]
+DAMAGE_TAKEN_FROM_MAGIC =   0.75
+ATTACK_BONUS_TO_SHADOW  =   6
 ATTACK_BONUS_TO_ROUTED  =   -4
-ATTACK_BONUS_TO_SHADOW  =   8
-HIT_POINTS_BONUS        =   1.2
-MORALE_LOSS_RATE_BONUS  =   .8
 
 [HeroData]
 AwakenCost              =   50

--- a/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
@@ -1,7 +1,7 @@
 [ObjectData]
 ProperName              =   Lucius Ajam
 Class                   =   2
-Sprite                  =   units\shock_trooper.tgr
+Sprite                  =   units\grenadier.tgr
 BoundingRadius          =   0.25
 RotTime                 =   30
 MaxHitPoints            =   540
@@ -27,7 +27,7 @@ CommandSound3           =   Game\agm_hero4_command3.wav
 
 [UnitData]
 Type                    =   Hero
-Icon                    =   Portraits\Unit Icons\Shock_Trooper_icon.tgr
+Icon                    =   Portraits\Unit Icons\Grenadier_icon.tgr
 Portrait                =   Portraits\Heroes\Lucius_Ajam_portrait.tgr
 DieTime                 =   1
 IdleTime                =   2
@@ -43,17 +43,17 @@ ManaRegenerationRate    =   2
 Spell0                  =   Courage
 
 [Attack1]
-Sound1                  =Game\elite_guard_attack.wav
+Sound1                  =   Game\elite_guard_attack.wav
 Sound2                  =   Game\grenadier_attack.wav
-AttackTime              =1
-DamagePoint             =0.5
-ReloadTime              =0.5
-AttackRange             =0.75
-AttackType              =Melee
-Damage                  =46
-DamageType              =Khaldunite
-MoraleDamage            =0
-MoraleDamageType        =Normal
+AttackTime              =   1
+DamagePoint             =   0.5
+ReloadTime              =   0.5
+AttackRange             =   0.75
+AttackType              =   Melee
+Damage                  =   46
+DamageType              =   Khaldunite
+MoraleDamage            =   0
+MoraleDamageType        =   Normal
 
 [Attack2]
 AttackTime              =   1

--- a/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
@@ -93,22 +93,22 @@ ATTACK_BONUS_TO_SHADOW  =   4
 ATTACK_BONUS_TO_ROUTED  =   -4
 
 [Level2]
-MaxHitPoints            =   710
+MaxHitPoints            =   780
 
 [SpellData2]
-Spell1                  =   Renewal
-ManaRegenerationRate    =   4
+Spell0                  =   Valor
 
 [Attack0Data2]
+Damage                  =   56
 
 [ElementBonus2]
-DEFENSE_BONUS_VS_ANY    =   6
+DEFENSE_BONUS_VS_ANY    =   5
+DAMAGE_TAKEN_FROM_RANGED    =   0.5
 
 [SupportBonus2]
+DAMAGE_TAKEN_FROM_MAGIC =   0.8
+ATTACK_BONUS_TO_SHADOW  =   4
 ATTACK_BONUS_TO_ROUTED  =   -4
-ATTACK_BONUS_TO_SHADOW  =   6
-HIT_POINTS_BONUS        =   1.1
-MORALE_LOSS_RATE_BONUS  =   .9
 
 [Level3]
 MaxHitPoints            =   800

--- a/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
@@ -1,7 +1,7 @@
 [ObjectData]
 ProperName              =   Lucius Ajam
 Class                   =   2
-Sprite                  =   units\battle_priest.tgr
+Sprite                  =   units\shock_trooper.tgr
 BoundingRadius          =   0.25
 RotTime                 =   30
 MaxHitPoints            =   530
@@ -17,17 +17,17 @@ Blocking                =   1
 Land                    =   1
 Water                   =   0
 
-DeathSound1             =   Game\ranger_death.wav
-SelectionSound1         =   Game\agm_hero5_select1.wav
-SelectionSound2         =   Game\agm_hero5_select2.wav
-SelectionSound3         =   Game\agm_hero5_select3.wav
-CommandSound1           =   Game\agm_hero5_command1.wav
-CommandSound2           =   Game\agm_hero5_command2.wav
-CommandSound3           =   Game\agm_hero5_command3.wav
+DeathSound1             =   Game\grenadier_death.wav
+SelectionSound1         =   Game\agm_hero4_select1.wav
+SelectionSound2         =   Game\agm_hero4_select2.wav
+SelectionSound3         =   Game\agm_hero4_select3.wav
+CommandSound1           =   Game\agm_hero4_command1.wav
+CommandSound2           =   Game\agm_hero4_command2.wav
+CommandSound3           =   Game\agm_hero4_command3.wav
 
 [UnitData]
 Type                    =   Hero
-Icon                    =   Portraits\Unit Icons\battle_priest_icon.tgr
+Icon                    =   Portraits\Unit Icons\Shock_Trooper_icon.tgr
 Portrait                =   Portraits\Heroes\Lucius_Ajam_portrait.tgr
 DieTime                 =   1
 IdleTime                =   2
@@ -44,10 +44,10 @@ Spell0                  =   Courage
 Spell1                  =   Recovery
 
 [Attack1]
-Sound1                  =Game\battle_priest_melee.wav
-Sound2                  =Game\club2.wav
+Sound1                  =Game\elite_guard_attack.wav
+Sound2                  =   Game\grenadier_attack.wav
 AttackTime              =1
-DamagePoint             =0.6
+DamagePoint             =0.5
 ReloadTime              =0.5
 AttackRange             =0.75
 AttackType              =Melee
@@ -64,6 +64,7 @@ AttackType              =   Cast
 DamageType              =   Normal
 MoraleDamage            =   0
 MoraleDamageType        =   Normal
+Animation		        = 	0		;animations are backwards
 
 [ElementBonus]
 

--- a/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/LUCIUS_AJAM.ini
@@ -71,24 +71,26 @@ DAMAGE_TAKEN_FROM_RANGED    =   0.5
 
 [SupportBonus]
 DAMAGE_TAKEN_FROM_MAGIC =   0.9
-ATTACK_BONUS_TO_SHADOW  -   2
+ATTACK_BONUS_TO_SHADOW  =   2
 ATTACK_BONUS_TO_ROUTED  =   -4
 
 [Level1]
-MaxHitPoints            =   620
+MaxHitPoints            =   660
+Defense                 =   12
 
 [SpellData1]
-MaxMana                 =   70
 
 [Attack0Data1]
-Damage                  =   40
+Damage                  =   50
 
 [ElementBonus1]
-DEFENSE_BONUS_VS_ANY    =   2
+DEFENSE_BONUS_VS_ANY    =   4
+DAMAGE_TAKEN_FROM_RANGED    =   0.5
 
 [SupportBonus1]
-ATTACK_BONUS_TO_ROUTED  =   -4
+DAMAGE_TAKEN_FROM_MAGIC =   0.9
 ATTACK_BONUS_TO_SHADOW  =   4
+ATTACK_BONUS_TO_ROUTED  =   -4
 
 [Level2]
 MaxHitPoints            =   710

--- a/TGX Files/Data/Spells.ini
+++ b/TGX Files/Data/Spells.ini
@@ -1001,7 +1001,7 @@ TargetLoopEffect0 = blessingloop
 
 [ValorBonuses]
 MORALE_LOSS_RATE_BONUS	= .75
-MORALE_CHECK_BONUS	= -5
+MORALE_CHECK_BONUS	= 5
 
 [55]
 Name = Spirit of Battle

--- a/TGX Files/Data/Spells.ini
+++ b/TGX Files/Data/Spells.ini
@@ -1000,7 +1000,7 @@ Sound = spells\courage.wav
 TargetLoopEffect0 = blessingloop
 
 [ValorBonuses]
-MORALE_LOSS_RATE_BONUS	= .75
+MORALE_LOSS_RATE_BONUS	= .50
 MORALE_CHECK_BONUS	= 5
 
 [55]
@@ -1021,7 +1021,7 @@ Sound = spells\spirit_battle.wav
 
 [BattleBonuses]
 MORALE_LOSS_RATE_BONUS	= .8
-MORALE_CHECK_BONUS	= -2
+MORALE_CHECK_BONUS	= 2
 DEFENSE_BONUS_VS_ANY = 4
 ATTACK_BONUS_TO_ANY = 4
 


### PR DESCRIPTION
### _Changelog:_

### Awakened

	Increased HP from 530 to 540
	Increased DV from 8 to 10
	Increased AV from 36 to 46 
	
	Decreased Max Mana from 60 to 50 
	Decreased Mana Regen from 3 to 2
	
	Removed Spell1: Recovery
	
	Added Ranged Resistance 50% (Personal)
	Added Bonus DV 2 (Personal)
	
	Added Shadowbane 2 (Provided)
	Added Magic Resistance 90% (Provided)

### Enlightened

	Increased HP from 620 to 660 
	Increased DV from 8 to 12
	Increased AV from 40 to 50
	Decreased Max Mana from 70 to 50 
	Mana regen 2.0
	
	
	Ranged Resistance 50% (Personal)
	Increased Bonus DV from 2 to 4 (Personal)
	
	
	Added Magic Resistance 90% (Provided)

### Restored

	Increased HP from 710 to 780
	Increased DV from 8 to 12
	Increased AV from 40 to 56 
	
	Decreased Mana Regen from 4 to 2
	
	Spell0: Valor (improved version of Courage)
	Removed Spell1: Renewal
	
	Personal:
	Added Ranged Resistance 50% (Personal)
	Decreased Bonus DV from 6 to 5 (Personal)
	
	
	Provided
	Added Shadowbane 4 (Provided)
	Added Magic Resistance 80% (Provided)
	Chivalry 4 (Provided)
	Removed Healthy 110%
	Removed Courageous 90%
	
### Ascended

	Increased HP from 800 to 900
	Increased AV from 44 to 56 
	Increased DV from 8 to 12
	
	Removed Spell0: Spirit of Battle
	
	Personal:
	Added Ranged Resistance 50% (Personal)
	Added Spell Immunity (Personal)
	
	Provided
	Decreased ShadowBane from 8 to 6 (Provided)
	Added Magic Resistance 75% (Provided)
	Removed Healthy 120%
	Removed Courageous 80%


### Spells:

Corrected an oversight on the Valor spell that gave the company Timid instead of the Valor buff, having the opposite effect as was intended. 

Valor has been adjusted to 50% Courageous instead of 75%, making it a direct upgrade to the Courage Spell.

Spirit of Battle: Timid (-2) corrected to Valor (+2) so the spell doesn't debuff anymore.