### PR TITLE
Leila Javidan rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/RAVYN_DUNN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/RAVYN_DUNN.INI
@@ -76,10 +76,11 @@ Damage                  =   36
 [SupportBonus1]
 
 [Level2]
-MaxHitPoints		=	560
+MaxHitPoints		=	580
 
 [SpellData2]
-Spell0			=	True Healing
+Spell1              =   Mystic Immunity
+ManaRegenerationRate 	=	4
 
 [Attack0Data2]
 Damage			=	38
@@ -87,7 +88,8 @@ Damage			=	38
 [ElementBonus2]
 
 [SupportBonus2]
-DEFENSE_BONUS_VS_SHADOW		= 2
+MORALE_LOSS_RATE_BONUS  =   0.8
+HIT_POINTS_BONUS        =   1.15
 
 [Level3]
 Defense			=	12

--- a/TGX Files/Data/ObjectData/Heroes/RAVYN_DUNN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/RAVYN_DUNN.INI
@@ -4,7 +4,7 @@ Class			= 	2			;enumeration list(int)
 Sprite			=   units\priestess.tgr
 BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	400			;health rating(float)
+MaxHitPoints		=	420			;health rating(float)
 CostGold		=	0			;int
 BuildTime		=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
@@ -36,7 +36,7 @@ CombatValue		= 15
 Description = STRING_2402_Leila_is_a_regal_looking_Kohan_with_long__dark_hair_and_piercing_hazel_eyes__A_Priestess_of_the_Creator__she_wields_powers_channeled_from_the_heavens_in_her_crusade_to_reunite_the_Kohan_and_bring_peace_back_to_Khaldun__She_has_been_awakened_for_some_time_now__but_still_cannot_remember_much_of_her_past_life_
 
 [SpellData]
-MaxMana 		=	60 	;the max amount that mana can be for the unit
+MaxMana 		=	65 	;the max amount that mana can be for the unit
 ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Recovery
 Spell1			=	Courage
@@ -60,6 +60,7 @@ AttackType		=	CAST		; enumeration list (int)
 [ElementBonus]
 
 [SupportBonus]
+HIT_POINTS_BONUS        =   1.1
 
 [Level1]
 MaxHitPoints		=	480

--- a/TGX Files/Data/ObjectData/Heroes/RAVYN_DUNN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/RAVYN_DUNN.INI
@@ -23,10 +23,6 @@ SelectionSound2		=	Game\f_hero3_select_good.wav
 CommandSound1		=	Game\f_hero3_command.wav
 CommandSound2		=	Game\f_hero3_command_good.wav
 
-[ElementBonus]
-
-[SupportBonus]
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Priestess_icon.tgr
@@ -45,10 +41,6 @@ ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Recovery
 Spell1			=	Courage
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0090_Leila_Javidan
-
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
@@ -65,43 +57,51 @@ DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 
+[ElementBonus]
+
+[SupportBonus]
+
 [Level1]
 MaxHitPoints		=	480
-
-[Level2]
-MaxHitPoints		=	560
-
-[Level3]
-Defense			=	12
-MaxHitPoints		=	640
-
-[Attack0Data1]
-
-[Attack0Data2]
-Damage			=	38
-
-[Attack0Data3]
-Damage			=	40
 
 [SpellData1]
 ManaRegenerationRate 	=	4
 
-[SpellData2]
-Spell0			=	True Healing
-
-[SpellData3]
-Spell1			=	Holy Strength
+[Attack0Data1]
 
 [ElementBonus1]
 
 [SupportBonus1]
+
+[Level2]
+MaxHitPoints		=	560
+
+[SpellData2]
+Spell0			=	True Healing
+
+[Attack0Data2]
+Damage			=	38
 
 [ElementBonus2]
 
 [SupportBonus2]
 DEFENSE_BONUS_VS_SHADOW		= 2
 
+[Level3]
+Defense			=	12
+MaxHitPoints		=	640
+
+[SpellData3]
+Spell1			=	Holy Strength
+
+[Attack0Data3]
+Damage			=	40
+
 [ElementBonus3]
 
 [SupportBonus3]
 DEFENSE_BONUS_VS_SHADOW		= 4
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0090_Leila_Javidan

--- a/TGX Files/Data/ObjectData/Heroes/RAVYN_DUNN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/RAVYN_DUNN.INI
@@ -96,15 +96,17 @@ Defense			=	12
 MaxHitPoints		=	640
 
 [SpellData3]
-Spell1			=	Holy Strength
+MaxMana                 =   75
+ManaRegenerationRate    =   6
 
 [Attack0Data3]
-Damage			=	40
+Damage			=	42
 
 [ElementBonus3]
 
 [SupportBonus3]
-DEFENSE_BONUS_VS_SHADOW		= 4
+MORALE_LOSS_RATE_BONUS  =   0.75
+HIT_POINTS_BONUS        =   1.2
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/RAVYN_DUNN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/RAVYN_DUNN.INI
@@ -63,12 +63,13 @@ AttackType		=	CAST		; enumeration list (int)
 HIT_POINTS_BONUS        =   1.1
 
 [Level1]
-MaxHitPoints		=	480
+MaxHitPoints		=	500
 
 [SpellData1]
-ManaRegenerationRate 	=	4
+MaxMana             =   70
 
 [Attack0Data1]
+Damage                  =   36
 
 [ElementBonus1]
 


### PR DESCRIPTION
### _Changelog:_

### Awakened
	Increased HP from 400 to 420 
	Increased Max Mana from 50 to 65 
	
	Added Healthy 110% (Provided)

### Enlightened

	Increased HP from 480 to 500 
	Increased AV from 34 to 36
	
	Increased Max Mana from 50 to 70 
	

### Restored

	Increased HP from 560 to 580 
	
	Increased Mana Regen from 2 to 4
	Spell0: Renewal retained in place of True Healing
	Spell1: Mystic Immunity replaces Courage
	
	Provided
	Added Courageous 80%  (Provided)
	Removed shadow resistant 2 (Provided)
	Added Healthy 115%  (Provided)



### Ascended

	Increased AV from 40 to 42 
	Increased MaxMana from 60 to 75 
	Increased Mana Regen from 4 to 6
	
	Renewal 
	Mystic Immunity retained instead of Holy Strength
	
	Provided
	Added Courageous 75%  (Provided)
	Added Healthy 120%  (Provided)
	Removed Shadow Resistant 4 (Provided)
