### PR TITLE
Aethan farhyd rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/AETHAN_FARHYD.ini
+++ b/TGX Files/Data/ObjectData/Heroes/AETHAN_FARHYD.ini
@@ -79,12 +79,14 @@ DamageType          =   KHALDUNITE
 Damage              =   58
 
 [Attack1Data1]
-Damage              =   32
+Damage              =   42
 
 [ElementBonus1]
-IGNORE_TERRAIN_BONUS=   1
+DAMAGE_TAKEN_FROM_MELEE =   0.9
+IGNORE_TERRAIN_BONUS    =   1
 
 [SupportBonus1]
+ENTRENCHMENT_RATE_BONUS =   1.25
 VISUAL_RANGE_BONUS  =   1.4
 ZONE_OF_CONTROL_BONUS=  1.15
 

--- a/TGX Files/Data/ObjectData/Heroes/AETHAN_FARHYD.ini
+++ b/TGX Files/Data/ObjectData/Heroes/AETHAN_FARHYD.ini
@@ -33,7 +33,7 @@ MovementRate        =   34
 WalkDistance        =   0.77
 ResupplyRate        =   10
 CombatValue         =   15
-Description         =   A crack shot with the bow and equally deadly with his sword, Aethan Farhyd is one of the Nationalists' fiercest warriors. Always dressed in black from head to toe, Aethan prefers to keep to himself, usually skulking in the shadows. If he is found with others, it is usually with his close companions and only friends, Sebastian Atafeh and Ahikar Iraj. If those two are found together, he is often not far behind. It has long been rumored that Aethan had feelings for Ahikar, but if that is true, he has kept those feelings hidden.
+Description         =   A crack shot with the bow and equally deadly with his sword, Aethan Farhyd is one of the Nationalists' fiercest warriors. Always dressed in black from head to toe, Aethan prefers to keep to himself, usually skulking in the shadows. If he is found with others, it is usually with his close companions and only friends, Sebastian Atafeh and Ahikar Iraj. If those two are found together, he is often not far behind. It has long been rumored that Aethan had feelings for Ahikar, but if that is true, he has kept those feelings hidden. ;'
 
 
 [Attack1]
@@ -58,7 +58,7 @@ DamagePoint         =   0.3
 ReloadTime          =   0.5
 AttackRange         =   0.75
 AttackType          =   Melee
-Damage              =   30
+Damage              =   40
 DamageType          =   Normal
 MoraleDamage        =   0
 MoraleDamageType    =   Normal
@@ -67,6 +67,7 @@ MoraleDamageType    =   Normal
 IGNORE_TERRAIN_BONUS=   1
 
 [SupportBonus]
+ENTRENCHMENT_RATE_BONUS =   1.25
 VISUAL_RANGE_BONUS  =   1.25
 ZONE_OF_CONTROL_BONUS   =  1.1
 

--- a/TGX Files/Data/ObjectData/Heroes/AETHAN_FARHYD.ini
+++ b/TGX Files/Data/ObjectData/Heroes/AETHAN_FARHYD.ini
@@ -91,20 +91,21 @@ VISUAL_RANGE_BONUS  =   1.4
 ZONE_OF_CONTROL_BONUS=  1.15
 
 [Level2]
-MaxHitPoints        =   630
+MaxHitPoints        =   690
 
 [Attack0Data2]
 Damage              =   62
 
 [Attack1Data2]
 DamageType          =   VORPAL
-Damage              =   36
+Damage              =   44
 
 [ElementBonus2]
+DAMAGE_TAKEN_FROM_MELEE =   0.9
 
 [SupportBonus2]
-ENTRENCHMENT_RATE_BONUS=    1.1
 IGNORE_TERRAIN_BONUS=   1
+ENTRENCHMENT_RATE_BONUS =   1.25
 VISUAL_RANGE_BONUS  =   1.5
 ZONE_OF_CONTROL_BONUS=  1.2
 

--- a/TGX Files/Data/ObjectData/Heroes/AETHAN_FARHYD.ini
+++ b/TGX Files/Data/ObjectData/Heroes/AETHAN_FARHYD.ini
@@ -110,21 +110,22 @@ VISUAL_RANGE_BONUS  =   1.5
 ZONE_OF_CONTROL_BONUS=  1.2
 
 [Level3]
-MaxHitPoints        =   770
+MaxHitPoints        =   790
+Defense             =   10
 
 [Attack0Data3]
 Damage              =   66
 
 [Attack1Data3]
-Damage              =   40
+Damage              =   50
 
 [ElementBonus3]
 
 [SupportBonus3]
-ENTRENCHMENT_RATE_BONUS=    1.25
 IGNORE_TERRAIN_BONUS=   1
+ENTRENCHMENT_RATE_BONUS=    1.25
 VISUAL_RANGE_BONUS  = 1.6
-ZONE_OF_CONTROL_BONUS=  1.25
+ZONE_OF_CONTROL_BONUS=  1.2
 
 
 [HeroData]


### PR DESCRIPTION
### _Changelog:_

### Awakened:
	
	Increased AV from 30 to 40Melee 
	
	
	Added Slow Entrenching 125% (Provided)

### Enlightened:

	Increased Melee AV from 32 to 42  
	
	Added Melee Resistance 90% (Personal)
	
	Added Slow Entrenchment 125% (Provided)

### Restored:

	Increased HP from 630 to 690 
	Increased Melee  AV from 36 to 44 
	
	Added Melee Resistance 90% (Personal)
	
	Increased Slow Entrenchment from 110% to 125% (Provided)

### Ascended:

	Increased HP from 770 to 790 
	Increased DV from 8 to 10
	Increased Melee AV from 40 to 50
	
	Added Melee Resistance 90% (Personal)
	
	Decreased Dominion from 125% to 120% (Provided)
