### PR TITLE
Thaddius Maesun Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SYRIUS_MAESUN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SYRIUS_MAESUN.INI
@@ -90,12 +90,15 @@ MaxHitPoints		=	1000
 ManaRegenerationRate 	=	2
 
 [Attack0Data2]
-Damage			=	42
+Damage			=	52
 
 [ElementBonus2]
+IMMUNITY_TO_ENCHANTMENT     =   1
+DAMAGE_TAKEN_FROM_RANGED   =    0.5
+MELEE_HOLY_DAMAGE		= 8
 
 [SupportBonus2]
-MORALE_LOSS_RATE_BONUS		= .8
+MORALE_LOSS_RATE_BONUS		= .9
 ATTACK_BONUS_TO_SHADOW		= 4
 
 [Level3]

--- a/TGX Files/Data/ObjectData/Heroes/SYRIUS_MAESUN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SYRIUS_MAESUN.INI
@@ -23,16 +23,6 @@ SelectionSound2		=	Game\m_hero3_select_good.wav
 CommandSound1		=	Game\m_hero3_command2.wav
 CommandSound2		=	Game\m_hero3_command_good.wav
 
-[SpellData]
-MaxMana 		=	50 	;the max amount that mana can be for the unit
-ManaRegenerationRate 	=	1	;the amount of mana that gets regenerated sec.
-
-[ElementBonus]
-MELEE_HOLY_DAMAGE		= 12
-
-[SupportBonus]
-ATTACK_BONUS_TO_SHADOW		= 2
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Paladin_icon.tgr
@@ -46,9 +36,9 @@ MeleeFX			= paladin_hitfx
 CombatValue		= 15
 Description = STRING_2414_Thaddeus_Maesun_is_a_very_serious_man__Humor_is_rarely_allowed_to_touch_upon_his_face__Awakened_recently_he_has_instantly_rededicated_his_whole_being_to_the_destruction_of_anything_linked_to_the_Shadow__Unfortunately_for_creatures_of_shadow__Thaddeus_is_trained_in_the_holy_arts_of_the_paladin__making_him_a_perfect_weapon_to_set_against_the_Dark_Master_
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0086_Thaddeus_Maesun
+[SpellData]
+MaxMana 		=	50 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	1	;the amount of mana that gets regenerated sec.
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
@@ -68,33 +58,19 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation		= 	0		;animations are backwards
 
+[ElementBonus]
+MELEE_HOLY_DAMAGE		= 12
+
+[SupportBonus]
+ATTACK_BONUS_TO_SHADOW		= 2
+
 [Level1]
 MaxHitPoints		=	800
-
-[Level2]
-MaxHitPoints		=	1000
-
-[Level3]
-MaxHitPoints		=	1200
-;Technology		= SampleTech
-
-[Attack0Data1]
-
-[Attack0Data2]
-Damage			=	42
-
-[Attack0Data3]
-Damage			=	46
 
 [SpellData1]
 Spell0			=	Banish Shadow
 
-[SpellData2]
-ManaRegenerationRate 	=	2
-
-[SpellData3]
-ManaRegenerationRate 	=	3
-MaxMana 		=	60
+[Attack0Data1]
 
 [ElementBonus1]
 
@@ -102,14 +78,38 @@ MaxMana 		=	60
 MORALE_LOSS_RATE_BONUS		= .9
 ATTACK_BONUS_TO_SHADOW		= 2
 
+[Level2]
+MaxHitPoints		=	1000
+
+[SpellData2]
+ManaRegenerationRate 	=	2
+
+[Attack0Data2]
+Damage			=	42
+
 [ElementBonus2]
 
 [SupportBonus2]
 MORALE_LOSS_RATE_BONUS		= .8
 ATTACK_BONUS_TO_SHADOW		= 4
 
+[Level3]
+MaxHitPoints		=	1200
+;Technology		= SampleTech
+
+[SpellData3]
+ManaRegenerationRate 	=	3
+MaxMana 		=	60
+
+[Attack0Data3]
+Damage			=	46
+
 [ElementBonus3]
 
 [SupportBonus3]
 MORALE_LOSS_RATE_BONUS		= .75
 ATTACK_BONUS_TO_SHADOW		= 4
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0086_Thaddeus_Maesun

--- a/TGX Files/Data/ObjectData/Heroes/SYRIUS_MAESUN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SYRIUS_MAESUN.INI
@@ -37,7 +37,7 @@ CombatValue		= 15
 Description = STRING_2414_Thaddeus_Maesun_is_a_very_serious_man__Humor_is_rarely_allowed_to_touch_upon_his_face__Awakened_recently_he_has_instantly_rededicated_his_whole_being_to_the_destruction_of_anything_linked_to_the_Shadow__Unfortunately_for_creatures_of_shadow__Thaddeus_is_trained_in_the_holy_arts_of_the_paladin__making_him_a_perfect_weapon_to_set_against_the_Dark_Master_
 
 [SpellData]
-MaxMana 		=	50 	;the max amount that mana can be for the unit
+MaxMana 		=	40 	;the max amount that mana can be for the unit
 ManaRegenerationRate 	=	1	;the amount of mana that gets regenerated sec.
 
 [Attack1]
@@ -59,7 +59,7 @@ AttackType		=	CAST		; enumeration list (int)
 Animation		= 	0		;animations are backwards
 
 [ElementBonus]
-DAMAGE_TAKEN_FROM_RANGED   =    50
+DAMAGE_TAKEN_FROM_RANGED   =    0.5
 MELEE_HOLY_DAMAGE		= 8
 
 [SupportBonus]
@@ -73,8 +73,11 @@ MaxHitPoints		=	800
 Spell0			=	Banish Shadow
 
 [Attack0Data1]
+Damage              =   46
 
 [ElementBonus1]
+DAMAGE_TAKEN_FROM_RANGED   =    0.5
+MELEE_HOLY_DAMAGE		= 8
 
 [SupportBonus1]
 MORALE_LOSS_RATE_BONUS		= .9

--- a/TGX Files/Data/ObjectData/Heroes/SYRIUS_MAESUN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SYRIUS_MAESUN.INI
@@ -46,7 +46,7 @@ DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	38		;number (float)
+Damage			=	42		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\paladin_attack.wav
 Sound2			= 	Game\sword1.wav
@@ -59,9 +59,11 @@ AttackType		=	CAST		; enumeration list (int)
 Animation		= 	0		;animations are backwards
 
 [ElementBonus]
-MELEE_HOLY_DAMAGE		= 12
+DAMAGE_TAKEN_FROM_RANGED   =    50
+MELEE_HOLY_DAMAGE		= 8
 
 [SupportBonus]
+MORALE_LOSS_RATE_BONUS      =   0.95
 ATTACK_BONUS_TO_SHADOW		= 2
 
 [Level1]

--- a/TGX Files/Data/ObjectData/Heroes/SYRIUS_MAESUN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SYRIUS_MAESUN.INI
@@ -103,19 +103,23 @@ ATTACK_BONUS_TO_SHADOW		= 4
 
 [Level3]
 MaxHitPoints		=	1200
+Defense             =   16
 ;Technology		= SampleTech
 
 [SpellData3]
-ManaRegenerationRate 	=	3
-MaxMana 		=	60
+ManaRegenerationRate 	=	2
+MaxMana 		=	50
 
 [Attack0Data3]
-Damage			=	46
+Damage			=	56
 
 [ElementBonus3]
+IMMUNITY_TO_ENCHANTMENT     =   1
+DAMAGE_TAKEN_FROM_RANGED   =    0.5
+MELEE_HOLY_DAMAGE		= 12
 
 [SupportBonus3]
-MORALE_LOSS_RATE_BONUS		= .75
+MORALE_LOSS_RATE_BONUS		= .8
 ATTACK_BONUS_TO_SHADOW		= 4
 
 [HeroData]


### PR DESCRIPTION
### _Changelog:_

### Awakened 
	Increased AV from 38 to 42
	
	
	Added Ranged Resistance 50% (Personal)
	Decreased Bonus Holy Damage from 12 to +8  (Personal)
	
	Added Courageous 95% (Provided)
	
### Enlightened
	Increased AV from 38 to 46
	Decreased MaxMana from 50 to 40 
	
	
	Added Ranged Resistance 50%  (Personal)
	Decreased Bonus Holy Damage from 12 to +8  (Personal)
	
	Decreased MaxMana from 50 to 40 
	
	

### Restored
	Increased AV from 42 to 52
	
	Added Ranged resist 50% (Personal)
	Decreased Bonus Holy Damage from 12 to +8  (Personal)
	Added Spell Immunity (Personal)
	
	Decreased Courageous from 80% to 90%  (Provided)
	

### Ascended 
	Increased AV from 46 to 56 
	Increased DV from 14 to 16 
	Decreased Max Mana from 60 to 50 
	Decreased Mana Regen from 3 to 2
	
	
	Added Ranged Resist 50% (Personal)
	Added Spell Immunity (Personal)
	
	Decreased Courageous from 75% to 80% (Provided)
