### PR TITLE
Elite Bowman Discount changed to Armory Guild

### DIFF
--- a/TGX Files/Data/ObjectData/units/ELITE_ARCHER.INI
+++ b/TGX Files/Data/ObjectData/units/ELITE_ARCHER.INI
@@ -33,7 +33,7 @@ CombatValue                             =   10.0
 BannerFrame                             =   8
 ResupplyRate                            =   8
 Description                             =   STRING_2475_The_archery_forces_of_the_Kohan__elite_bowmen_wield_powerful_bows_that_fire_khaldunite_tipped_arrows_
-Group1                                  =   1
+Group1                                  =   2
 
 [CompanyData]
 Morale                                  =   50


### PR DESCRIPTION
### _Changelog:_

As the title says, Elite Bowmen will get their discount from Armory Guild instead of Carpentry Guild, just like Crossbowmen.