### PR TITLE
Player faction neutral changes

### DIFF
--- a/TGX Files/Data/ObjectData/buildings/CEYAH_CITY.INI
+++ b/TGX Files/Data/ObjectData/buildings/CEYAH_CITY.INI
@@ -10,7 +10,7 @@ Defense			=	0	;number (float)
 RotTime			=	120	;seconds(float)
 Description		= 	STRING_2165_Mareten_City
 Faction			=	Ceyah
-Weight			=	1
+Weight			=	0
 
 SelectionSound1	= 	Game\select_settlement.wav
 DeathSound1		=	Game\building_destroyed.wav

--- a/TGX Files/Data/ObjectData/buildings/CEYAH_TOWN.INI
+++ b/TGX Files/Data/ObjectData/buildings/CEYAH_TOWN.INI
@@ -10,7 +10,7 @@ Defense			=	0	;number (float)
 RotTime			=	120	;seconds(float)
 Description		= 	STRING_2168_Mareten_Town
 Faction			=	Ceyah
-Weight			=	10
+Weight			=	1
 
 SelectionSound1	= 	Game\select_settlement.wav
 DeathSound1		=	Game\building_destroyed.wav

--- a/TGX Files/Data/ObjectData/buildings/COUNCIL_CITY.INI
+++ b/TGX Files/Data/ObjectData/buildings/COUNCIL_CITY.INI
@@ -10,7 +10,7 @@ Defense			=	0	;number (float)
 RotTime			=	120	;seconds(float)
 Description		= 	STRING_2165_Mareten_City
 Faction			=	Council
-Weight			=	1
+Weight			=	0
 
 SelectionSound1	= 	Game\select_settlement.wav
 DeathSound1		=	Game\building_destroyed.wav

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_CITY.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_CITY.INI
@@ -10,7 +10,7 @@ Defense			=	0	;number (float)
 RotTime			=	120	;seconds(float)
 Description		= 	STRING_2165_Mareten_City
 Faction			=	Nationalist
-Weight			=	1
+Weight			=	0
 
 SelectionSound1	= 	Game\select_settlement.wav
 DeathSound1		=	Game\building_destroyed.wav

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_TOWN.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_TOWN.INI
@@ -10,7 +10,7 @@ Defense			=	0	;number (float)
 RotTime			=	120	;seconds(float)
 Description		= 	STRING_2168_Mareten_Town
 Faction			=	Nationalist
-Weight			=	10
+Weight			=	1
 
 SelectionSound1	= 	Game\select_settlement.wav
 DeathSound1		=	Game\building_destroyed.wav

--- a/TGX Files/Data/ObjectData/buildings/ROYALIST_CITY.INI
+++ b/TGX Files/Data/ObjectData/buildings/ROYALIST_CITY.INI
@@ -10,7 +10,7 @@ Defense			=	0	;number (float)
 RotTime			=	120	;seconds(float)
 Description		= 	STRING_2165_Mareten_City
 Faction			=	Royalist
-Weight			=	1
+Weight			=	0
 
 SelectionSound1	= 	Game\select_settlement.wav
 DeathSound1		=	Game\building_destroyed.wav


### PR DESCRIPTION
### _Changelog:_

All cities (Ceyah, Council, Nationalist, Royalist) no longer spawn as neutrals on random maps.

Ceyah and Nationalist towns have been known to ruin random map games from their massive impact, and have been adjusted to be as rare as cities used to be.