### PR TITLE
Captain adjustment:

### DIFF
--- a/TGX Files/Data/ObjectData/buildings/DARK_RIFT.INI
+++ b/TGX Files/Data/ObjectData/buildings/DARK_RIFT.INI
@@ -26,7 +26,7 @@ SupplyRange		=	0			;tiles (float)
 CompanySize		=	1			; militia per company
 MilitiaStart		=	1
 MaxMilitia		=	1			; total max militia
-MilitiaType		=	Shadow_Devil		; militia type
+MilitiaType		=	Shadow_Lord		; militia type
 MilitiaGrowth		=	0			; points per second
 
 ;Animations are drawn in order of declaration in INI file (1,2,3,...)

--- a/TGX Files/Data/ObjectData/units/CREATURE.INI
+++ b/TGX Files/Data/ObjectData/units/CREATURE.INI
@@ -1,16 +1,17 @@
 [ObjectData]
-ProperName = STRING_2555_Undead_Captain
+ProperName = STRING_2455_Creature
+MonsterCompanyName = STRING_2886_Creatures
 Class			= 	0			;enumeration list(int)
-Sprite			=   units\undead_captain.tgr
+Sprite			=   units\rhaksha.tgr
 BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	300			;health rating(float)
-CostGold		=	10			;int
+MaxHitPoints		=	150			;health rating(float)
+CostGold		=	0			;int
+CostMana		=	0			;int
 UpkeepGold		=	0			;int
-CostMana		=	1			;int
-CostIron		=	1			;int
+UpkeepMana		=	0			:int
 BuildTime		=	5			;seconds(float)
-Defense			=	10			;number (float)
+Defense			=	6			;number (float)
 DieTime			=	1			;seconds(float)
 
 Moveable		=	1			;BOOLEAN
@@ -19,40 +20,40 @@ Blocking		=	1			;BOOLEAN
 Land			=	1			;BOOLEAN
 Water			=	0			;BOOLEAN
 
-DeathSound1		=	Game\zombie_death.wav
+DeathSound1		=	Game\rhaksha_death.wav
+SelectionSound1		=	Game\select_rhaksha.wav
+CommandSound1		=	Game\select_rhaksha.wav
 
+[UnitData]
+Type			=	MONSTER
+Icon			=   Portraits\Unit Icons\Rhaksha_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	24			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	3.0		; SAI combat rating (float)
+ResupplyRate		=	1		; health / second (float)
+Description 		= STRING_2456_Foul_creatures_of_unknown_origin__these_beasts_are_violent_and_dangerous_
 
 [ElementBonus]
-DAMAGE_TAKEN_FROM_RANGED	= .25
+ATTACK_BONUS_TO_ROUTED	= 4
 
 [SupportBonus]
 
 [CompanyData]
-
-[UnitData]
-Type			=	CAPTAIN
-Shadow			=	1
-Icon			=   Portraits\Unit Icons\Undead_Captain_icon.tgr
-Portrait		=	Portraits\Heroes\Undead_Captain_Portrait.tgr
-IdleTime		=	2			;seconds(float)
-MovementRate		=	26			;movement points(float)
-WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
-CombatValue		=	10.0		; SAI combat rating (float)
-ResupplyRate		=	15			; health / second (float)
-Description 		= STRING_2556_The_undead_captain_is_the_unholy_monster_created_to_lead_the_forces_of_evil_into_battle_
-Group1			= 10
-Group2			= 15
+Morale			= 40
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 0
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
-DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animation to apply damage
+DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animation to apply damage
 ReloadTime		=	0.5		;seconds(float)
-AttackRange		=	.75		;tiles (float)
+AttackRange		=	0.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	30		;number (float)
+Damage			=	24		;number (float)
 DamageType		=	NORMAL
-Sound1			= 	Game\sword4.wav
-Sound2			= 	Game\sword3.wav
+Sound1			= 	Game\rhaksha_attack.wav
 
 [Attack2]
 AttackTime		=	0		;seconds(float) seconds per animation cycle

--- a/TGX Files/Data/ObjectData/units/GRENADIER.INI
+++ b/TGX Files/Data/ObjectData/units/GRENADIER.INI
@@ -26,7 +26,7 @@ CommandSound2                   =   Game\command_infantry2.wav
 
 [UnitData]
 Type                            =   FRONT
-Captain                         =   shadow_lord
+Captain                         =   captain
 Icon                            =   Portraits\Unit Icons\Grenadier_icon.tgr
 IdleTime                        =   2
 MovementRate                    =   15

--- a/TGX Files/Data/ObjectData/units/SHADOW_KNIGHT.INI
+++ b/TGX Files/Data/ObjectData/units/SHADOW_KNIGHT.INI
@@ -28,7 +28,7 @@ CommandSound3               =   Game\shadow_knight_command3.wav
 [UnitData]
 Type                        =   FRONT
 Shadow                      =   1
-Captain                     =   creature
+Captain                     =   undead_captain
 Icon                        =   Portraits\Unit Icons\Shadowknight_icon.tgr
 IdleTime                    =   2
 MovementRate                =   16

--- a/TGX Files/Data/ObjectData/units/SHADOW_LORD.INI
+++ b/TGX Files/Data/ObjectData/units/SHADOW_LORD.INI
@@ -1,15 +1,18 @@
 [ObjectData]
-ProperName = STRING_1637_Captain
-Class			= 	0			;enumeration list(int)
-Sprite			=   units\captain.tgr
+ProperName = STRING_2531_Shadow_Lord
+MonsterCompanyName = STRING_2531_Shadow_Lord
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\shadow_lord.tgr
 BoundingRadius		=	0.25		;tiles(float)
-RotTime			=	30			;seconds(float)
-MaxHitPoints		=	300			;health rating(float)
-CostGold		=	15			;int
+RotTime			=	.5			;seconds(float)
+MaxHitPoints		=	1800		;health rating(float)
+CostGold		=	0			;int
 UpkeepGold		=	0			;int
-BuildTime		=	5			;seconds(float)
-Defense			=	10			;number (float)
-DieTime			=	1			;seconds(float)
+UpkeepIron		=	0			;int
+UpkeepMana		=	0			;int
+BuildTime		=	10			;seconds(float)
+Defense			=	16			;number (float)
+DieTime			= 	2
 
 Moveable		=	1			;BOOLEAN
 Selectable		=	1			;BOOLEAN
@@ -17,45 +20,57 @@ Blocking		=	1			;BOOLEAN
 Land			=	1			;BOOLEAN
 Water			=	0			;BOOLEAN
 
-DeathSound1		=	Game\infantry_death.wav
-
-[ElementBonus]
-DAMAGE_TAKEN_FROM_RANGED	= .5
-
-[SupportBonus]
-RESUPPLY_RATE_BONUS=1.2
-
-[CompanyData]
+DeathSound1		=	Game\Shadow_lord_death.wav
+SelectionSound1		=	Game\select_shadow_lord.wav
+CommandSound1		=	Game\select_shadow_lord.wav
 
 [UnitData]
-Type			=	CAPTAIN
-Icon			=   Portraits\Unit Icons\Captain_icon.tgr
-Portrait		=	Portraits\Heroes\Captain_Portrait.tgr
+Type			=	SOLO
+Shadow			=	1
+Portrait		=   Portraits\Heroes\Shadow_Lord_Portrait.tgr
 IdleTime		=	2			;seconds(float)
-MovementRate		=	26			;movement points(float)
-WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
-CombatValue		=	10.0 		; SAI combat rating (float)
-ResupplyRate		=	15			; health / second (float)
-Description 		= STRING_2445_The_captain_is_the_fighting_warrior_trained_to_lead_a_company_into_battle_
-Group1			= 8
-Group2			= 11
-Group3			= 9
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	75.0		; SAI combat rating (float)
+ResupplyRate		=	10		; health / second (float)
+AttachedFX0		=	shadow_demon_combustion_trail
+AttachedFX1		=	shadow_lord_combustion
+MeleeFx			= 	drakeburst
+Description 		= STRING_2532_Shadow_Lords_are_the_most_dangerous_of_all_shadow_creatures__They_are_capable_of_summoning_other_shadow_creatures_to_fight_along_side_of_them__Though_they_are_dangerous_enough_without_minions_
+
+
+[SpellData]
+MaxMana 		= 50 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 3		;the amount of mana that gets regenerated per update (30 times/sec)
+Spell0 			= Summon Shadow Demons
+
+[ElementBonus]
+MELEE_UNHOLY_DAMAGE		= 10
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.5
+REVERSE_DAMAGE_WHEN_HIT		= 8
+DAMAGE_TAKEN_FROM_RANGED	= .5
+IMMUNITY_TO_ENCHANTMENT		= 1
+IGNORE_TERRAIN_BONUS 		= 1
+
+[SupportBonus]
+
+[CompanyData]
+Berserk			= 1
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
-DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animation to apply damage
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
 ReloadTime		=	0.5		;seconds(float)
-AttackRange		=	.75		;tiles (float)
-AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	28		;number (float)
+AttackRange		=	1.25		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)	
+Damage			=	50		;number (float)
 DamageType		=	NORMAL
-Sound1			= 	Game\captain_attack.wav
-Sound2			= 	Game\sword3.wav
+Sound1			= 	Game\shadow_lord_attack.wav
+Animation = 0
 
 [Attack2]
-AttackTime		=	0		;seconds(float) seconds per animation cycle
-DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
-ReloadTime		=	0		;seconds(float)
-AttackRange		=	0		;tiles (float)
-AttackType		=	0		;enumeration list(int)	
-DamageType		=	0		;number (float)
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.25		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		= 1

--- a/TGX Files/Data/ObjectData/units/SHOCK_TROOPER.INI
+++ b/TGX Files/Data/ObjectData/units/SHOCK_TROOPER.INI
@@ -28,7 +28,7 @@ CommandSound2               =   Game\command_infantry2.wav
 
 [UnitData]
 Type                        =   FRONT
-Captain                     =   shadow_lord
+Captain                     =   captain
 Icon                        =   Portraits\Unit Icons\Shock_Trooper_icon.tgr
 IdleTime                    =   2
 MovementRate                =   18

--- a/TGX Files/Data/ObjectData/units/UNDEAD_CAPTAIN.INI
+++ b/TGX Files/Data/ObjectData/units/UNDEAD_CAPTAIN.INI
@@ -24,8 +24,7 @@ DeathSound1		=	Game\zombie_death.wav
 
 [ElementBonus]
 DAMAGE_TAKEN_FROM_RANGED	= .25
-DAMAGE_TAKEN_FROM_HOLY		= 2
-DAMAGE_TAKEN_FROM_MAGIC		= 1.25
+
 
 [SupportBonus]
 


### PR DESCRIPTION
### _Changelog:_

Changes the Creature unit from being an alternate Undead Captain for Shadow Knights back to its default state. This allows for the basic tutorial to be playable with the mod.

Changes the Shadow Lord unit from being an alternate captain for Grenadiers and Elite Guards back to its default state. This fixes maps like Bonehenge and allows for shadow lords to be used as lair monsters.

This does however mean that Grenadier and Elite Guard captains lose their 120% quicker recovery.

It's a necessity that the Shadow Knight captain is not vulnerable to magic and holy damage like most undead. Therefore those vulnerabilities have been removed from the regular Undead Captain, so they are now a lot more durable to holy and magic damage.