### PR TITLE
Sijansur Rework

### DIFF
--- a/TGX Files/Data/ModInfo.ini
+++ b/TGX Files/Data/ModInfo.ini
@@ -1,6 +1,6 @@
 [ModInfo]
 TwoCharacterIdentifier=KG
-Version=0.5.0
+Version=0.5.2
 Author=KohanCitadel
 Author_www=https://discord.gg/U4K4vPS
 Author_email=

--- a/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
@@ -23,17 +23,6 @@ SelectionSound2		=	Game\m_hero4_select_evil.wav
 CommandSound1		=	Game\m_hero4_command2.wav
 CommandSound2		=	Game\m_hero4_command_evil.wav
 
-[ElementBonus]
-IMMUNITY_TO_ENCHANTMENT		= 1
-DAMAGE_TAKEN_FROM_RANGED	= .5
-
-[SupportBonus]
-DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
-
-[SpellData]
-MaxMana 		=	50 	;the max amount that mana can be for the unit
-ManaRegenerationRate 	=	2	;the amount of mana that gets regenerated sec.
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Grenadier_icon.tgr
@@ -46,9 +35,9 @@ ResupplyRate	=	10			; health / second (float)
 CombatValue		= 15
 Description = STRING_2413_Sijansur_is_a_powerful_general_of_the_Ceyah_forces__He_was_horrifically_scarred_in_battle_by_magical_forces__resulting_in_a_terrible_disfigurement_his_immortal_body_could_not_heal__He_now_wears_a_demonic_looking_mask_that_has_never_been_removed_since_the_day_he_first_placed_it_over_his_face__He_is_well_known_for_his_relentlessness_in_pursuing_his_enemies_after_they_have_broken_from_the_field_
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0035_Sijansur
+[SpellData]
+MaxMana 		=	50 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	2	;the amount of mana that gets regenerated sec.
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
@@ -67,30 +56,19 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation		= 	0		;animations are backwards
 
+[ElementBonus]
+IMMUNITY_TO_ENCHANTMENT		= 1
+DAMAGE_TAKEN_FROM_RANGED	= .5
+
+[SupportBonus]
+DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
+
 [Level1]
 MaxHitPoints		=	750
 
-[Level2]
-MaxHitPoints		=	960
-Defense			=	14
-
-[Level3]
-MaxHitPoints		=	1170
-
-[Attack0Data1]
-
-[Attack0Data2]
-Damage			=	48
-
-[Attack0Data3]
-Damage			=	52
-
 [SpellData1]
 
-[SpellData2]
-
-[SpellData3]
-Spell0			=	Immortal Fury
+[Attack0Data1]
 
 [ElementBonus1]
 IMMUNITY_TO_ENCHANTMENT		= 1
@@ -98,6 +76,15 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
+
+[Level2]
+MaxHitPoints		=	960
+Defense			=	14
+
+[SpellData2]
+
+[Attack0Data2]
+Damage			=	48
 
 [ElementBonus2]
 IMMUNITY_TO_ENCHANTMENT		= 1
@@ -107,6 +94,15 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 ATTACK_BONUS_TO_ANY		= 2
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
 
+[Level3]
+MaxHitPoints		=	1170
+
+[SpellData3]
+Spell0			=	Immortal Fury
+
+[Attack0Data3]
+Damage			=	52
+
 [ElementBonus3]
 IMMUNITY_TO_ENCHANTMENT		= 1
 DAMAGE_TAKEN_FROM_RANGED	= .5
@@ -114,3 +110,7 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 [SupportBonus3]
 ATTACK_BONUS_TO_ANY		= 4
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0035_Sijansur

--- a/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
@@ -4,11 +4,11 @@ Class			= 	2			;enumeration list(int)
 Sprite			=   units\Grenadier.tgr
 BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	540			;health rating(float)
+MaxHitPoints		=	550			;health rating(float)
 CostGold		=	0			;int
 BuildTime		=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
-Defense			=	12			;number (float)
+Defense			=	14			;number (float)
 Faction			=	Ceyah
 
 Moveable		=	1			;BOOLEAN
@@ -45,7 +45,7 @@ DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	0.75	;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	44		;number (float)
+Damage			=	40		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\sword4.wav
 
@@ -61,6 +61,7 @@ IMMUNITY_TO_ENCHANTMENT		= 1
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus]
+ATTACK_BONUS_TO_ROUTED          =   4
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
 
 [Level1]

--- a/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
@@ -71,8 +71,6 @@ MaxHitPoints		=	760
 Damage                      =   44
 
 [ElementBonus1]
-IMMUNITY_TO_ENCHANTMENT		= 1
-DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
 ATTACK_BONUS_TO_ANY             =   2
@@ -88,8 +86,6 @@ MaxHitPoints		=	970
 Damage			=	48
 
 [ElementBonus2]
-IMMUNITY_TO_ENCHANTMENT		= 1
-DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus2]
 ATTACK_BONUS_TO_ANY             =   4
@@ -109,8 +105,6 @@ Spell0			=	Immortal Fury
 Damage			=	50
 
 [ElementBonus3]
-IMMUNITY_TO_ENCHANTMENT		= 1
-DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
 ATTACK_BONUS_TO_ANY             =   4

--- a/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
@@ -65,18 +65,21 @@ ATTACK_BONUS_TO_ROUTED          =   4
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
 
 [Level1]
-MaxHitPoints		=	750
+MaxHitPoints		=	760
 
 [SpellData1]
 
 [Attack0Data1]
+Damage                      =   44
 
 [ElementBonus1]
 IMMUNITY_TO_ENCHANTMENT		= 1
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
-DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
+ATTACK_BONUS_TO_ANY             =   2
+ATTACK_BONUS_TO_ROUTED          =   6
+DAMAGE_TAKEN_FROM_KHALDUNITE	= .75
 
 [Level2]
 MaxHitPoints		=	960

--- a/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
@@ -82,8 +82,7 @@ ATTACK_BONUS_TO_ROUTED          =   6
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .75
 
 [Level2]
-MaxHitPoints		=	960
-Defense			=	14
+MaxHitPoints		=	970
 
 [SpellData2]
 
@@ -95,8 +94,9 @@ IMMUNITY_TO_ENCHANTMENT		= 1
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus2]
-ATTACK_BONUS_TO_ANY		= 2
-DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
+ATTACK_BONUS_TO_ANY             =   4
+ATTACK_BONUS_TO_ROUTED          =   6
+DAMAGE_TAKEN_FROM_KHALDUNITE	= .7
 
 [Level3]
 MaxHitPoints		=	1170

--- a/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
@@ -36,8 +36,6 @@ CombatValue		= 15
 Description = STRING_2413_Sijansur_is_a_powerful_general_of_the_Ceyah_forces__He_was_horrifically_scarred_in_battle_by_magical_forces__resulting_in_a_terrible_disfigurement_his_immortal_body_could_not_heal__He_now_wears_a_demonic_looking_mask_that_has_never_been_removed_since_the_day_he_first_placed_it_over_his_face__He_is_well_known_for_his_relentlessness_in_pursuing_his_enemies_after_they_have_broken_from_the_field_
 
 [SpellData]
-MaxMana 		=	50 	;the max amount that mana can be for the unit
-ManaRegenerationRate 	=	2	;the amount of mana that gets regenerated sec.
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
@@ -99,21 +97,25 @@ ATTACK_BONUS_TO_ROUTED          =   6
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .7
 
 [Level3]
-MaxHitPoints		=	1170
+MaxHitPoints		=	1180
+Defense             =   16
 
 [SpellData3]
+MaxMana 		=	50 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	2	;the amount of mana that gets regenerated sec.
 Spell0			=	Immortal Fury
 
 [Attack0Data3]
-Damage			=	52
+Damage			=	50
 
 [ElementBonus3]
 IMMUNITY_TO_ENCHANTMENT		= 1
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
-ATTACK_BONUS_TO_ANY		= 4
-DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
+ATTACK_BONUS_TO_ANY             =   4
+ATTACK_BONUS_TO_ROUTED          =   10
+DAMAGE_TAKEN_FROM_KHALDUNITE	= .65
 
 [HeroData]
 AwakenCost		=	50


### PR DESCRIPTION
### __Changelog:__

### Awakened

	Increased HP from 540 to 550 
	Increased DV from 12 to 14
	Decreased AV from 44 to 40
	
	Added Blood Lust 4 (Provided)


### Enlightened

	Increased HP from 750 to 760
	
	
	Increased Khaldunite Resistant from 80% to 75% (Provided)
	Added Blood Lust 6 (Provided)
	Added  Bonus AV 2 (Provided)



### Restored

	Increased HP from 960 to 970 
	
	Increased Khaldunite Resistant from 80% to 70% (Provided)
	Added Blood Lust 6 (Provided)
	Added  Bonus AV 4 (Provided)



### Ascended

	Increased HP from 1170 to 1180 
	Increased DV from 14 to 16
	Decreased AV from 52 to 50
	
	Increased Khaldunite Resistant from 80% to 65% (Provided)
	Added Blood Lust 10 (Provided)
