### PR TITLE
Darius Javidan rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/DARIUS_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DARIUS_JAVIDAN.INI
@@ -47,7 +47,7 @@ DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.2		;seconds(float)
 AttackRange		=	.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	40		;number (float)
+Damage			=	44		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\darius_attack.wav
 
@@ -61,10 +61,10 @@ AttackType		=	CAST		; enumeration list (int)
 ;Sound1			=	Game\web_cast.wav
 
 [ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED    =   0.8
 
 [SupportBonus]
 MORALE_RECOVERY_RATE_BONUS	= 1.2
-DEFENSE_BONUS_VS_ANY = -1
 
 [Level1]
 MaxHitPoints	= 720

--- a/TGX Files/Data/ObjectData/Heroes/DARIUS_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DARIUS_JAVIDAN.INI
@@ -67,7 +67,7 @@ DAMAGE_TAKEN_FROM_RANGED    =   0.8
 MORALE_RECOVERY_RATE_BONUS	= 1.2
 
 [Level1]
-MaxHitPoints	= 720
+MaxHitPoints	= 750
 
 [SpellData1]
 ManaRegenerationRate	= 5
@@ -78,8 +78,7 @@ Damage			= 50
 [ElementBonus1]
 
 [SupportBonus1]
-MORALE_RECOVERY_RATE_BONUS	= 1.2
-DEFENSE_BONUS_VS_ANY = 0
+MORALE_RECOVERY_RATE_BONUS	= 1.25
 
 [Level2]
 MaxHitPoints	= 1000

--- a/TGX Files/Data/ObjectData/Heroes/DARIUS_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DARIUS_JAVIDAN.INI
@@ -24,12 +24,6 @@ SelectionSound3		=	Game\darius_select3.wav
 CommandSound1		=	Game\darius_command1.wav
 CommandSound2		=	Game\darius_command2.wav
 
-[ElementBonus]
-
-[SupportBonus]
-MORALE_RECOVERY_RATE_BONUS	= 1.2
-DEFENSE_BONUS_VS_ANY = -1
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Darius_Javidan_Icon.tgr
@@ -46,10 +40,6 @@ CombatValue		= 18
 MaxMana 		=	60 	;the max amount that mana can be for the unit
 ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Blessing
-
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0095_Darius_Javidan
 
 [Attack1]
 AttackTime		=	1.3		;seconds(float) seconds per animation cycle
@@ -70,38 +60,20 @@ AttackType		=	CAST		; enumeration list (int)
 ;DamageType		=	0			; number (float)
 ;Sound1			=	Game\web_cast.wav
 
+[ElementBonus]
+
+[SupportBonus]
+MORALE_RECOVERY_RATE_BONUS	= 1.2
+DEFENSE_BONUS_VS_ANY = -1
+
 [Level1]
 MaxHitPoints	= 720
-
-[Level2]
-MaxHitPoints	= 1000
-
-[Level3]
-MaxHitPoints	= 1300
-;Technology		= SampleTech
-
-[Attack0Data1]
-Damage			= 50
-
-[Attack1Data1]
-
-[Attack0Data2]
-Damage			= 60
-
-[Attack1Data2]
-
-[Attack0Data3]
-DamageType		= Khaldunite
-
-[Attack1Data3]
 
 [SpellData1]
 ManaRegenerationRate	= 5
 
-[SpellData2]
-Spell0			= True Blessing
-
-[SpellData3]
+[Attack0Data1]
+Damage			= 50
 
 [ElementBonus1]
 
@@ -109,13 +81,34 @@ Spell0			= True Blessing
 MORALE_RECOVERY_RATE_BONUS	= 1.2
 DEFENSE_BONUS_VS_ANY = 0
 
+[Level2]
+MaxHitPoints	= 1000
+
+[SpellData2]
+Spell0			= True Blessing
+
+[Attack0Data2]
+Damage			= 60
+
 [ElementBonus2]
 
 [SupportBonus2]
 MORALE_RECOVERY_RATE_BONUS	= 1.25
+
+[Level3]
+MaxHitPoints	= 1300
+
+[SpellData3]
+
+[Attack0Data3]
+DamageType		= Khaldunite
 
 [ElementBonus3]
 
 [SupportBonus3]
 ATTACK_BONUS_TO_SHADOW		= 2
 MORALE_RECOVERY_RATE_BONUS	= 1.3
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0095_Darius_Javidan

--- a/TGX Files/Data/ObjectData/Heroes/DARIUS_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DARIUS_JAVIDAN.INI
@@ -1,5 +1,5 @@
 [ObjectData]
-ProperName = Lord Javidan
+ProperName = Darius Javidan
 Class			= 	2			;enumeration list(int)
 Sprite			=   units\Darius.tgr
 BoundingRadius		=	0.25		;tiles(float)

--- a/TGX Files/Data/ObjectData/Heroes/DARIUS_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DARIUS_JAVIDAN.INI
@@ -1,5 +1,5 @@
 [ObjectData]
-ProperName = Darius Javidan
+ProperName = Lord Javidan
 Class			= 	2			;enumeration list(int)
 Sprite			=   units\Darius.tgr
 BoundingRadius		=	0.25		;tiles(float)
@@ -8,7 +8,7 @@ MaxHitPoints		=	550			;health rating(float)
 CostGold		=	0			;int
 BuildTime		=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
-Defense			=	14			;number (float)
+Defense			=	12			;number (float)
 Faction			=	Royalist
 
 Moveable		=	1			;BOOLEAN
@@ -28,6 +28,7 @@ CommandSound2		=	Game\darius_command2.wav
 
 [SupportBonus]
 MORALE_RECOVERY_RATE_BONUS	= 1.2
+DEFENSE_BONUS_VS_ANY = -1
 
 [UnitData]
 Type			=	HERO
@@ -48,7 +49,6 @@ Spell0			=	Blessing
 
 [HeroData]
 AwakenCost		=	50
-Boss			= 1
 TranslatedName = STRING_0095_Darius_Javidan
 
 [Attack1]
@@ -57,7 +57,7 @@ DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.2		;seconds(float)
 AttackRange		=	.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	50		;number (float)
+Damage			=	40		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\darius_attack.wav
 
@@ -71,28 +71,27 @@ AttackType		=	CAST		; enumeration list (int)
 ;Sound1			=	Game\web_cast.wav
 
 [Level1]
-MaxHitPoints	= 820
+MaxHitPoints	= 720
 
 [Level2]
-MaxHitPoints	= 1100
+MaxHitPoints	= 1000
 
 [Level3]
-MaxHitPoints	= 1400
+MaxHitPoints	= 1300
 ;Technology		= SampleTech
 
 [Attack0Data1]
-Damage			= 60
+Damage			= 50
 
 [Attack1Data1]
 
 [Attack0Data2]
-Damage			= 70
+Damage			= 60
 
 [Attack1Data2]
 
 [Attack0Data3]
 DamageType		= Khaldunite
-Damage			= 75
 
 [Attack1Data3]
 
@@ -108,15 +107,15 @@ Spell0			= True Blessing
 
 [SupportBonus1]
 MORALE_RECOVERY_RATE_BONUS	= 1.2
+DEFENSE_BONUS_VS_ANY = 0
 
 [ElementBonus2]
 
 [SupportBonus2]
-ATTACK_BONUS_TO_SHADOW		= 2
-MORALE_RECOVERY_RATE_BONUS	= 1.4
+MORALE_RECOVERY_RATE_BONUS	= 1.25
 
 [ElementBonus3]
 
 [SupportBonus3]
-ATTACK_BONUS_TO_SHADOW		= 4
-MORALE_RECOVERY_RATE_BONUS	= 1.5
+ATTACK_BONUS_TO_SHADOW		= 2
+MORALE_RECOVERY_RATE_BONUS	= 1.3

--- a/TGX Files/Data/ObjectData/Heroes/LORD_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/LORD_JAVIDAN.INI
@@ -1,5 +1,5 @@
 [ObjectData]
-ProperName = Lord Javidan
+ProperName = Unused1
 Class			= 	2			;enumeration list(int)
 Sprite			=   units\Darius.tgr
 BoundingRadius		=	0.25		;tiles(float)
@@ -112,3 +112,4 @@ MORALE_RECOVERY_RATE_BONUS	= 1.3
 [HeroData]
 AwakenCost		=	50
 TranslatedName = STRING_0095_Darius_Javidan
+Boss            =   1

--- a/TGX Files/Data/ObjectData/Heroes/LORD_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/LORD_JAVIDAN.INI
@@ -24,12 +24,6 @@ SelectionSound3		=	Game\darius_select3.wav
 CommandSound1		=	Game\darius_command1.wav
 CommandSound2		=	Game\darius_command2.wav
 
-[ElementBonus]
-
-[SupportBonus]
-MORALE_RECOVERY_RATE_BONUS	= 1.2
-DEFENSE_BONUS_VS_ANY = -1
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Darius_Javidan_Icon.tgr
@@ -46,10 +40,6 @@ CombatValue		= 18
 MaxMana 		=	60 	;the max amount that mana can be for the unit
 ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Blessing
-
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0095_Darius_Javidan
 
 [Attack1]
 AttackTime		=	1.3		;seconds(float) seconds per animation cycle
@@ -70,38 +60,20 @@ AttackType		=	CAST		; enumeration list (int)
 ;DamageType		=	0			; number (float)
 ;Sound1			=	Game\web_cast.wav
 
+[ElementBonus]
+
+[SupportBonus]
+MORALE_RECOVERY_RATE_BONUS	= 1.2
+DEFENSE_BONUS_VS_ANY = -1
+
 [Level1]
 MaxHitPoints	= 720
-
-[Level2]
-MaxHitPoints	= 1000
-
-[Level3]
-MaxHitPoints	= 1300
-;Technology		= SampleTech
-
-[Attack0Data1]
-Damage			= 50
-
-[Attack1Data1]
-
-[Attack0Data2]
-Damage			= 60
-
-[Attack1Data2]
-
-[Attack0Data3]
-DamageType		= Khaldunite
-
-[Attack1Data3]
 
 [SpellData1]
 ManaRegenerationRate	= 5
 
-[SpellData2]
-Spell0			= True Blessing
-
-[SpellData3]
+[Attack0Data1]
+Damage			= 50
 
 [ElementBonus1]
 
@@ -109,13 +81,34 @@ Spell0			= True Blessing
 MORALE_RECOVERY_RATE_BONUS	= 1.2
 DEFENSE_BONUS_VS_ANY = 0
 
+[Level2]
+MaxHitPoints	= 1000
+
+[SpellData2]
+Spell0			= True Blessing
+
+[Attack0Data2]
+Damage			= 60
+
 [ElementBonus2]
 
 [SupportBonus2]
 MORALE_RECOVERY_RATE_BONUS	= 1.25
+
+[Level3]
+MaxHitPoints	= 1300
+
+[SpellData3]
+
+[Attack0Data3]
+DamageType		= Khaldunite
 
 [ElementBonus3]
 
 [SupportBonus3]
 ATTACK_BONUS_TO_SHADOW		= 2
 MORALE_RECOVERY_RATE_BONUS	= 1.3
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0095_Darius_Javidan


### PR DESCRIPTION
### _Changelog:_

### All levels

	Added 80% Range Resistant (Personal)

### Awakened

	Increased AV from 40 to  44
	Removed DV bonus -1
	
### Enlightened

	Increased HP from 720 to 750 
	Increased Inspirational from 120% to 125%
	
### Restored

### Ascended

> Added note here, for development purposes. Freed up LORD_JAVIDAN.ini for later use for another hero, as now Darius's campaign and multiplayer versions are one-in-the-same. This may result in some slightly different balance on some campaign missions but ultimately, it's necessary that we preserve the limited space we have for later additions and filling out the hero roster in the game. 