### PR TITLE
Selvana rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SELVANA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SELVANA.INI
@@ -23,11 +23,6 @@ SelectionSound2		=	Game\f_hero5_select_evil.wav
 CommandSound1		=	Game\f_hero5_command.wav
 CommandSound2		=	Game\f_hero5_command_evil.wav
 
-[ElementBonus]
-
-[SupportBonus]
-DAMAGE_TAKEN_FROM_HOLY		= .8
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Priestess_icon.tgr
@@ -46,10 +41,6 @@ ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Summon Shadelings
 Spell1			=	Mystic Armor
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0048_Selvana
-
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
@@ -67,38 +58,37 @@ DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 
+[ElementBonus]
+
+[SupportBonus]
+DAMAGE_TAKEN_FROM_HOLY		= .8
+
+;======Enlightened======
+
 [Level1]
 MaxHitPoints		=	540
-
-[Level2]
-MaxHitPoints		=	630
-
-[Level3]
-MaxHitPoints		=	720
-
-[Attack0Data1]
-Damage			=	38
-
-[Attack0Data2]
-Damage			=	40
-
-[Attack0Data3]
-Damage			=	42
 
 [SpellData1]
 ManaRegenerationRate 	=	4
 
-[SpellData2]
-Spell0			=	Summon Shadeling Swarm
-
-[SpellData3]
-MaxMana 		=	80
-ManaRegenerationRate 	=	5
+[Attack0Data1]
+Damage			=	38
 
 [ElementBonus1]
 
 [SupportBonus1]
 DAMAGE_TAKEN_FROM_HOLY		= .8
+
+;======Restored======
+
+[Level2]
+MaxHitPoints		=	630
+
+[SpellData2]
+Spell0			=	Summon Shadeling Swarm
+
+[Attack0Data2]
+Damage			=	40
 
 [ElementBonus2]
 
@@ -106,8 +96,24 @@ DAMAGE_TAKEN_FROM_HOLY		= .8
 ZONE_OF_CONTROL_BONUS		= 1.1
 DAMAGE_TAKEN_FROM_HOLY		= .75
 
+;======Ascended
+
+[Level3]
+MaxHitPoints		=	720
+
+[SpellData3]
+MaxMana 		=	80
+ManaRegenerationRate 	=	5
+
+[Attack0Data3]
+Damage			=	42
+
 [ElementBonus3]
 
 [SupportBonus3]
 ZONE_OF_CONTROL_BONUS		= 1.2
 DAMAGE_TAKEN_FROM_HOLY		= .7
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0048_Selvana

--- a/TGX Files/Data/ObjectData/Heroes/SELVANA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SELVANA.INI
@@ -61,24 +61,29 @@ AttackType		=	CAST		; enumeration list (int)
 [ElementBonus]
 
 [SupportBonus]
-ZONE_OF_CONTROL_BONUS		=	1.1
-DAMAGE_TAKEN_FROM_HOLY		=	.8
+ZONE_OF_CONTROL_BONUS	=	1.1
+DAMAGE_TAKEN_FROM_HOLY	=	.8
 
 ;======Enlightened======
 
 [Level1]
-MaxHitPoints		=	540
+MaxHitPoints			=	600
+Defense					=	10
 
 [SpellData1]
+MaxMana 				=	60
 ManaRegenerationRate 	=	4
+Spell0			=	Summon Shadeling Swarm
+Spell1			=	Mystic Armor
 
 [Attack0Data1]
-Damage			=	38
+Damage					=	42
 
 [ElementBonus1]
 
 [SupportBonus1]
-DAMAGE_TAKEN_FROM_HOLY		= .8
+ZONE_OF_CONTROL_BONUS	=	1.2
+DAMAGE_TAKEN_FROM_HOLY	=	.75
 
 ;======Restored======
 

--- a/TGX Files/Data/ObjectData/Heroes/SELVANA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SELVANA.INI
@@ -106,20 +106,22 @@ DAMAGE_TAKEN_FROM_HOLY		= .50
 ;======Ascended
 
 [Level3]
-MaxHitPoints		=	720
+MaxHitPoints			=	820
+Defense					=	12
 
 [SpellData3]
-MaxMana 		=	80
+MaxMana 				=	80
 ManaRegenerationRate 	=	5
 
 [Attack0Data3]
-Damage			=	42
+Damage					=	52
 
 [ElementBonus3]
+DAMAGE_TAKEN_FROM_KHALDUNITE	=	0.8
 
 [SupportBonus3]
-ZONE_OF_CONTROL_BONUS		= 1.2
-DAMAGE_TAKEN_FROM_HOLY		= .7
+ZONE_OF_CONTROL_BONUS		= 1.3
+DAMAGE_TAKEN_FROM_HOLY		= .50
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/SELVANA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SELVANA.INI
@@ -88,19 +88,20 @@ DAMAGE_TAKEN_FROM_HOLY	=	.75
 ;======Restored======
 
 [Level2]
-MaxHitPoints		=	630
+MaxHitPoints			=	700
+Defense					=	12
 
 [SpellData2]
-Spell0			=	Summon Shadeling Swarm
 
 [Attack0Data2]
-Damage			=	40
+Damage					=	46
 
 [ElementBonus2]
+DAMAGE_TAKEN_FROM_KHALDUNITE	=	0.9
 
 [SupportBonus2]
-ZONE_OF_CONTROL_BONUS		= 1.1
-DAMAGE_TAKEN_FROM_HOLY		= .75
+ZONE_OF_CONTROL_BONUS		= 1.25
+DAMAGE_TAKEN_FROM_HOLY		= .50
 
 ;======Ascended
 

--- a/TGX Files/Data/ObjectData/Heroes/SELVANA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SELVANA.INI
@@ -47,7 +47,7 @@ DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	0.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	34		;number (float)
+Damage			=	38		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\battle_priest_melee.wav
 Sound2			= 	Game\club2.wav
@@ -61,7 +61,8 @@ AttackType		=	CAST		; enumeration list (int)
 [ElementBonus]
 
 [SupportBonus]
-DAMAGE_TAKEN_FROM_HOLY		= .8
+ZONE_OF_CONTROL_BONUS		=	1.1
+DAMAGE_TAKEN_FROM_HOLY		=	.8
 
 ;======Enlightened======
 


### PR DESCRIPTION
### **_Changelog:_**

### Awakened
```
Increased AV from 34 to 38
Added Dominion 110%
```

### Enlightened
```
Increased HP from 540 to 600 
Increased AV from 38 to 42
Replaced Summon Shadelings with Summon Shadeling Swarm
Increased Holy Resistance (Provided) from 80% to 75%
Added Dominion 120%
```

### Restored
```
Increased HP from 630 to 700
Increased DV from 10 to 12
Increased AV from 40 to 46
Added Khaldunite Resistance (Personal) 90%
Increased Dominion from 110% to 125%
Increased Holy Resistance (Provided) from 75% to 50%
```

### Ascended
```
Increased HP from 720 to 820
Increased DV from 10 to 12
Increased AV from 42 to 52
Added Khaldunite Resistance (Personal) 80%
Increased Dominion from 120% to 130%
Increased Holy Resistance (Provided) from 70% to 50%
```

