### PR TITLE
Shamael Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
@@ -23,13 +23,6 @@ SelectionSound2		=	Game\m_heroD_select_evil.wav
 CommandSound1		=	Game\m_heroD_command1.wav
 CommandSound2		=	Game\m_heroD_command_evil.wav
 
-[ElementBonus]
-DEFENSE_BONUS_VS_SHADOW		= 2
-DAMAGE_TAKEN_FROM_RANGED	= .5
-
-[SupportBonus]
-ZONE_OF_CONTROL_BONUS		= 1.2
-
 [UnitData]
 Type			=	HERO
 Icon			=   	Portraits\Unit Icons\Captain_icon.tgr
@@ -46,10 +39,6 @@ Description = STRING_2411_Shamael_is_a_cruel_creature_of_darkness__Few_of_the_ot
 MaxMana 		=	50 	;the max amount that mana can be for the unit
 ManaRegenerationRate 	=	1	;the amount of mana that gets regenerated sec.
 Spell0			=	Cloud of Fear
-
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0029_Shamael
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
@@ -68,34 +57,21 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation		= 	0		;animations are backwards
 
+[ElementBonus]
+DEFENSE_BONUS_VS_SHADOW		= 2
+DAMAGE_TAKEN_FROM_RANGED	= .5
+
+[SupportBonus]
+ZONE_OF_CONTROL_BONUS		= 1.2
+
 [Level1]
 MaxHitPoints		=	650
-
-[Level2]
-MaxHitPoints		=	800
-
-[Level3]
-MaxHitPoints		=	950
-;Technology		= SampleTech
-
-[Attack0Data1]
-Damage			=	46
-
-[Attack0Data2]
-Damage			=	52
-
-[Attack0Data3]
-
 
 [SpellData1]
 ManaRegenerationRate 	=	2
 
-[SpellData2]
-ManaRegenerationRate 	=	3
-Spell0			=	Shadowshock
-
-[SpellData3]
-Spell0			=	Unholy Strength
+[Attack0Data1]
+Damage			=	46
 
 [ElementBonus1]
 DEFENSE_BONUS_VS_SHADOW		= 4
@@ -104,6 +80,16 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 [SupportBonus1]
 ZONE_OF_CONTROL_BONUS		= 1.2
 
+[Level2]
+MaxHitPoints		=	800
+
+[SpellData2]
+ManaRegenerationRate 	=	3
+Spell0			=	Shadowshock
+
+[Attack0Data2]
+Damage			=	52
+
 [ElementBonus2]
 DEFENSE_BONUS_VS_SHADOW		= 4
 DAMAGE_TAKEN_FROM_RANGED	= .5
@@ -111,9 +97,21 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 [SupportBonus2]
 ZONE_OF_CONTROL_BONUS		= 1.3
 
+[Level3]
+MaxHitPoints		=	950
+
+[SpellData3]
+Spell0			=	Unholy Strength
+
+[Attack0Data3]
+
 [ElementBonus3]
 DEFENSE_BONUS_VS_SHADOW		= 6
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
 ZONE_OF_CONTROL_BONUS		= 1.4
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0029_Shamael

--- a/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
@@ -84,21 +84,22 @@ DEFENSE_BONUS_VS_SHADOW		= 3
 ZONE_OF_CONTROL_BONUS		= 1.25
 
 [Level2]
-MaxHitPoints		=	800
+MaxHitPoints		=	870
 
 [SpellData2]
-ManaRegenerationRate 	=	3
-Spell0			=	Shadowshock
+MaxMana                 =   60
+Spell1			=	Unholy Strength
 
 [Attack0Data2]
-Damage			=	52
+Damage			=	50
 
 [ElementBonus2]
 DEFENSE_BONUS_VS_SHADOW		= 4
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus2]
-ZONE_OF_CONTROL_BONUS		= 1.3
+DEFENSE_BONUS_VS_SHADOW		= 3
+ZONE_OF_CONTROL_BONUS		= 1.25
 
 [Level3]
 MaxHitPoints		=	950

--- a/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
@@ -102,19 +102,20 @@ DEFENSE_BONUS_VS_SHADOW		= 3
 ZONE_OF_CONTROL_BONUS		= 1.25
 
 [Level3]
-MaxHitPoints		=	950
+MaxHitPoints		=	1040
 
 [SpellData3]
-Spell0			=	Unholy Strength
 
 [Attack0Data3]
+Damage              =   56
 
 [ElementBonus3]
-DEFENSE_BONUS_VS_SHADOW		= 6
+DEFENSE_BONUS_VS_SHADOW		= 4
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
-ZONE_OF_CONTROL_BONUS		= 1.4
+DEFENSE_BONUS_VS_SHADOW		= 5
+ZONE_OF_CONTROL_BONUS		= 1.35
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
@@ -4,7 +4,7 @@ Class			= 	2			;enumeration list(int)
 Sprite			=   units\Captain.tgr
 BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	500			;health rating(float)
+MaxHitPoints		=	530			;health rating(float)
 CostGold		=	0			;int
 BuildTime		=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
@@ -46,7 +46,7 @@ DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	0.75	;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	40		;number (float)
+Damage			=	44		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\sword1.wav
 
@@ -58,10 +58,11 @@ AttackType		=	CAST		; enumeration list (int)
 Animation		= 	0		;animations are backwards
 
 [ElementBonus]
-DEFENSE_BONUS_VS_SHADOW		= 2
+DEFENSE_BONUS_VS_SHADOW		= 4
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus]
+DEFENSE_BONUS_VS_SHADOW		= 2
 ZONE_OF_CONTROL_BONUS		= 1.2
 
 [Level1]

--- a/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
@@ -76,8 +76,6 @@ Damage			=	46
 DamageType      =   MAGIC
 
 [ElementBonus1]
-DEFENSE_BONUS_VS_SHADOW		= 4
-DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
 DEFENSE_BONUS_VS_SHADOW		= 3
@@ -94,12 +92,8 @@ Spell1			=	Unholy Strength
 Damage			=	50
 
 [ElementBonus2]
-DEFENSE_BONUS_VS_SHADOW		= 4
-DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus2]
-DEFENSE_BONUS_VS_SHADOW		= 3
-ZONE_OF_CONTROL_BONUS		= 1.25
 
 [Level3]
 MaxHitPoints		=	1040
@@ -110,8 +104,6 @@ MaxHitPoints		=	1040
 Damage              =   56
 
 [ElementBonus3]
-DEFENSE_BONUS_VS_SHADOW		= 4
-DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
 DEFENSE_BONUS_VS_SHADOW		= 5

--- a/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SHAMAEL.INI
@@ -66,20 +66,22 @@ DEFENSE_BONUS_VS_SHADOW		= 2
 ZONE_OF_CONTROL_BONUS		= 1.2
 
 [Level1]
-MaxHitPoints		=	650
+MaxHitPoints		=	700
 
 [SpellData1]
 ManaRegenerationRate 	=	2
 
 [Attack0Data1]
 Damage			=	46
+DamageType      =   MAGIC
 
 [ElementBonus1]
 DEFENSE_BONUS_VS_SHADOW		= 4
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
-ZONE_OF_CONTROL_BONUS		= 1.2
+DEFENSE_BONUS_VS_SHADOW		= 3
+ZONE_OF_CONTROL_BONUS		= 1.25
 
 [Level2]
 MaxHitPoints		=	800

--- a/TGX Files/Data/Spells.ini
+++ b/TGX Files/Data/Spells.ini
@@ -351,6 +351,7 @@ ProperName = STRING_1444_Cloud_Of_Fear
 Description = STRING_1445_Creates_a_bubbling_cloud_of_darkness_that_lowers_the_morale_of_enemies_caught_within_
 Mana_Cost = 35
 Type = Group
+Special     =   Unholy
 Offensive =	1	;DEFENSIVE or OFFENSIVE
 Duration = 50
 Range = 10


### PR DESCRIPTION
### _Changelog:_

### Awakened

	Increased HP from 500 to 530 
	Increased AV from 40 to 44
	
	Increased Shadow Resistance from 2 to 4 (Personal)
	
	Added Shadow Resistance 2 (Provided)

### Enlightened

	Increased HP from 650 to 700
	Damage type changed from Normal to Magic
	
	Increased Dominion from 120% to 125% (Provided)
	Added Shadow Resistance 3 (Provided)

### Restored

	Increased HP from 800 to  870 
	Decreased AV from 52 to 50
	
	Increased MaxMana from 50 to 60 
	Decreased Mana Regen from 3 to 2
	
	Added Unholy Strength as 2nd spell
	
	Decreased Dominion from 130% to 125% (Provided)
	
	
### Ascended

	Increased HP from 950 to 1040 
	Increased AV from 52 to 56
	
	Decreased Shadow Resistance from 6 to 4
	
	Decreased Dominion from 140% to 135% (Provided)
	Added Shadow Resistance +5 (Provided) 

### Spells:

Cloud of Fear changed to Unholy spell (Only targets non-shadow or "living" units)