### PR TITLE
Qasim Majere rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
@@ -23,17 +23,6 @@ SelectionSound2		=	Game\m_hero7_select_good.wav
 CommandSound1		=	Game\m_hero7_command2.wav
 CommandSound2		=	Game\m_hero7_command_good.wav
 
-[SpellData]
-MaxMana 		=	50 	;the max amount that mana can be for the unit
-ManaRegenerationRate 	=	2	;the amount of mana that gets regenerated sec.
-Spell0			=	Courage
-
-[ElementBonus]
-MELEE_HOLY_DAMAGE	= 6
-DAMAGE_TAKEN_FROM_RANGED	= .5
-
-[SupportBonus]
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Footman_icon.tgr
@@ -46,9 +35,10 @@ ResupplyRate		=	10			; health / second (float)
 CombatValue		= 15
 Description = STRING_2400_Qasim_is_a_proud_warrior_who_has_been_preparing_for_the_final_battle_with_the_Dark_Master_ever_since_he_was_awakened__Devoting_himself_to_the_powers_of_the_Creator_he_has_gained_many_spiritual_powers_to_aid_him_in_his_quest_
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_2401_Qasim_Majere
+[SpellData]
+MaxMana 		=	50 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	2	;the amount of mana that gets regenerated sec.
+Spell0			=	Courage
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
@@ -67,32 +57,20 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation		= 	0
 
+[ElementBonus]
+MELEE_HOLY_DAMAGE	= 6
+DAMAGE_TAKEN_FROM_RANGED	= .5
+
+[SupportBonus]
+
 [Level1]
 MaxHitPoints		=	740
-
-[Level2]
-MaxHitPoints		=	950
-
-[Level3]
-MaxHitPoints		=	1160
-
-[Attack0Data1]
-Damage			=	44
-
-[Attack0Data2]
-Damage			=	48
-
-[Attack0Data3]
-Damage			=	52
 
 [SpellData1]
 Spell0			=	Blessing
 
-[SpellData2]
-Spell0			=	Valor
-
-[SpellData3]
-Spell0			=	Spirit of Battle
+[Attack0Data1]
+Damage			=	44
 
 [ElementBonus1]
 MELEE_HOLY_DAMAGE	= 8
@@ -100,14 +78,36 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
 
+[Level2]
+MaxHitPoints		=	950
+
+[SpellData2]
+Spell0			=	Valor
+
+[Attack0Data2]
+Damage			=	48
+
 [ElementBonus2]
 MELEE_HOLY_DAMAGE	= 10
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus2]
 
+[Level3]
+MaxHitPoints		=	1160
+
+[SpellData3]
+Spell0			=	Spirit of Battle
+
+[Attack0Data3]
+Damage			=	52
+
 [ElementBonus3]
 MELEE_HOLY_DAMAGE	= 12
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_2401_Qasim_Majere

--- a/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
@@ -68,19 +68,22 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 ATTACK_BONUS_TO_BUILDING    =   2
 
 [Level1]
-MaxHitPoints		=	740
+MaxHitPoints		=	750
 
 [SpellData1]
 Spell0			=	Blessing
 
 [Attack0Data1]
-Damage			=	44
+Damage			=	50
 
 [ElementBonus1]
-MELEE_HOLY_DAMAGE	= 8
+ATTACK_BONUS_TO_MOUNTED     =   4
+MELEE_HOLY_DAMAGE	= 6
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
+MORALE_LOSS_RATE_BONUS      =   .8
+ATTACK_BONUS_TO_BUILDING    =   4
 
 [Level2]
 MaxHitPoints		=	950

--- a/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
@@ -4,7 +4,7 @@ Class			= 	2			;enumeration list(int)
 Sprite			=   units\Footman.tgr
 BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	530			;health rating(float)
+MaxHitPoints		=	550			;health rating(float)
 CostGold		=	0			;int
 BuildTime		=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
@@ -48,7 +48,7 @@ DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	40		;number (float)
+Damage			=	46		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\spear2.wav
 
@@ -60,10 +60,12 @@ AttackType		=	CAST		; enumeration list (int)
 Animation		= 	0
 
 [ElementBonus]
-MELEE_HOLY_DAMAGE	= 6
+ATTACK_BONUS_TO_MOUNTED     =   4
+MELEE_HOLY_DAMAGE	= 4
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus]
+ATTACK_BONUS_TO_BUILDING    =   2
 
 [Level1]
 MaxHitPoints		=	740

--- a/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
@@ -89,16 +89,19 @@ ATTACK_BONUS_TO_BUILDING    =   4
 MaxHitPoints		=	950
 
 [SpellData2]
-Spell0			=	Valor
+Spell0			=	Spirit of Battle
 
 [Attack0Data2]
-Damage			=	48
+Damage			=	54
 
 [ElementBonus2]
-MELEE_HOLY_DAMAGE	= 10
+ATTACK_BONUS_TO_MOUNTED     =   6
+MELEE_HOLY_DAMAGE	= 8
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus2]
+MORALE_LOSS_RATE_BONUS      =   .8
+ATTACK_BONUS_TO_BUILDING    =   6
 
 [Level3]
 MaxHitPoints		=	1160

--- a/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
@@ -18,10 +18,12 @@ Land			=	1			;BOOLEAN
 Water			=	0			;BOOLEAN
 
 DeathSound1		=	Game\footman_death.wav
-SelectionSound1		=	Game\m_hero7_select2.wav
-SelectionSound2		=	Game\m_hero7_select_good.wav
-CommandSound1		=	Game\m_hero7_command2.wav
-CommandSound2		=	Game\m_hero7_command_good.wav
+SelectionSound1		=	Game\agm_hero1_select1.wav
+SelectionSound2		=	Game\agm_hero1_select2.wav
+SelectionSound3		=	Game\agm_hero1_select3.wav
+CommandSound1		=	Game\agm_hero1_command1.wav
+CommandSound2		=	Game\agm_hero1_command2.wav
+CommandSound3		=	Game\agm_hero1_command3.wav
 
 [UnitData]
 Type			=	HERO

--- a/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
@@ -104,19 +104,22 @@ MORALE_LOSS_RATE_BONUS      =   .8
 ATTACK_BONUS_TO_BUILDING    =   6
 
 [Level3]
-MaxHitPoints		=	1160
+MaxHitPoints		=	1100
+Defense             =   14
 
 [SpellData3]
-Spell0			=	Spirit of Battle
 
 [Attack0Data3]
-Damage			=	52
+Damage			=	58
 
 [ElementBonus3]
-MELEE_HOLY_DAMAGE	= 12
+ATTACK_BONUS_TO_MOUNTED     =   8
+MELEE_HOLY_DAMAGE	= 10
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
+MORALE_LOSS_RATE_BONUS      =   .8
+ATTACK_BONUS_TO_BUILDING    =   6
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/QASIM_MAJERE.INI
@@ -118,8 +118,6 @@ MELEE_HOLY_DAMAGE	= 10
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
-MORALE_LOSS_RATE_BONUS      =   .8
-ATTACK_BONUS_TO_BUILDING    =   6
 
 [HeroData]
 AwakenCost		=	50


### PR DESCRIPTION
### _Changelog:_

### Awakened

	Increased HP from 530 to 550 
	Increased AV from 40 to 46 
	
	Added Cavalry Foe +4 (Personal)
	Decreased Holy attacks from 6 to 4 (Personal)
	
	Added Siege Bonus +2 (Provided)
	
### Enlightened

	Increased HP from 740 to 750 
	Increased AV from 44 to  50
	
	Added Cavalry Foe +4 (Personal)
	Decreased Holy attacks from 8 to 6 (Personal)
	
	Added Courageous 80% (Provided)
	Added Siege bonus +4 (Provided)

### Restored

	Increased AV from 48 to 54
	
	Spell0: Valor replaced with Spirit of battle
	
	Added Cavalry foe +6 (Personal)
	Decreased Holy attacks from 10 to 8 (Personal)
	
	Added Courageous 80% (Provided)
	Added Siege Bonus +6 (Provided)
	
### Ascended

	Decreased HP from 1160 to 1100 
	Increased DV from 12 to 14
	Increased AV from 52 to 58
	
	Added Cavalry Foe +8 (Personal)
	Decreased Holy attacks from 12 to 10 (Personal)
	
	Added Courageous 80% (Provided)
	Added Siege Bonus +6  (Provided)
