### PR TITLE
Seth Aswan Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SETH_ASWAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SETH_ASWAN.INI
@@ -42,7 +42,7 @@ DamagePoint		=	0.6			;seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	1			;seconds(float)
 AttackRange		=	6			;tiles (float)
 AttackType		=	PROJECTILE			;enumeration list(int)
-Damage			=	40		;number (float)
+Damage			=	42		;number (float)
 DamageType		=	KHALDUNITE
 Sound1			=	Game\ranger_fire.wav
 

--- a/TGX Files/Data/ObjectData/Heroes/SETH_ASWAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SETH_ASWAN.INI
@@ -87,11 +87,12 @@ MORALE_CHECK_BONUS		= 3
 
 [Level2]
 MaxHitPoints		=	760
+Defense             =   10
 
 [SpellData2]
 
 [Attack0Data2]
-Damage			=	44
+Damage			=	50
 
 [Attack1Data2]
 
@@ -100,7 +101,8 @@ DAMAGE_TAKEN_FROM_RANGED	= .6
 DAMAGE_TAKEN_FROM_MELEE		= 1.1
 
 [SupportBonus2]
-VISUAL_RANGE_BONUS		= 1.2
+MOVEMENT_BONUS          =   1.1
+VISUAL_RANGE_BONUS		= 1.25
 IGNORE_TERRAIN_BONUS		= 1
 MORALE_CHECK_BONUS		= 3
 

--- a/TGX Files/Data/ObjectData/Heroes/SETH_ASWAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SETH_ASWAN.INI
@@ -23,14 +23,6 @@ SelectionSound2		=	Game\m_hero5_select_good.wav
 CommandSound1		=	Game\m_hero5_command2.wav
 CommandSound2		=	Game\m_hero5_command_good.wav
 
-[ElementBonus]
-DAMAGE_TAKEN_FROM_RANGED	= .75
-DAMAGE_TAKEN_FROM_MELEE		= 1.25
-
-[SupportBonus]
-IGNORE_TERRAIN_BONUS		= 1
-MORALE_CHECK_BONUS		= 2
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Ranger_icon.tgr
@@ -42,10 +34,6 @@ WalkDistance		=   	0.77		;tiles (float) how far does unit move in one animation 
 ResupplyRate		=	10			; health / second (float)
 CombatValue		= 15
 Description = STRING_2410_Seth_Aswan_enjoyed_living_a_fairly_carefree_existance_among_the_Haroun_people__then_the_shadow_of_the_Dark_Master_began_to_fall_upon_their_land__He_has_taken_to_his_Ranger_ways_of_old_to_combat_the_threat_of_the_Dark_Master_
-
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0043_Seth_Aswan
 
 [Attack1]
 AttackTime		=	1			;seconds(float) seconds per animation cycle
@@ -69,37 +57,23 @@ Damage			=	32		;number (float)
 DamageType		=	KHALDUNITE
 Sound1			=	Game\ranger_attack.wav
 
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .75
+DAMAGE_TAKEN_FROM_MELEE		= 1.25
+
+[SupportBonus]
+IGNORE_TERRAIN_BONUS		= 1
+MORALE_CHECK_BONUS		= 2
+
 [Level1]
 MaxHitPoints		=	620
 
-[Level2]
-MaxHitPoints		=	760
-
-[Level3]
-Defense			=	10
-MaxHitPoints		=	900
+[SpellData1]
 
 [Attack0Data1]
 
-[Attack0Data2]
-Damage			=	44
-
-[Attack0Data3]
-Damage			=	48
-
 [Attack1Data1]
 Damage			=	36
-
-[Attack1Data2]
-
-[Attack1Data3]
-Damage			=	40
-
-[SpellData1]
-
-[SpellData2]
-
-[SpellData3]
 
 [ElementBonus1]
 DAMAGE_TAKEN_FROM_RANGED	= .7
@@ -110,6 +84,16 @@ VISUAL_RANGE_BONUS		= 1.1
 IGNORE_TERRAIN_BONUS		= 1
 MORALE_CHECK_BONUS		= 3
 
+[Level2]
+MaxHitPoints		=	760
+
+[SpellData2]
+
+[Attack0Data2]
+Damage			=	44
+
+[Attack1Data2]
+
 [ElementBonus2]
 DAMAGE_TAKEN_FROM_RANGED	= .6
 DAMAGE_TAKEN_FROM_MELEE		= 1.1
@@ -119,6 +103,18 @@ VISUAL_RANGE_BONUS		= 1.2
 IGNORE_TERRAIN_BONUS		= 1
 MORALE_CHECK_BONUS		= 3
 
+[Level3]
+Defense			=	10
+MaxHitPoints		=	900
+
+[SpellData3]
+
+[Attack0Data3]
+Damage			=	48
+
+[Attack1Data3]
+Damage			=	40
+
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
@@ -126,3 +122,7 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 VISUAL_RANGE_BONUS		= 1.25
 IGNORE_TERRAIN_BONUS		= 1
 MORALE_CHECK_BONUS		= 4
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0043_Seth_Aswan

--- a/TGX Files/Data/ObjectData/Heroes/SETH_ASWAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SETH_ASWAN.INI
@@ -107,22 +107,23 @@ IGNORE_TERRAIN_BONUS		= 1
 MORALE_CHECK_BONUS		= 3
 
 [Level3]
-Defense			=	10
 MaxHitPoints		=	900
 
 [SpellData3]
 
 [Attack0Data3]
-Damage			=	48
+Damage			=	54
 
 [Attack1Data3]
 Damage			=	40
 
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_RANGED	= .5
+DAMAGE_TAKEN_FROM_MELEE		= 1.1
 
 [SupportBonus3]
-VISUAL_RANGE_BONUS		= 1.25
+MOVEMENT_BONUS          =   1.15
+VISUAL_RANGE_BONUS		= 1.3
 IGNORE_TERRAIN_BONUS		= 1
 MORALE_CHECK_BONUS		= 4
 

--- a/TGX Files/Data/ObjectData/Heroes/SETH_ASWAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SETH_ASWAN.INI
@@ -71,16 +71,17 @@ MaxHitPoints		=	620
 [SpellData1]
 
 [Attack0Data1]
+Damage              =   46
 
 [Attack1Data1]
 Damage			=	36
 
 [ElementBonus1]
-DAMAGE_TAKEN_FROM_RANGED	= .7
-DAMAGE_TAKEN_FROM_MELEE		= 1.2
+DAMAGE_TAKEN_FROM_RANGED	= .65
+DAMAGE_TAKEN_FROM_MELEE		= 1.15
 
 [SupportBonus1]
-VISUAL_RANGE_BONUS		= 1.1
+VISUAL_RANGE_BONUS		= 1.2
 IGNORE_TERRAIN_BONUS		= 1
 MORALE_CHECK_BONUS		= 3
 


### PR DESCRIPTION
### _Changelog:_

### Awakened
	
	Increased AV from 40 to 42 
	
### Enlightened

	Increased AV from 40 to 46
	
	Increased Ranged Resistant from 70% to 65% (Personal)
	Decreased Melee Vulnerable from 120% to 115% (Personal)
	
	Increased Recon from 110% to 120% (Provided)

### Restored

	Increased DV from 8 to 10
	Increased AV from 44 to 50
	
	Increased Recon from 120% to 125% (Provided)
	Added Movement speed 110% (Provided)
	

### Ascended

	Increased AV from 48 to 54
	
	Added Melee Vulnerable 110%
	
	Increased Recon from 125% to 130% (Provided)
	Added Movement speed 115% (Provided)
