### PR TITLE
Eben rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
+++ b/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
@@ -104,20 +104,22 @@ IGNORE_TERRAIN_BONUS	=	1
 ;========Ascended========
 
 [Level3]
-MaxHitPoints		=	1030
+MaxHitPoints		=	1050
+Defense				=	12
 ;Technology		= SampleTech
 
 [Attack0Data3]
-
+Damage				=	55
 [Attack1Data3]
 Damage				=	40
 
 [ElementBonus3]
 
 [SupportBonus3]
-VISUAL_RANGE_BONUS		= 1.4
-ZONE_OF_CONTROL_BONUS	= 1.5
-IGNORE_TERRAIN_BONUS	= 1
+MOVEMENT_BONUS			=	1.1
+ZONE_OF_CONTROL_BONUS	=	1.5
+VISUAL_RANGE_BONUS		=	1.4
+IGNORE_TERRAIN_BONUS	=	1
 
 [HeroData]
 AwakenCost			=	50

--- a/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
+++ b/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
@@ -70,15 +70,16 @@ IGNORE_TERRAIN_BONUS	=	1
 MaxHitPoints		=	710
 
 [Attack0Data1]
-Damage				=	44
+Damage				=	46
 
 [Attack1Data1]
-
+Damage				=	34
 [ElementBonus1]
 
 [SupportBonus1]
+ZONE_OF_CONTROL_BONUS	=	1.3
 VISUAL_RANGE_BONUS		=	1.2
-ZONE_OF_CONTROL_BONUS	=	1.4
+IGNORE_TERRAIN_BONUS	=	1
 
 ;========Restored========
 

--- a/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
+++ b/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
@@ -60,9 +60,9 @@ Sound1				=	Game\ranger_attack.wav
 [ElementBonus]
 
 [SupportBonus]
-ZONE_OF_CONTROL_BONUS	=	1.2
-VISUAL_RANGE_BONUS		=	1.1
 IGNORE_TERRAIN_BONUS	=	1
+VISUAL_RANGE_BONUS		=	1.1
+ZONE_OF_CONTROL_BONUS	=	1.2
 
 ;========Enlightened========
 
@@ -77,9 +77,9 @@ Damage				=	34
 [ElementBonus1]
 
 [SupportBonus1]
-ZONE_OF_CONTROL_BONUS	=	1.3
-VISUAL_RANGE_BONUS		=	1.2
 IGNORE_TERRAIN_BONUS	=	1
+VISUAL_RANGE_BONUS		=	1.2
+ZONE_OF_CONTROL_BONUS	=	1.3
 
 ;========Restored========
 
@@ -97,9 +97,9 @@ Damage				=	38
 
 [SupportBonus2]
 MOVEMENT_BONUS			=	1.1
-ZONE_OF_CONTROL_BONUS	=	1.4
-VISUAL_RANGE_BONUS		=	1.3
 IGNORE_TERRAIN_BONUS	=	1
+VISUAL_RANGE_BONUS		=	1.3
+ZONE_OF_CONTROL_BONUS	=	1.4
 
 ;========Ascended========
 
@@ -117,9 +117,9 @@ Damage				=	40
 
 [SupportBonus3]
 MOVEMENT_BONUS			=	1.1
-ZONE_OF_CONTROL_BONUS	=	1.5
-VISUAL_RANGE_BONUS		=	1.4
 IGNORE_TERRAIN_BONUS	=	1
+VISUAL_RANGE_BONUS		=	1.4
+ZONE_OF_CONTROL_BONUS	=	1.5
 
 [HeroData]
 AwakenCost			=	50

--- a/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
+++ b/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
@@ -1,120 +1,120 @@
 [ObjectData]
-ProperName = Eben Baruch
-Class			= 	2			;enumeration list(int)
-Sprite			=   units\Ranger.tgr
+ProperName			=	Eben Baruch
+Class				=	2			;enumeration list(int)
+Sprite				=	units\Ranger.tgr
 BoundingRadius		=	0.25		;tiles(float)
-RotTime			=	30			;seconds(float)
+RotTime				=	30			;seconds(float)
 MaxHitPoints		=	550			;health rating(float)
-CostGold		=	0			;int
-BuildTime		=	5			;seconds(float)
+CostGold			=	0			;int
+BuildTime			=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
-Defense			=	8			;number (float)
-Faction			=	Council
+Defense				=	8			;number (float)
+Faction				=	Council
 
-Moveable		=	1			;BOOLEAN
-Selectable		=	1			;BOOLEAN
-Blocking		=	1			;BOOLEAN
-Land			=	1			;BOOLEAN
-Water			=	0			;BOOLEAN
+Moveable			=	1			;BOOLEAN
+Selectable			=	1			;BOOLEAN
+Blocking			=	1			;BOOLEAN
+Land				=	1			;BOOLEAN
+Water				=	0			;BOOLEAN
 
-DeathSound1		=	Game\ranger_death.wav
+DeathSound1			=	Game\ranger_death.wav
 SelectionSound1		=	Game\m_hero2_select1.wav
 SelectionSound2		=	Game\m_hero2_select_good.wav
 CommandSound1		=	Game\m_hero2_command1.wav
 CommandSound2		=	Game\m_hero2_command_good.wav
 
+[UnitData]
+Type				=	HERO
+Icon				=	Portraits\Unit Icons\Ranger_icon.tgr
+Portrait			=	Portraits\Heroes\Eben_Baruch_Portrait.tgr
+DieTime				=	1			;seconds(float)
+IdleTime			=	2			;seconds(float)
+MovementRate		=	34			;movement points(float)
+WalkDistance		=	0.77		;tiles (float) how far does unit move in one animation cycle
+ResupplyRate		=	10			; health / second (float)
+CombatValue			=	15
+Description			=	STRING_2376_Eben_loves_nature__He_likes_nothing_better_than_traveling_across_the_land__sleeping_under_the_stars__and_foraging_for_his_dinner__He_is_believed_to_be_one_of_the_originators_of_the_Ranger_society_that_helped_hold_back_the_minions_of_shadow_during_the_Cataclysms_
+
+[Attack1]
+AttackTime			=	1			;seconds(float) seconds per animation cycle
+Projectile			=   flamearrow
+DamagePoint			=	0.6			;seconds(float) at what point (percentage) in attack animation to apply damage/shoot projectile
+ReloadTime			=	1.5			;seconds(float)
+AttackRange			=	6			;tiles (float)
+AttackType			=	PROJECTILE			;enumeration list(int)
+Damage				=	40		;number (float)
+DamageType			=	MAGIC
+Sound1				=	Game\ranger_fire.wav
+
+[Attack2]
+AttackTime			=	1			;seconds(float) seconds per animation cycle
+Projectile			=	flamearrow
+DamagePoint			=	0.5			;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime			=	0.5			;seconds(float)
+AttackRange			=	0.75			;tiles (float)
+AttackType			=	MELEE		;enumeration list(int)	
+Damage				=	32		;number (float)
+DamageType			=	MAGIC
+Sound1				=	Game\ranger_attack.wav
+
 [ElementBonus]
 
 [SupportBonus]
-VISUAL_RANGE_BONUS	= 1.2
-ZONE_OF_CONTROL_BONUS	= 1.3
+VISUAL_RANGE_BONUS		=	1.2
+ZONE_OF_CONTROL_BONUS	=	1.3
 
-[UnitData]
-Type			=	HERO
-Icon			=   Portraits\Unit Icons\Ranger_icon.tgr
-Portrait		=	Portraits\Heroes\Eben_Baruch_Portrait.tgr
-DieTime			=	1			;seconds(float)
-IdleTime		=	2			;seconds(float)
-MovementRate		=	34			;movement points(float)
-WalkDistance		=   	0.77		;tiles (float) how far does unit move in one animation cycle
-ResupplyRate	=	10			; health / second (float)
-CombatValue		= 15
-Description = STRING_2376_Eben_loves_nature__He_likes_nothing_better_than_traveling_across_the_land__sleeping_under_the_stars__and_foraging_for_his_dinner__He_is_believed_to_be_one_of_the_originators_of_the_Ranger_society_that_helped_hold_back_the_minions_of_shadow_during_the_Cataclysms_
-
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_2377_Eben_Baruch
-
-[Attack1]
-AttackTime		=	1			;seconds(float) seconds per animation cycle
-Projectile		=   flamearrow
-DamagePoint		=	0.6			;seconds(float) at what point (percentage) in attack animation to apply damage/shoot projectile
-ReloadTime		=	1.5			;seconds(float)
-AttackRange		=	6			;tiles (float)
-AttackType		=	PROJECTILE			;enumeration list(int)
-Damage			=	40		;number (float)
-DamageType		=	MAGIC
-Sound1			=	Game\ranger_fire.wav
-
-[Attack2]
-AttackTime		=	1			;seconds(float) seconds per animation cycle
-Projectile		=   flamearrow
-DamagePoint		=	0.5			;seconds(float) at what point (percentage) in attack animation to apply damage
-ReloadTime		=	0.5			;seconds(float)
-AttackRange		=	0.75			;tiles (float)
-AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	32		;number (float)
-DamageType		=	MAGIC
-Sound1			=	Game\ranger_attack.wav
+;========Enlightened========
 
 [Level1]
 MaxHitPoints		=	710
 
+[Attack0Data1]
+Damage				=	44
+
+[Attack1Data1]
+
+[ElementBonus1]
+
+[SupportBonus1]
+VISUAL_RANGE_BONUS		=	1.2
+ZONE_OF_CONTROL_BONUS	=	1.4
+
+;========Restored========
+
 [Level2]
 MaxHitPoints		=	870
-Defense			=	10
+Defense				=	10
+
+[Attack0Data2]
+Damage				=	50
+
+[Attack1Data2]
+Damage				=	36
+
+[ElementBonus2]
+
+[SupportBonus2]
+VISUAL_RANGE_BONUS		=	1.3
+ZONE_OF_CONTROL_BONUS	=	1.4
+
+;========Ascended========
 
 [Level3]
 MaxHitPoints		=	1030
 ;Technology		= SampleTech
 
-[Attack0Data1]
-Damage			=	44
-
-[Attack1Data1]
-
-[Attack0Data2]
-Damage			=	50
-
-[Attack1Data2]
-Damage			=	36
-
 [Attack0Data3]
 
 [Attack1Data3]
-Damage			=	40
-
-[SpellData1]
-
-[SpellData2]
-
-[SpellData3]
-
-[ElementBonus1]
-
-[SupportBonus1]
-VISUAL_RANGE_BONUS	= 1.2
-ZONE_OF_CONTROL_BONUS	= 1.4
-
-[ElementBonus2]
-
-[SupportBonus2]
-VISUAL_RANGE_BONUS	= 1.3
-ZONE_OF_CONTROL_BONUS	= 1.4
+Damage				=	40
 
 [ElementBonus3]
 
 [SupportBonus3]
-VISUAL_RANGE_BONUS	= 1.4
+VISUAL_RANGE_BONUS		= 1.4
 ZONE_OF_CONTROL_BONUS	= 1.5
 IGNORE_TERRAIN_BONUS	= 1
+
+[HeroData]
+AwakenCost			=	50
+TranslatedName		=	STRING_2377_Eben_Baruch

--- a/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
+++ b/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
@@ -39,10 +39,10 @@ Description			=	STRING_2376_Eben_loves_nature__He_likes_nothing_better_than_trav
 AttackTime			=	1			;seconds(float) seconds per animation cycle
 Projectile			=   flamearrow
 DamagePoint			=	0.6			;seconds(float) at what point (percentage) in attack animation to apply damage/shoot projectile
-ReloadTime			=	1.5			;seconds(float)
+ReloadTime			=	1			;seconds(float)
 AttackRange			=	6			;tiles (float)
 AttackType			=	PROJECTILE			;enumeration list(int)
-Damage				=	40		;number (float)
+Damage				=	42		;number (float)
 DamageType			=	MAGIC
 Sound1				=	Game\ranger_fire.wav
 
@@ -60,8 +60,9 @@ Sound1				=	Game\ranger_attack.wav
 [ElementBonus]
 
 [SupportBonus]
-VISUAL_RANGE_BONUS		=	1.2
-ZONE_OF_CONTROL_BONUS	=	1.3
+ZONE_OF_CONTROL_BONUS	=	1.2
+VISUAL_RANGE_BONUS		=	1.1
+IGNORE_TERRAIN_BONUS	=	1
 
 ;========Enlightened========
 

--- a/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
+++ b/TGX Files/Data/ObjectData/Heroes/EBEN_BARUCH.INI
@@ -91,13 +91,15 @@ Defense				=	10
 Damage				=	50
 
 [Attack1Data2]
-Damage				=	36
+Damage				=	38
 
 [ElementBonus2]
 
 [SupportBonus2]
-VISUAL_RANGE_BONUS		=	1.3
+MOVEMENT_BONUS			=	1.1
 ZONE_OF_CONTROL_BONUS	=	1.4
+VISUAL_RANGE_BONUS		=	1.3
+IGNORE_TERRAIN_BONUS	=	1
 
 ;========Ascended========
 


### PR DESCRIPTION
### **_Changelog:_**
### All Levels:
```
Reduced ranged attack reload time from 1.5s to 1s
```
### Awakened:
```
Increased ranged AV from 40 to 42
Added Trailblazing (Provided)
Reduced Recon from 120% to 110%
Reduced Dominion from 130% to 120%
```
### Enlightened:
```
Increased ranged AV from 44 to 46
Increased melee AV from 32 to 34
Added Trailblazing (Provided)
Reduced Dominion from 140% to 130%
```
### Restored:
```
Increased melee AV from 36 to 38
Added Trailblazing (Provided)
Added Movement Speed (Provided) 110%
```
### Ascended:
```
Increased HP from 1030 to 1050
Increased DV from 10 to 12
Increased ranged AV from 50 to 55
Added Movement Speed 110%
```