### PR TITLE
Samman Osahyr Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
@@ -1,5 +1,5 @@
 [ObjectData]
-ProperName = Samman Ravid
+ProperName = Samman Osahyr
 Class			= 	2			;enumeration list(int)
 Sprite			=   units\Scout.tgr
 BoundingRadius		=	0.25		;tiles(float)
@@ -109,4 +109,4 @@ VISUAL_RANGE_BONUS	= 1.25
 
 [HeroData]
 AwakenCost		=	50
-TranslatedName = STRING_2406_Samman_Ravid
+TranslatedName = Samman Osahyr

--- a/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
@@ -23,13 +23,6 @@ SelectionSound2		=	Game\m_hero1_select_good.wav
 CommandSound1		=	Game\m_hero1_command2.wav
 CommandSound2		=	Game\m_hero1_command_good.wav
 
-[ElementBonus]
-DAMAGE_TAKEN_FROM_RANGED	= .5
-
-[SupportBonus]
-DEFENSE_BONUS_VS_MOUNTED = 2
-VISUAL_RANGE_BONUS	= 1.1
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Scout_icon.tgr
@@ -41,10 +34,6 @@ WalkDistance		=   	2		;tiles (float) how far does unit move in one animation cyc
 ResupplyRate		=	10			; health / second (float)
 CombatValue		= 15
 Description = STRING_2405_Samman_is_a_thoughtful_and_intelligent_leader__He_wears_light_armor_and_always_looks_like_he_is_reflecting_deeply_upon_some_problem_that_plagues_him__He_prefers_to_command_light_cavalry_as_he_knows_the_tactics_of_cavalry_well__Samman_wields_a_khaldunite_spear_from_the_back_of_a_horse_as_swift_as_the_wind_
-
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_2406_Samman_Ravid
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
@@ -64,29 +53,20 @@ AttackRange		=	0		;tiles (float)
 AttackType		=	0		;enumeration list(int)	
 DamageType		=	0		;number (float)
 
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .5
+
+[SupportBonus]
+DEFENSE_BONUS_VS_MOUNTED = 2
+VISUAL_RANGE_BONUS	= 1.1
+
 [Level1]
 MaxHitPoints		=	780
 
-[Level2]
-MaxHitPoints		=	940
-
-[Level3]
-MaxHitPoints		=	1100
-;Technology		= SampleTech
+[SpellData1]
 
 [Attack0Data1]
 Damage			=	44
-
-[Attack0Data2]
-Damage			=	48
-
-[Attack0Data3]
-
-[SpellData1]
-
-[SpellData2]
-
-[SpellData3]
 
 [ElementBonus1]
 DAMAGE_TAKEN_FROM_RANGED	= .5
@@ -96,6 +76,14 @@ DEFENSE_BONUS_VS_MOUNTED = 2
 IGNORE_TERRAIN_BONUS		= 1
 VISUAL_RANGE_BONUS	= 1.1
 
+[Level2]
+MaxHitPoints		=	940
+
+[SpellData2]
+
+[Attack0Data2]
+Damage			=	48
+
 [ElementBonus2]
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
@@ -104,6 +92,13 @@ DEFENSE_BONUS_VS_MOUNTED 	= 4
 IGNORE_TERRAIN_BONUS		= 1
 VISUAL_RANGE_BONUS	= 1.2
 
+[Level3]
+MaxHitPoints		=	1100
+
+[SpellData3]
+
+[Attack0Data3]
+
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
@@ -111,3 +106,7 @@ DAMAGE_TAKEN_FROM_RANGED	= .5
 DEFENSE_BONUS_VS_MOUNTED 	= 6
 IGNORE_TERRAIN_BONUS		= 1
 VISUAL_RANGE_BONUS	= 1.25
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_2406_Samman_Ravid

--- a/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
@@ -4,7 +4,7 @@ Class			= 	2			;enumeration list(int)
 Sprite			=   units\Scout.tgr
 BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	620			;health rating(float)
+MaxHitPoints		=	700			;health rating(float)
 CostGold		=	0			;int
 BuildTime		=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
@@ -31,7 +31,7 @@ Icon			=   Portraits\Unit Icons\Scout_icon.tgr
 Portrait		=	Portraits\Heroes\Samman_Portrait.tgr
 DieTime			=	1			;seconds(float)
 IdleTime		=	2			;seconds(float)
-MovementRate		=	34			;movement points(float)
+MovementRate		=	36			;movement points(float)
 WalkDistance		=   	2		;tiles (float) how far does unit move in one animation cycle
 ResupplyRate		=	10			; health / second (float)
 CombatValue		= 15
@@ -43,7 +43,7 @@ DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	0.75	;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	40		;number (float)
+Damage			=	48		;number (float)
 DamageType		=	Khaldunite
 Sound1			= 	Game\spear1.wav
 
@@ -56,6 +56,7 @@ AttackType		=	0		;enumeration list(int)
 DamageType		=	0		;number (float)
 
 [ElementBonus]
+IGNORE_TERRAIN_BONUS        =   1
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus]

--- a/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
@@ -64,20 +64,21 @@ DEFENSE_BONUS_VS_MOUNTED = 2
 VISUAL_RANGE_BONUS	= 1.1
 
 [Level1]
-MaxHitPoints		=	780
+MaxHitPoints		=	950
 
 [SpellData1]
 
 [Attack0Data1]
-Damage			=	44
+Damage			=	52
 
 [ElementBonus1]
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
-DEFENSE_BONUS_VS_MOUNTED = 2
 IGNORE_TERRAIN_BONUS		= 1
-VISUAL_RANGE_BONUS	= 1.1
+ATTACK_BONUS_TO_MOUNTED     =   2
+DEFENSE_BONUS_VS_MOUNTED = 4
+VISUAL_RANGE_BONUS	= 1.2
 
 [Level2]
 MaxHitPoints		=	940

--- a/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
@@ -98,19 +98,21 @@ DEFENSE_BONUS_VS_MOUNTED 	= 5
 VISUAL_RANGE_BONUS	= 1.25
 
 [Level3]
-MaxHitPoints		=	1100
+MaxHitPoints		=	1300
 
 [SpellData3]
 
 [Attack0Data3]
+Damage              =   64
 
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
-DEFENSE_BONUS_VS_MOUNTED 	= 6
 IGNORE_TERRAIN_BONUS		= 1
-VISUAL_RANGE_BONUS	= 1.25
+ATTACK_BONUS_TO_MOUNTED     =   6
+DEFENSE_BONUS_VS_MOUNTED 	= 8
+VISUAL_RANGE_BONUS	= 1.3
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
@@ -89,7 +89,6 @@ MaxHitPoints		=	1150
 Damage			=	56
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus2]
 IGNORE_TERRAIN_BONUS		= 1
@@ -106,7 +105,6 @@ MaxHitPoints		=	1300
 Damage              =   64
 
 [ElementBonus3]
-DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
 IGNORE_TERRAIN_BONUS		= 1

--- a/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
@@ -18,10 +18,12 @@ Land			=	1			;BOOLEAN
 Water			=	0			;BOOLEAN
 
 DeathSound1		=	Game\scout_death.wav
-SelectionSound1		=	Game\m_hero1_select2.wav
-SelectionSound2		=	Game\m_hero1_select_good.wav
-CommandSound1		=	Game\m_hero1_command2.wav
-CommandSound2		=	Game\m_hero1_command_good.wav
+SelectionSound1		=	Game\agm_hero1_select1.wav
+SelectionSound2		=	Game\agm_hero1_select2.wav
+SelectionSound3		=	Game\agm_hero1_select3.wav
+CommandSound1		=	Game\agm_hero1_command1.wav
+CommandSound2		=	Game\agm_hero1_command2.wav
+CommandSound3		=	Game\agm_hero1_command3.wav
 
 [UnitData]
 Type			=	HERO

--- a/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAMMAN OSAHYR.INI
@@ -81,20 +81,21 @@ DEFENSE_BONUS_VS_MOUNTED = 4
 VISUAL_RANGE_BONUS	= 1.2
 
 [Level2]
-MaxHitPoints		=	940
+MaxHitPoints		=	1150
 
 [SpellData2]
 
 [Attack0Data2]
-Damage			=	48
+Damage			=	56
 
 [ElementBonus2]
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus2]
-DEFENSE_BONUS_VS_MOUNTED 	= 4
 IGNORE_TERRAIN_BONUS		= 1
-VISUAL_RANGE_BONUS	= 1.2
+ATTACK_BONUS_TO_MOUNTED     =   4
+DEFENSE_BONUS_VS_MOUNTED 	= 5
+VISUAL_RANGE_BONUS	= 1.25
 
 [Level3]
 MaxHitPoints		=	1100


### PR DESCRIPTION
### _Changelog:_

### Awakened:

	Increased HP from 620 to 700 
	Increased Movement from 34 to 36
	Increased AV from 40 to 48 
	
	Added Trailblazing (Personal)
	
### Enlightened:

	Increased HP from 780 to 950 
	Increased AV from 44 to 52 
	
	Increased Cavalry Resistant from 2 to 4 (Provided)
	Added Cavalry Foe 2 (Provided)
	Increased Recon from 110% to 120% (Provided)

### Restored:

	Increased HP from 940 to 1150 
	Increased AV from 48 to 56
	
	Increased Cavalry Resistant  from 4 to 5 (Provided)
	Added Cavalry foe +4 (Provided)
	Increased Recon from 120% to 125% (Provided)
	
### Ascended:

	Increased HP from 1100 to 1300 
	Increased AV from 48 to 64 
	
	Increased Cav Resistant from 6 to 8 (Provided)
	Added Cavalry Foe +6 (Provided)
	Increased Recon from 125% to 130% (Provided)
