### PR TITLE
Arya rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/CYRA_BLOODSTONE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/CYRA_BLOODSTONE.INI
@@ -4,11 +4,11 @@ Class					=		2			;enumeration list(int)
 Sprite					=	units\female_hero.tgr
 BoundingRadius			=	0.25		;tiles(float)
 RotTime					=	30			;seconds(float)
-MaxHitPoints			=	470			;health rating(float)
+MaxHitPoints			=	450			;health rating(float)
 CostGold				=	0			;int
 BuildTime				=	5			;seconds(float)
 DetectionRadius			=	100			;movement points(float)
-Defense					=	10			;number (float)
+Defense					=	12			;number (float)
 Faction					=	Royalist
 
 Moveable				=	1			;BOOLEAN
@@ -39,10 +39,10 @@ Description				=	STRING_2369_Arya_Shahin_is_a_most_confrontational_woman__She_ne
 Sound1					=	Game\sword1.wav
 AttackTime				=	1
 DamagePoint				=	0.4
-ReloadTime				=	0.5
+ReloadTime				=	0.36
 AttackRange				=	0.75
 AttackType				=	MELEE
-Damage					=	44
+Damage					=	42
 DamageType				=	NORMAL
 
 [Attack2]
@@ -54,10 +54,11 @@ AttackType				=	0
 DamageType				=	0
 
 [ElementBonus]
+DAMAGE_TAKEN_FROM_MELEE		=	.9
 DAMAGE_TAKEN_FROM_RANGED	=	.5
 
 [SupportBonus]
-RESUPPLY_RATE_BONUS			=	1.2
+RESUPPLY_RATE_BONUS			=	1.15
 
 ;========Enlightened========
 

--- a/TGX Files/Data/ObjectData/Heroes/CYRA_BLOODSTONE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/CYRA_BLOODSTONE.INI
@@ -81,18 +81,22 @@ RESUPPLY_RATE_BONUS			=	1.25
 ;========Restored========
 
 [Level2]
-MaxHitPoints			=	940
+MaxHitPoints			=	850
+Defense					=	14
 
 [Attack0Data2]
-Damage					=	55
+Damage					=	46
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_MAGIC		=	.5
+ATTACK_BONUS_TO_SHADOW		=	2
+IGNORE_TERRAIN_BONUS		=	1
+IMMUNITY_TO_ENCHANTMENT		=	1
+DAMAGE_TAKEN_FROM_MELEE		=	.9
 DAMAGE_TAKEN_FROM_RANGED	=	.5
 
 [SupportBonus2]
 ATTACK_BONUS_TO_SHADOW		=	6
-RESUPPLY_RATE_BONUS			=	1.4
+RESUPPLY_RATE_BONUS			=	1.35
 
 ;========Ascended========
 

--- a/TGX Files/Data/ObjectData/Heroes/CYRA_BLOODSTONE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/CYRA_BLOODSTONE.INI
@@ -63,16 +63,20 @@ RESUPPLY_RATE_BONUS			=	1.15
 ;========Enlightened========
 
 [Level1]
-MaxHitPoints			=	705
+MaxHitPoints			=	650
+Defense					=	13
+MeleeFX					=	Paladin_HitFX
 
 [Attack0Data1]
+DamageType				=	MAGIC
 
 [ElementBonus1]
+IMMUNITY_TO_ENCHANTMENT		=	1
+DAMAGE_TAKEN_FROM_MELEE		=	.9
 DAMAGE_TAKEN_FROM_RANGED	=	.5
 
 [SupportBonus1]
-ATTACK_BONUS_TO_SHADOW		=	3
-RESUPPLY_RATE_BONUS			=	1.3
+RESUPPLY_RATE_BONUS			=	1.25
 
 ;========Restored========
 

--- a/TGX Files/Data/ObjectData/Heroes/CYRA_BLOODSTONE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/CYRA_BLOODSTONE.INI
@@ -1,113 +1,113 @@
 [ObjectData]
-ProperName = Arya Shahin
-Class			= 	2			;enumeration list(int)
-Sprite			=   units\female_hero.tgr
-BoundingRadius		=	0.25		;tiles(float)
-RotTime			=	30			;seconds(float)
-MaxHitPoints		=	470			;health rating(float)
-CostGold		=	0			;int
-BuildTime		=	5			;seconds(float)
-DetectionRadius		=	100			;movement points(float)
-Defense			=	10			;number (float)
-Faction			=	Royalist
+ProperName				=	Arya Shahin
+Class					=		2			;enumeration list(int)
+Sprite					=	units\female_hero.tgr
+BoundingRadius			=	0.25		;tiles(float)
+RotTime					=	30			;seconds(float)
+MaxHitPoints			=	470			;health rating(float)
+CostGold				=	0			;int
+BuildTime				=	5			;seconds(float)
+DetectionRadius			=	100			;movement points(float)
+Defense					=	10			;number (float)
+Faction					=	Royalist
 
-Moveable		=	1			;BOOLEAN
-Selectable		=	1			;BOOLEAN
-Blocking		=	1			;BOOLEAN
-Land			=	1			;BOOLEAN
-Water			=	0			;BOOLEAN
+Moveable				=	1			;BOOLEAN
+Selectable				=	1			;BOOLEAN
+Blocking				=	1			;BOOLEAN
+Land					=	1			;BOOLEAN
+Water					=	0			;BOOLEAN
 
-DeathSound1		=	Game\Priestess_death.wav
-SelectionSound1		=	Game\f_hero5_select.wav
-SelectionSound2		=	Game\f_hero5_select_good.wav
-CommandSound1		=	Game\f_hero5_command.wav
-CommandSound2		=	Game\f_hero5_command_good.wav
+DeathSound1				=	Game\Priestess_death.wav
+SelectionSound1			=	Game\f_hero5_select.wav
+SelectionSound2			=	Game\f_hero5_select_good.wav
+CommandSound1			=	Game\f_hero5_command.wav
+CommandSound2			=	Game\f_hero5_command_good.wav
 
 [UnitData]
-Type                =   HERO
-Icon                =   Portraits\Unit Icons\Female_Hero_icon.tgr
-Portrait            =   Portraits\Heroes\Arya_Shahin_Portrait.tgr
-DieTime             =   1
-IdleTime            =   2
-MovementRate        =   34
-WalkDistance        =   0.77
-ResupplyRate        =   10
-CombatValue         =   15
-Description         =   STRING_2369_Arya_Shahin_is_a_most_confrontational_woman__She_never_takes_a_back_seat_on_the_battlefield_and_if_she_has_something_to_say_she_never_hesitates_to_make_her_opinion_known__Her_skills_have_been_focused_on_battling_the_Shadow_and_she_has_become_very_intent_on_proving_herself_in_the_approaching_conflict_
+Type					=	HERO
+Icon					=	Portraits\Unit Icons\Female_Hero_icon.tgr
+Portrait				=	Portraits\Heroes\Arya_Shahin_Portrait.tgr
+DieTime					=	1
+IdleTime				=	2
+MovementRate			=	34
+WalkDistance			=	0.77
+ResupplyRate			=	10
+CombatValue				=	15
+Description				=	STRING_2369_Arya_Shahin_is_a_most_confrontational_woman__She_never_takes_a_back_seat_on_the_battlefield_and_if_she_has_something_to_say_she_never_hesitates_to_make_her_opinion_known__Her_skills_have_been_focused_on_battling_the_Shadow_and_she_has_become_very_intent_on_proving_herself_in_the_approaching_conflict_
 
 [Attack1]
-Sound1              =   Game\sword1.wav
-AttackTime          =   1
-DamagePoint         =   0.4
-ReloadTime          =   0.5
-AttackRange         =   0.75
-AttackType          =   MELEE
-Damage              =   44
-DamageType          =   NORMAL
+Sound1					=	Game\sword1.wav
+AttackTime				=	1
+DamagePoint				=	0.4
+ReloadTime				=	0.5
+AttackRange				=	0.75
+AttackType				=	MELEE
+Damage					=	44
+DamageType				=	NORMAL
 
 [Attack2]
-AttackTime          =   0
-DamagePoint         =   0.7
-ReloadTime          =   0
-AttackRange         =   0
-AttackType          =   0
-DamageType          =   0
+AttackTime				=	0
+DamagePoint				=	0.7
+ReloadTime				=	0
+AttackRange				=	0
+AttackType				=	0
+DamageType				=	0
 
 [ElementBonus]
-DAMAGE_TAKEN_FROM_RANGED        =   .5
+DAMAGE_TAKEN_FROM_RANGED	=	.5
 
 [SupportBonus]
-RESUPPLY_RATE_BONUS             =   1.2
+RESUPPLY_RATE_BONUS			=	1.2
+
+;========Enlightened========
 
 [Level1]
-MaxHitPoints        =   705
-
-[SpellData1]
+MaxHitPoints			=	705
 
 [Attack0Data1]
 
 [ElementBonus1]
-DAMAGE_TAKEN_FROM_RANGED        =   .5
+DAMAGE_TAKEN_FROM_RANGED	=	.5
 
 [SupportBonus1]
-ATTACK_BONUS_TO_SHADOW          =   3
-RESUPPLY_RATE_BONUS             =   1.3
+ATTACK_BONUS_TO_SHADOW		=	3
+RESUPPLY_RATE_BONUS			=	1.3
+
+;========Restored========
 
 [Level2]
-MaxHitPoints        =   940
-
-[SpellData2]
+MaxHitPoints			=	940
 
 [Attack0Data2]
-Damage              =   55
+Damage					=	55
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_MAGIC         =   .5
-DAMAGE_TAKEN_FROM_RANGED        =   .5
+DAMAGE_TAKEN_FROM_MAGIC		=	.5
+DAMAGE_TAKEN_FROM_RANGED	=	.5
 
 [SupportBonus2]
-ATTACK_BONUS_TO_SHADOW          =   6
-RESUPPLY_RATE_BONUS             =   1.4
+ATTACK_BONUS_TO_SHADOW		=	6
+RESUPPLY_RATE_BONUS			=	1.4
+
+;========Ascended========
 
 [Level3]
-MaxHitPoints        =   1175
-Defense             =   12
-MeleeFX             =   Paladin_HitFX
-
-[SpellData3]
+MaxHitPoints			=	1175
+Defense					=	12
+MeleeFX					=	Paladin_HitFX
 
 [Attack0Data3]
-DamageType=MAGIC
+DamageType				=	MAGIC
 
 [ElementBonus3]
-DAMAGE_TAKEN_FROM_MAGIC         =   .5
-DAMAGE_TAKEN_FROM_RANGED        =   .5
-IMMUNITY_TO_ENCHANTMENT         =   1
+DAMAGE_TAKEN_FROM_MAGIC		=	.5
+DAMAGE_TAKEN_FROM_RANGED	=	.5
+IMMUNITY_TO_ENCHANTMENT		=	1
 
 [SupportBonus3]
-ATTACK_BONUS_TO_SHADOW          =   8
-RESUPPLY_RATE_BONUS             =   1.5
+ATTACK_BONUS_TO_SHADOW		=	8
+RESUPPLY_RATE_BONUS			=	1.5
 
 [HeroData]
-AwakenCost          =   50
-TranslatedName      =   STRING_0051_Arya_Shahin
+AwakenCost				=	50
+TranslatedName			=	STRING_0051_Arya_Shahin

--- a/TGX Files/Data/ObjectData/Heroes/CYRA_BLOODSTONE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/CYRA_BLOODSTONE.INI
@@ -83,6 +83,7 @@ RESUPPLY_RATE_BONUS			=	1.25
 [Level2]
 MaxHitPoints			=	850
 Defense					=	14
+MeleeFX					=	Paladin_HitFX
 
 [Attack0Data2]
 Damage					=	46
@@ -101,20 +102,21 @@ RESUPPLY_RATE_BONUS			=	1.35
 ;========Ascended========
 
 [Level3]
-MaxHitPoints			=	1175
-Defense					=	12
+MaxHitPoints			=	1000
+Defense					=	16
 MeleeFX					=	Paladin_HitFX
 
 [Attack0Data3]
-DamageType				=	MAGIC
+Damage					=	50
 
 [ElementBonus3]
-DAMAGE_TAKEN_FROM_MAGIC		=	.5
-DAMAGE_TAKEN_FROM_RANGED	=	.5
+ATTACK_BONUS_TO_SHADOW		=	4
+IGNORE_TERRAIN_BONUS		=	1
 IMMUNITY_TO_ENCHANTMENT		=	1
+DAMAGE_TAKEN_FROM_MELEE		=	.8
+DAMAGE_TAKEN_FROM_RANGED	=	.5
 
 [SupportBonus3]
-ATTACK_BONUS_TO_SHADOW		=	8
 RESUPPLY_RATE_BONUS			=	1.5
 
 [HeroData]


### PR DESCRIPTION
### **_Changelog:_**
### All Levels:
```
Increased Attack Speed to 110% (RT 0.5s to 0.36s)
```
### Awakened:
```
Decreased HP from 470 to 450
Increased DV from 10 to 12
Decreased AV from 44 to 42
Added Melee resistance (Personal) 90%
Reduced Quicker Recovery from 120% to 115%
```
### Enlightened:
```
Reduced HP from 705 to 650
Increased DV from 10 to 13
Changed Damage Type from Normal to Magic
Added Paladin_HitFX
Added Melee resistance (Personal) 90%
Added Spell Immunity (Personal)
Reduced Quicker Recovery from 130% to 125%
Removed Shadowbane (Provided) +3
```
### Restored:
```
Decreased HP from 940 to 850
Increased DV from 10 to 14
Reduced AV from 55 to 46
Changed Damage Type from Normal to Magic
Added Paladin_HitFX
Added Melee resistance (Personal) 90%
Added Spell Immunity (Personal)
Added Trailblazing (Personal)
Removed Magic Resistance (Personal) 50%
Added Shadowbane (Personal) +2
Reduced Quicker Recovery from 140% to 135%
Removed Shadowbane (Provided) +6
```
### Ascended:
```
Reduced HP from 1175 to 1000
Increased DV from 12 to 16
Reduced AV from 55 to 50
Added Melee resistance (Personal) 80%
Added Trailblazing (Personal)
Removed Magic Resistance (Personal) 50%
Added Shadowbane (Personal) +4
Removed Shadowbane (Provided) +8

```