### PR TITLE
Ashavir Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/ASHAVIR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/ASHAVIR.INI
@@ -106,12 +106,15 @@ MaxHitPoints		=	1060
 [SpellData3]
 
 [Attack0Data3]
-Damage		    	=	54
+Damage		    	=	58
+DamageType          =   KHALDUNITE
 
 [ElementBonus3]
+DAMAGE_TAKEN_FROM_MAGIC     =   .4
+DAMAGE_TAKEN_FROM_RANGED    =   .4
 
 [SupportBonus3]
-DEFENSE_BONUS_VS_SHADOW= 6
+DEFENSE_BONUS_VS_SHADOW     =   6
 
 
 [HeroData]

--- a/TGX Files/Data/ObjectData/Heroes/ASHAVIR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/ASHAVIR.INI
@@ -68,17 +68,20 @@ MORALE_BONUS                =   -4
 DEFENSE_BONUS_VS_SHADOW     =   2
 
 [Level1]
-MaxHitPoints		=	690
+MaxHitPoints		=	720
+Defense             =   12
 
 [SpellData1]
 
 [Attack0Data1]
-Damage	    		=	46
+Damage	    		=	50
 
 [ElementBonus1]
+DAMAGE_TAKEN_FROM_RANGED    =   .8
 
 [SupportBonus1]
-DEFENSE_BONUS_VS_SHADOW= 4
+MORALE_BONUS                =   -4
+DEFENSE_BONUS_VS_SHADOW     =   4
 
 [Level2]
 MaxHitPoints	    =	880

--- a/TGX Files/Data/ObjectData/Heroes/ASHAVIR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/ASHAVIR.INI
@@ -82,7 +82,7 @@ DEFENSE_BONUS_VS_SHADOW= 4
 MaxHitPoints	    =	880
 
 [SpellData2]
-Spell0			    =	Ahriman's Gift
+Spell0			    =	Ahriman's Gift ;'
 
 [Attack0Data2]
 Damage		    	=	50

--- a/TGX Files/Data/ObjectData/Heroes/ASHAVIR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/ASHAVIR.INI
@@ -90,12 +90,15 @@ MaxHitPoints	    =	880
 Spell0			    =	Ahriman's Gift ;'
 
 [Attack0Data2]
-Damage		    	=	50
+Damage		    	=	54
 
 [ElementBonus2]
+DAMAGE_TAKEN_FROM_MAGIC     =   .5
+DAMAGE_TAKEN_FROM_RANGED    =   .5
 
 [SupportBonus2]
-DEFENSE_BONUS_VS_SHADOW= 4
+MORALE_BONUS                =   -4
+DEFENSE_BONUS_VS_SHADOW     =   4
 
 [Level3]
 MaxHitPoints		=	1060

--- a/TGX Files/Data/ObjectData/Heroes/ASHAVIR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/ASHAVIR.INI
@@ -4,7 +4,7 @@ Class			    = 	2			;enumeration list(int)
 Sprite		        =   units\dreadlord.tgr
 BoundingRadius	    =	0.25		;tiles(float)
 RotTime			    =	30			;seconds(float)
-MaxHitPoints		=	520		;health rating(float)
+MaxHitPoints		=	570		;health rating(float)
 CostGold	    	=	0			;int
 BuildTime	    	=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
@@ -48,7 +48,7 @@ DamagePoint	    	=	0.6		;seconds(float) at what point (percentage) in attack ani
 ReloadTime		    =	0.5		;seconds(float)
 AttackRange	    	=	.75		;tiles (float)
 AttackType	    	=	MELEE		;enumeration list(int)
-Damage		    	=	42		;number (float)
+Damage		    	=	46		;number (float)
 DamageType	    	=	NORMAL
 Sound1		    	= 	Game\paladin_attack.wav
 Sound2		    	= 	Game\sword1.wav
@@ -61,9 +61,11 @@ AttackType	    	=	CAST		; enumeration list (int)
 Animation	    	= 	0		;animations are backwards
 
 [ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED    =   .9
 
 [SupportBonus]
-DEFENSE_BONUS_VS_SHADOW= 2
+MORALE_BONUS                =   -4
+DEFENSE_BONUS_VS_SHADOW     =   2
 
 [Level1]
 MaxHitPoints		=	690


### PR DESCRIPTION
### _Changelog:_

### Awakened:
	
	Increased HP from 520 to 570 
	Increased AV from 42 to 46
	
	Added Range Resistant 90% (Personal)
	
	Added Cowardice 4 (Provided)
	
### Enlightened:

	Increased HP from 690 to 720 
	Increased DV from 10 to 12
	Increased AV from 46 to 50
	
	Added Range Resistant 80% (Personal)
	
	Added Cowardice -4 (Provided)
	
### Restored:

	Increased AV from 50 to 54
	
	Added Range Resistant 50% (Personal)
	Added Magic Resistant 50% (Personal)
	
	Added Cowardice -4  (Provided)

### Ascended:

	Increased AV from 54 to 58 
	Damage type changed to Khaldunite
	
	Added Range Resistant 40% (Personal)
	Added Magic Resistant 40% (Personal)
