### PR TITLE
Technology adjustments

### DIFF
--- a/TGX Files/Data/ObjectData/buildings/CEYAH_FORTRESS.INI
+++ b/TGX Files/Data/ObjectData/buildings/CEYAH_FORTRESS.INI
@@ -1,0 +1,47 @@
+[ObjectData]
+ProperName = STRING_4617_Ceyah_Fort
+Class				= 	2	;enumeration list(int)
+Sprite				=   buildings\Ceyah_Fort.tgr
+BoundingRadius			=	3	;tiles (float)
+ClearOut			=   	2	;tiles
+MaxHitPoints			=	4100	;health rating(float)
+DetectionRadius			=	16	;tiles(float)
+Defense				=	0	;number (float)
+DieTime				=	1
+RotTime				=	60	;seconds(float)
+Captureable		=	0
+Description = STRING_4618_The_fort_is_an_upgraded_outpost_that_features_increased_fortification__more_militia__and_an_extended_supply_range_
+CostGold			=	50
+
+SelectionSound1		= 	Game\select_outpost.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Ceyah_fort_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\ceyah_fort_Destroy.tgr
+NameList			=	CeyahOutposts
+IconIndex 			= 	13
+StoneProduction			=	-3		;int
+booty_min	 = 0
+booty_max	 = 0
+
+[BaseData]
+ControlRange			=   	7		;tiles (float)
+SupplyRange			=	18		; tiles (float)
+CompanySize			=	6		; militia per company
+MaxMilitia			=	12		; total max militia
+MilitiaType			=	Undead_Militia		; militia type
+MilitiaType2			=	Shadow_Militia		; militia type
+MilitiaGrowth			=	0.05		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+FrameRate = 180		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 7
+
+
+

--- a/TGX Files/Data/ObjectData/buildings/CEYAH_FORTRESS.INI
+++ b/TGX Files/Data/ObjectData/buildings/CEYAH_FORTRESS.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_4617_Ceyah_Fort
-Class				= 	2	;enumeration list(int)
+Class				= 	1	;enumeration list(int)
 Sprite				=   buildings\Ceyah_Fort.tgr
 BoundingRadius			=	3	;tiles (float)
 ClearOut			=   	2	;tiles

--- a/TGX Files/Data/ObjectData/buildings/CEYAH_OUTPOST.INI
+++ b/TGX Files/Data/ObjectData/buildings/CEYAH_OUTPOST.INI
@@ -1,0 +1,49 @@
+[ObjectData]
+ProperName = STRING_2166_Ceyah_Outpost
+Class				= 	2	;enumeration list(int)
+Sprite				=   buildings\Ceyah_Outpost.tgr
+BoundingRadius			=	3	;tiles (float)
+ClearOut			=   	2	;tiles
+MaxHitPoints			=	2400	;health rating(float)
+DetectionRadius			=	16	;tiles(float)
+Defense				=	0	;number (float)
+DieTime				=	1
+RotTime				=	60	;seconds(float)
+Captureable		=	0
+Description			=	STRING_2158_Outposts_are_used_to_extend_a_kingdom_s_supply_range_and_protect_its_borders_from_incursion_
+CostGold			=	50
+Faction			=	Ceyah
+
+SelectionSound1	= 	Game\select_outpost.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Ceyah_Outpost_portrait.tgr
+ConstructionAnimation 	= Art\Objects\Buildings\Animations\ceyah_outpost_build.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\ceyah_outpost_Destroy.tgr
+NameList			=	CeyahOutposts
+IconIndex 			= 	3
+StoneProduction			=	-3		;int
+booty_min	 = 0
+booty_max	 = 0
+
+[BaseData]
+ControlRange			=   	7		;tiles (float)
+SupplyRange			=	16		; tiles (float)
+CompanySize			=	6		; militia per company
+MaxMilitia			=	6		; total max militia
+MilitiaType			=	Undead_Militia		; militia type
+MilitiaType2			=	Shadow_Militia		; militia type
+MilitiaGrowth			=	0.05		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+FrameRate = 180		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 5
+
+
+

--- a/TGX Files/Data/ObjectData/buildings/CEYAH_OUTPOST.INI
+++ b/TGX Files/Data/ObjectData/buildings/CEYAH_OUTPOST.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_2166_Ceyah_Outpost
-Class				= 	2	;enumeration list(int)
+Class				= 	1	;enumeration list(int)
 Sprite				=   buildings\Ceyah_Outpost.tgr
 BoundingRadius			=	3	;tiles (float)
 ClearOut			=   	2	;tiles

--- a/TGX Files/Data/ObjectData/buildings/COUNCIL_FORTRESS.INI
+++ b/TGX Files/Data/ObjectData/buildings/COUNCIL_FORTRESS.INI
@@ -1,0 +1,47 @@
+[ObjectData]
+ProperName = STRING_4619_Council_Fort
+Class				= 	2	;enumeration list(int)
+Sprite				=   buildings\council_Fort.tgr
+BoundingRadius			=	3	;tiles (float)
+ClearOut			=   	2	;tiles
+MaxHitPoints			=	3500	;health rating(float)
+DetectionRadius			=	16	;tiles(float)
+Defense				=	0	;number (float)
+DieTime				=	1
+RotTime				=	60	;seconds(float)
+Captureable		=	0
+Description = STRING_4618_The_fort_is_an_upgraded_outpost_that_features_increased_fortification__more_militia__and_an_extended_supply_range_
+CostGold			=	50
+
+SelectionSound1		= 	Game\select_outpost.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Council_fort_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\council_fort_destroy.tgr
+NameList			=	Outposts
+IconIndex 			= 	13
+StoneProduction			=	-3		;int
+booty_min	 = 0
+booty_max	 = 0
+
+[BaseData]
+ControlRange			=   	7		;tiles (float)
+SupplyRange			=	18		; tiles (float)
+CompanySize			=	6		; militia per company
+MaxMilitia			=	12		; total max militia
+MilitiaType			=	City_Militia	; militia type
+MilitiaType2			=	Archer_Militia		; militia type
+MilitiaGrowth			=	0.05		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+FrameRate = 180		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 7
+
+
+

--- a/TGX Files/Data/ObjectData/buildings/COUNCIL_FORTRESS.INI
+++ b/TGX Files/Data/ObjectData/buildings/COUNCIL_FORTRESS.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_4619_Council_Fort
-Class				= 	2	;enumeration list(int)
+Class				= 	1	;enumeration list(int)
 Sprite				=   buildings\council_Fort.tgr
 BoundingRadius			=	3	;tiles (float)
 ClearOut			=   	2	;tiles

--- a/TGX Files/Data/ObjectData/buildings/COUNCIL_OUTPOST.INI
+++ b/TGX Files/Data/ObjectData/buildings/COUNCIL_OUTPOST.INI
@@ -1,0 +1,49 @@
+[ObjectData]
+ProperName = STRING_2173_Council_Outpost
+Class				= 	2	;enumeration list(int)
+Sprite				=   buildings\council_Outpost.tgr
+BoundingRadius			=	3	;tiles (float)
+ClearOut			=   	2	;tiles
+MaxHitPoints			=	2000	;health rating(float)
+DetectionRadius			=	16	;tiles(float)
+Defense				=	0	;number (float)
+DieTime				=	1
+RotTime				=	60	;seconds(float)
+Captureable		=	0
+Description			=	STRING_2158_Outposts_are_used_to_extend_a_kingdom_s_supply_range_and_protect_its_borders_from_incursion_
+CostGold			=	50
+Faction			=	Council
+
+SelectionSound1	= 	Game\select_outpost.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Council_Outpost_portrait.tgr
+ConstructionAnimation 	= Art\Objects\Buildings\Animations\council_outpost_build.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\council_outpost_destroy.tgr
+NameList			=	Outposts
+IconIndex 			= 	3
+StoneProduction			=	-3		;int
+booty_min	 = 0
+booty_max	 = 0
+
+[BaseData]
+ControlRange			=   	7		;tiles (float)
+SupplyRange			=	16		; tiles (float)
+CompanySize			=	6		; militia per company
+MaxMilitia			=	6		; total max militia
+MilitiaType			=	City_Militia	; militia type
+MilitiaType2			=	Archer_Militia		; militia type
+MilitiaGrowth			=	0.05		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+FrameRate = 180		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 4
+
+
+

--- a/TGX Files/Data/ObjectData/buildings/COUNCIL_OUTPOST.INI
+++ b/TGX Files/Data/ObjectData/buildings/COUNCIL_OUTPOST.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_2173_Council_Outpost
-Class				= 	2	;enumeration list(int)
+Class				= 	1	;enumeration list(int)
 Sprite				=   buildings\council_Outpost.tgr
 BoundingRadius			=	3	;tiles (float)
 ClearOut			=   	2	;tiles

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_FORTRESS.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_FORTRESS.INI
@@ -1,0 +1,47 @@
+[ObjectData]
+ProperName = STRING_4627_Nationalist_Fort
+Class				= 	2	;enumeration list(int)
+Sprite				=   buildings\Nationalist_Fort.tgr
+BoundingRadius			=	3	;tiles (float)
+ClearOut			=   	2	;tiles
+MaxHitPoints			=	3500	;health rating(float)
+DetectionRadius			=	16	;tiles(float)
+Defense				=	0	;number (float)
+DieTime				=	1
+RotTime				=	60	;seconds(float)
+Captureable		=	0
+Description = STRING_4618_The_fort_is_an_upgraded_outpost_that_features_increased_fortification__more_militia__and_an_extended_supply_range_
+CostGold			=	50
+
+SelectionSound1		= 	Game\select_outpost.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Nationalist_fort_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\nationalist_fort_destroy.tgr
+NameList			=	Outposts
+IconIndex 			= 	13
+StoneProduction			=	-3		;int
+booty_min	 = 0
+booty_max	 = 0
+
+[BaseData]
+ControlRange			=   	8		;tiles (float)
+SupplyRange			=	18		; tiles (float)
+CompanySize			=	6		; militia per company
+MaxMilitia			=	12		; total max militia
+MilitiaType			=	City_Militia	; militia type
+MilitiaType2			=	Archer_Militia		; militia type
+MilitiaGrowth			=	0.05		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+FrameRate = 180		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 7
+
+
+

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_FORTRESS.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_FORTRESS.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_4627_Nationalist_Fort
-Class				= 	2	;enumeration list(int)
+Class				= 	1	;enumeration list(int)
 Sprite				=   buildings\Nationalist_Fort.tgr
 BoundingRadius			=	3	;tiles (float)
 ClearOut			=   	2	;tiles

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_OUTPOST.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_OUTPOST.INI
@@ -1,0 +1,49 @@
+[ObjectData]
+ProperName = STRING_2210_Nationalist_Outpost
+Class				= 	2	;enumeration list(int)
+Sprite				=   buildings\Nationalist_Outpost.tgr
+BoundingRadius			=	3	;tiles (float)
+ClearOut			=   	2	;tiles
+MaxHitPoints			=	2000	;health rating(float)
+DetectionRadius			=	16	;tiles(float)
+Defense				=	0	;number (float)
+DieTime				=	1
+RotTime				=	60	;seconds(float)
+Captureable		=	0
+Description			=	STRING_2158_Outposts_are_used_to_extend_a_kingdom_s_supply_range_and_protect_its_borders_from_incursion_
+CostGold			=	50
+Faction			=	Nationalist
+
+SelectionSound1	= 	Game\select_outpost.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Nationalist_Outpost_portrait.tgr
+ConstructionAnimation 	= Art\Objects\Buildings\Animations\nationalist_outpost_build.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\nationalist_outpost_destroy.tgr
+NameList			=	Outposts
+IconIndex 			= 	3
+StoneProduction			=	-3		;int
+booty_min	 = 0
+booty_max	 = 0
+
+[BaseData]
+ControlRange			=   	7		;tiles (float)
+SupplyRange			=	16		; tiles (float)
+CompanySize			=	6		; militia per company
+MaxMilitia			=	6		; total max militia
+MilitiaType			=	City_Militia	; militia type
+MilitiaType2			=	Archer_Militia		; militia type
+MilitiaGrowth			=	0.05		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+FrameRate = 180		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 4
+
+
+

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_OUTPOST.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_OUTPOST.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_2210_Nationalist_Outpost
-Class				= 	2	;enumeration list(int)
+Class				= 	1	;enumeration list(int)
 Sprite				=   buildings\Nationalist_Outpost.tgr
 BoundingRadius			=	3	;tiles (float)
 ClearOut			=   	2	;tiles

--- a/TGX Files/Data/ObjectData/buildings/ROYALIST_FORTRESS.INI
+++ b/TGX Files/Data/ObjectData/buildings/ROYALIST_FORTRESS.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_4629_Royalist_Fort
-Class				= 	2	;enumeration list(int)
+Class				= 	1	;enumeration list(int)
 Sprite				=   buildings\Royalist_Fort.tgr
 BoundingRadius			=	3	;tiles (float)
 ClearOut			=   	2	;tiles

--- a/TGX Files/Data/ObjectData/buildings/ROYALIST_OUTPOST.INI
+++ b/TGX Files/Data/ObjectData/buildings/ROYALIST_OUTPOST.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_2221_Royalist_Outpost
-Class				= 	2	;enumeration list(int)
+Class				= 	1	;enumeration list(int)
 Sprite				=   buildings\Royalist_Outpost.tgr
 BoundingRadius			=	3	;tiles (float)
 ClearOut			=   	2	;tiles

--- a/TGX Files/Data/Technology.ini
+++ b/TGX Files/Data/Technology.ini
@@ -351,13 +351,13 @@ DAMAGE_TAKEN_FROM_HOLY		= .5
 
 [Silk Armor]
 ProperName		= STRING_1573_Silk_Armor
-Description		= STRING_1574_Specially_crafted_silk_tunics_that_are_worn_under_normal_armor_protect_the_wearer_from_arrows_and_similar_missiles_
+Description		= Specially crafted spider-silk tunics that are light as air and can be worn under robes that can avert a stray arrow or similar missile with ease.
 BonusSection	= SilkArmorBonuses
 UnitGroup		= 12
 Sprite			= Art\Interface\Panels\Defense_Bonus.tgr
 
 [SilkArmorBonuses]
-DEFENSE_BONUS_VS_ARCHER		= 4
+DEFENSE_BONUS_VS_ARCHER		= 8
 
 [Dragon Dust]
 ProperName		= STRING_0060_Dragon_Dust

--- a/TGX Files/Data/Technology.ini
+++ b/TGX Files/Data/Technology.ini
@@ -152,7 +152,7 @@ UnitGroup		= 10
 Sprite			= Art\Interface\Panels\Defense_Bonus.tgr
 
 [EnchantedLeatherBonuses]
-DEFENSE_BONUS_VS_ANY		= 2
+DEFENSE_BONUS_VS_ANY		= 1
 
 [Crystal Ring]
 ProperName		= STRING_0055_Crystal_Ring
@@ -192,7 +192,7 @@ UnitGroup		= -1
 Sprite			= Art\Interface\Panels\Company_Bonus.tgr
 
 [HealingPotionsBonuses]
-RESUPPLY_RATE_BONUS		= 1.25
+RESUPPLY_RATE_BONUS		= 1.1
 
 [Potion of Strength]
 ProperName		= STRING_1548_Potion_of_Strength
@@ -315,7 +315,7 @@ UnitGroup		= 8
 Sprite			= Art\Interface\Panels\Melee_Bonus.tgr
 
 [HolyBladesBonuses]
-MELEE_HOLY_DAMAGE		= 4
+MELEE_HOLY_DAMAGE		= 2
 
 [Unholy Blades]
 ProperName		= STRING_1567_Unholy_Blades
@@ -353,7 +353,7 @@ DAMAGE_TAKEN_FROM_HOLY		= .5
 ProperName		= STRING_1573_Silk_Armor
 Description		= STRING_1574_Specially_crafted_silk_tunics_that_are_worn_under_normal_armor_protect_the_wearer_from_arrows_and_similar_missiles_
 BonusSection	= SilkArmorBonuses
-UnitGroup		= -1
+UnitGroup		= 12
 Sprite			= Art\Interface\Panels\Defense_Bonus.tgr
 
 [SilkArmorBonuses]
@@ -420,7 +420,7 @@ UnitGroup		= 6
 Sprite			= Art\Interface\Panels\Ranged_Bonus.tgr
 
 [IronBowBonuses]
-ATTACK_BONUS_TO_ANY		= 4
+ATTACK_BONUS_TO_ANY		= 2
 
 [Blessing of Shadow]
 ProperName		= STRING_0075_Blessing_of_Shadow
@@ -439,8 +439,8 @@ BonusSection	= MilitaryCollegeBonuses
 Sprite			= Art\Interface\Panels\Settlement_Bonus.tgr
 
 [MilitaryCollegeBonuses]
-UPGRADE_BONUS_COST_GROUP_1	= .8
-UPGRADE_BONUS_COST_GROUP_2	= .8
+UPGRADE_BONUS_COST_GROUP_1	= .85
+UPGRADE_BONUS_COST_GROUP_2	= .85
 
 [Academy of Magicks]
 ProperName		= STRING_1587_Academy_of_Magicks
@@ -480,8 +480,8 @@ BonusSection	= MilitiaTrainingBonuses
 Sprite			= Art\Interface\Panels\Settlement_Bonus.tgr
 
 [MilitiaTrainingBonuses]
-UPGRADE_BONUS_MILITIA_AV	= 4
-UPGRADE_BONUS_MILITIA_DV	= 2
+UPGRADE_BONUS_MILITIA_AV	= 2
+UPGRADE_BONUS_MILITIA_DV	= 1
 
 [Golems]
 ProperName		= STRING_1594_Golem_Warriors

--- a/TGX Files/Data/Technology_KE.ini
+++ b/TGX Files/Data/Technology_KE.ini
@@ -131,7 +131,7 @@ ATTACK_BONUS_TO_MOUNTED		= 2
 
 [Defensive Tactics]
 ProperName		= STRING_4561_Defensive_Tactics
-Description		= STRING_4562_Defensive_tactics_are_tactical_plans_developed_to_increase_the_defensive_positioning_of_troops_during_battle__This_increases_the_defense_of_all_units_
+Description		= Defensive tactics are tactical plans developed to increase the defensive positioning of troops during battle. This increases the defense of most trained foot soldiers.
 BonusSection	= DefTacticsBonuses
 UnitGroup		= 8
 Sprite			= Art\Interface\Panels\Defense_Bonus.tgr
@@ -142,7 +142,7 @@ DEFENSE_BONUS_VS_ANY		= 2
 
 [Combat Tactics]
 ProperName		= STRING_4563_Combat_Tactics
-Description		= STRING_4564_Combat_tactics_are_tactical_plans_developed_to_maximize_combat_maneuvers_and_effectiveness__This_increases_the_combat_values_of_all_units_
+Description		= Combat tactics are tactical plans developed to maximize combat maneuvers and effectiveness. This increases the combat values of most trained foot soldiers.
 BonusSection	= ComTacticsBonuses
 UnitGroup		= 8
 Sprite			= Art\Interface\Panels\Melee_Bonus.tgr

--- a/TGX Files/Data/Technology_KE.ini
+++ b/TGX Files/Data/Technology_KE.ini
@@ -121,7 +121,7 @@ IMMUNITY_TO_ENCHANTMENT		= 1
 ProperName		= STRING_4559_Cavalry_Tactics
 Description		= STRING_4560_Cavalry_tactics_are_tactical_plans_developed_to_increase_the_ability_of_all_troops_to_combat_cavalry_
 BonusSection	= CavTacticsBonuses
-UnitGroup		= -1
+UnitGroup		= 17
 Sprite			= Art\Interface\Panels\Melee_Bonus.tgr
 
 [CavTacticsBonuses]
@@ -133,7 +133,7 @@ ATTACK_BONUS_TO_MOUNTED		= 2
 ProperName		= STRING_4561_Defensive_Tactics
 Description		= STRING_4562_Defensive_tactics_are_tactical_plans_developed_to_increase_the_defensive_positioning_of_troops_during_battle__This_increases_the_defense_of_all_units_
 BonusSection	= DefTacticsBonuses
-UnitGroup		= -1
+UnitGroup		= 8
 Sprite			= Art\Interface\Panels\Defense_Bonus.tgr
 
 [DefTacticsBonuses]
@@ -144,7 +144,7 @@ DEFENSE_BONUS_VS_ANY		= 2
 ProperName		= STRING_4563_Combat_Tactics
 Description		= STRING_4564_Combat_tactics_are_tactical_plans_developed_to_maximize_combat_maneuvers_and_effectiveness__This_increases_the_combat_values_of_all_units_
 BonusSection	= ComTacticsBonuses
-UnitGroup		= -1
+UnitGroup		= 8
 Sprite			= Art\Interface\Panels\Melee_Bonus.tgr
 
 [ComTacticsBonuses]
@@ -193,7 +193,7 @@ UnitGroup		= 7
 Sprite			= Art\Interface\Panels\Melee_Bonus.tgr
 
 [SlaanriBonuses]
-ATTACK_BONUS_TO_ANY	= 3
+ATTACK_BONUS_TO_ANY	= 2
 
 
 [Khaldunite Rings]
@@ -237,7 +237,7 @@ UnitGroup		= -1
 Sprite			= Art\Interface\Panels\Company_Bonus.tgr
 
 [SpyBonuses]
-VISUAL_RANGE_BONUS	= 1.15
+VISUAL_RANGE_BONUS	= 1.2
 
 
 [Oracle]
@@ -266,6 +266,7 @@ Description		= STRING_4588_The_bones_of_dragons_are_the_perfect_resource_for_cre
 BonusSection	= DragonBowBonuses
 UnitGroup		= 6
 Sprite			= Art\Interface\Panels\Ranged_Bonus.tgr
+Boss            =   1
 
 [DragonBowBonuses]
 DAMAGE_BONUS_TO_ANY		= 1.2

--- a/TGX Files/Data/Technology_KE.ini
+++ b/TGX Files/Data/Technology_KE.ini
@@ -119,7 +119,7 @@ IMMUNITY_TO_ENCHANTMENT		= 1
 
 [Cavalry Tactics]
 ProperName		= STRING_4559_Cavalry_Tactics
-Description		= STRING_4560_Cavalry_tactics_are_tactical_plans_developed_to_increase_the_ability_of_all_troops_to_combat_cavalry_
+Description		= Cavalry tactics are expert techniques developed to increase the ability of all mounted troops to combat enemy cavalry.
 BonusSection	= CavTacticsBonuses
 UnitGroup		= 17
 Sprite			= Art\Interface\Panels\Melee_Bonus.tgr


### PR DESCRIPTION
### _Changelog:_

### Buildings:

Outposts and Forts class changed from 2 to 1.
This will allow them to benefit from technologies in the same way that settlements do.

> Honestly I have no idea what this will do in the long run, we will need to keep a very careful eye on this and monitor for any strange behaviour or crashes relating to outposts/forts.

### Technologies:

Decreased DV Bonus of Enchanted leather from 2 to 1

**Crystal Ring removed from skirmish/MP (For now)**

Decreased Healing Potion's recovery from 120% to 110%

Decreased Holy Blade's bonus holy damage from 4 to 2

Silk Armor now applies to the caster group
Increased bonus AV against archers from 4 to 8

Decreased Ironwood Bow's AV from 4 to 2

Decreased Military College's discount from 20% to 15%

Decreased Militia Training bonuses by half
From 4 AV to 2 AV
From 2 DV to 1 DV

Cavalry Tactics now only applies to mounted units

Combat and Defensive tactics now only apply to sword & axe elements (group 8, see the Trello for more info)

Increased Spyglasses recon bonus from 115% to 120%

**Dragonbone Bows removed from skirmish/MP**