### PR TITLE
Ruin Adjustments

### DIFF
--- a/TGX Files/Data/ObjectData/buildings/ABANDONED_RUINS.INI
+++ b/TGX Files/Data/ObjectData/buildings/ABANDONED_RUINS.INI
@@ -1,0 +1,31 @@
+[ObjectData]
+ProperName = STRING_2152_Abandoned_Ruins
+Class			= 	0	;enumeration list(int)
+Sprite			=   buildings\Ruined_City.tgr
+BoundingRadius		=	2.5	;tiles (float)
+ClearOut		=   4	;tiles
+MaxHitPoints		=	1500	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2153_The_dust_covered__crumbled_remains_of_ancient_buildings_are_all_that_are_left_of_a_once_glorious_city_
+Weight			=	10
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Ruined_City_portrait.tgr
+booty_min	 = 25
+booty_max	 = 125
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+
+
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 0

--- a/TGX Files/Data/ObjectData/buildings/ABANDONED_RUINS.INI
+++ b/TGX Files/Data/ObjectData/buildings/ABANDONED_RUINS.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\Ruined_City_portrait.tgr
-booty_min	 = 25
-booty_max	 = 125
+booty_min	 = 40
+booty_max	 = 65
 
 [BaseData]
 ControlRange		=	8

--- a/TGX Files/Data/ObjectData/buildings/ANCIENT_RUIN.INI
+++ b/TGX Files/Data/ObjectData/buildings/ANCIENT_RUIN.INI
@@ -1,0 +1,37 @@
+[ObjectData]
+ProperName = STRING_2155_Ancient_Ruin
+Class			= 	0	;enumeration list(int)
+Sprite			=   buildings\ancient_ruin.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	750	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2156_The_crumbled_remains_of_ancient_buildings_are_all_that_are_left_of_a_once_glorious_city_
+Weight			=	15	;; drp012701 - changed 20 to 15
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Ancient_Ruin_portrait.tgr
+booty_min	 = 25
+booty_max	 = 125
+
+;[NotUsed]
+;ObjectDisplay		=	1	;enumeration in button.h	
+;ActionScroll    	=   	1	;enumeration in button.h
+;BuildSound			= 	audio\Game\construction.wav
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+Type = 0
+FrameRate = 230		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 8
+AlwaysDraw = 1

--- a/TGX Files/Data/ObjectData/buildings/ANCIENT_RUIN.INI
+++ b/TGX Files/Data/ObjectData/buildings/ANCIENT_RUIN.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\Ancient_Ruin_portrait.tgr
-booty_min	 = 25
-booty_max	 = 125
+booty_min	 = 40
+booty_max	 = 65
 
 ;[NotUsed]
 ;ObjectDisplay		=	1	;enumeration in button.h	

--- a/TGX Files/Data/ObjectData/buildings/CRYSTAL_RUIN.INI
+++ b/TGX Files/Data/ObjectData/buildings/CRYSTAL_RUIN.INI
@@ -1,0 +1,34 @@
+[ObjectData]
+ProperName = STRING_4620_Crystal_Castle
+Class			= 	0	;enumeration list(int)
+Sprite			=   buildings\crystal_ruin.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	750	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description = STRING_4621_A_magnificent_castle_composed_of_giant_ice_crystals_rises_from_the_ground__reflecting_and_refracting_light_from_every_angle_
+Weight			=	5	;; drp012701 - changed 20 to 15
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\crystal_castle_portrait.tgr
+booty_min	 = 50
+booty_max	 = 150
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+
+[Animation0]
+Type = 0
+FrameRate = 150		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 6
+AlwaysDraw = 0
+

--- a/TGX Files/Data/ObjectData/buildings/CRYSTAL_RUIN.INI
+++ b/TGX Files/Data/ObjectData/buildings/CRYSTAL_RUIN.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\crystal_castle_portrait.tgr
-booty_min	 = 50
-booty_max	 = 150
+booty_min	 = 40
+booty_max	 = 65
 
 ;Animations are drawn in order of declaration in INI file (1,2,3,...)
 [AnimationData]

--- a/TGX Files/Data/ObjectData/buildings/LOST_TEMPLE.INI
+++ b/TGX Files/Data/ObjectData/buildings/LOST_TEMPLE.INI
@@ -1,0 +1,25 @@
+[ObjectData]
+ProperName = STRING_2198_Lost_Temple
+Class			= 	0	;enumeration list(int)
+Sprite			=   buildings\temple_ruin.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	1500	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2199_The_broken_remnants_of_an_ancient_Kohan_populace_can_be_seen_jutting_from_the_ground_
+Weight			= 	15
+
+DeathSound1		=	Game\building_destroyed.wav
+SelectionSound1		= 	Game\select_ruins.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Desert_City2_portrait.tgr
+booty_min	 = 25
+booty_max	 = 125
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 0

--- a/TGX Files/Data/ObjectData/buildings/LOST_TEMPLE.INI
+++ b/TGX Files/Data/ObjectData/buildings/LOST_TEMPLE.INI
@@ -17,8 +17,8 @@ SelectionSound1		= 	Game\select_ruins.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\Desert_City2_portrait.tgr
-booty_min	 = 25
-booty_max	 = 125
+booty_min	 = 40
+booty_max	 = 65
 
 ;Animations are drawn in order of declaration in INI file (1,2,3,...)
 [AnimationData]

--- a/TGX Files/Data/ObjectData/buildings/MEGALITH.INI
+++ b/TGX Files/Data/ObjectData/buildings/MEGALITH.INI
@@ -26,7 +26,7 @@ SupplyRange		=	0		;tiles (float)
 CompanySize		=	4		; militia per company
 MilitiaStart		=	4
 MaxMilitia		=	4		; total max militia
-MilitiaType		=	Shadeling	; militia type
+MilitiaType		=	dark_wolf	; militia type
 MilitiaGrowth		=	0		; points per second
 
 ;[NotUsed]

--- a/TGX Files/Data/ObjectData/buildings/MEGALITH.INI
+++ b/TGX Files/Data/ObjectData/buildings/MEGALITH.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_2202_Megalith
-Class			= 	0	;enumeration list(int)
+Class			= 	3	;enumeration list(int)
 Sprite			=   buildings\Megalith.tgr
 BoundingRadius		=	3	;tiles (float)
 ClearOut		=   	2	;tiles

--- a/TGX Files/Data/ObjectData/buildings/MEGALITH.INI
+++ b/TGX Files/Data/ObjectData/buildings/MEGALITH.INI
@@ -1,0 +1,39 @@
+[ObjectData]
+ProperName = STRING_2202_Megalith
+Class			= 	0	;enumeration list(int)
+Sprite			=   buildings\Megalith.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	250	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2203_Strange_stones_left_behind_where_monuments__cities__and_other_ancient_structures_once_stood_
+Weight			=	10	;; drp012701 - changed 20 to 10
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Megalith_portrait.tgr
+booty_min	 = 10
+booty_max	 = 50
+
+[BaseData]
+ControlRange		=	6
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	4		; militia per company
+MilitiaStart		=	4
+MaxMilitia		=	4		; total max militia
+MilitiaType		=	Shadeling	; militia type
+MilitiaGrowth		=	0		; points per second
+
+;[NotUsed]
+;ObjectDisplay		=	1	;enumeration in button.h	
+;ActionScroll    	=   	1	;enumeration in button.h
+;BuildSound			= 	audio\Game\construction.wav
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 0

--- a/TGX Files/Data/ObjectData/buildings/MONOLITH.INI
+++ b/TGX Files/Data/ObjectData/buildings/MONOLITH.INI
@@ -1,0 +1,39 @@
+[ObjectData]
+ProperName = STRING_0180_Monolith
+Class			= 	0	;enumeration list(int)
+Sprite			=   buildings\Megalith.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	250	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	3	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2204_All_that_is_left_of_the_ancient_structure_is_a_large_standing_stone_inscribed_in_wind_worn_runes_
+Weight			=	10	;; drp012701 - changed 20 to 10
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Megalith_portrait.tgr
+booty_min	 = 10
+booty_max	 = 50
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	5		; militia per company
+MilitiaStart		=	5
+MaxMilitia		=	5		; total max militia
+MilitiaType		=	dark_wolf	; militia type
+MilitiaGrowth		=	0		; points per second
+
+;[NotUsed]
+;ObjectDisplay		=	1	;enumeration in button.h	
+;ActionScroll    	=   	1	;enumeration in button.h
+;BuildSound			= 	audio\Game\construction.wav
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 0

--- a/TGX Files/Data/ObjectData/buildings/MONOLITH.INI
+++ b/TGX Files/Data/ObjectData/buildings/MONOLITH.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_0180_Monolith
-Class			= 	3	;enumeration list(int)
+Class			= 	0	;enumeration list(int)
 Sprite			=   buildings\Megalith.tgr
 BoundingRadius		=	3	;tiles (float)
 ClearOut		=   	2	;tiles
@@ -19,15 +19,6 @@ DeathSound1		=	Game\building_destroyed.wav
 Icon			=	Portraits\Buildings\Megalith_portrait.tgr
 booty_min	 = 10
 booty_max	 = 50
-
-[BaseData]
-ControlRange		=	8
-SupplyRange		=	0		;tiles (float)	
-CompanySize		=	5		; militia per company
-MilitiaStart		=	5
-MaxMilitia		=	5		; total max militia
-MilitiaType		=	dark_wolf	; militia type
-MilitiaGrowth		=	0		; points per second
 
 ;[NotUsed]
 ;ObjectDisplay		=	1	;enumeration in button.h	

--- a/TGX Files/Data/ObjectData/buildings/MONOLITH.INI
+++ b/TGX Files/Data/ObjectData/buildings/MONOLITH.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\Megalith_portrait.tgr
-booty_min	 = 10
-booty_max	 = 50
+booty_min	 = 40
+booty_max	 = 65
 
 ;[NotUsed]
 ;ObjectDisplay		=	1	;enumeration in button.h	

--- a/TGX Files/Data/ObjectData/buildings/MONOLITH.INI
+++ b/TGX Files/Data/ObjectData/buildings/MONOLITH.INI
@@ -1,6 +1,6 @@
 [ObjectData]
 ProperName = STRING_0180_Monolith
-Class			= 	0	;enumeration list(int)
+Class			= 	3	;enumeration list(int)
 Sprite			=   buildings\Megalith.tgr
 BoundingRadius		=	3	;tiles (float)
 ClearOut		=   	2	;tiles

--- a/TGX Files/Data/ObjectData/buildings/RUINED_CITY.INI
+++ b/TGX Files/Data/ObjectData/buildings/RUINED_CITY.INI
@@ -1,0 +1,35 @@
+[ObjectData]
+ProperName = STRING_2224_Ruined_City
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\Ruined_City.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	1500	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2225_Once_a_great_temple_or_palace__now_this_remnant_of_the_greater_glory_of_the_Kohan_lies_decrepit_and_forgotten_
+Weight			=	12
+
+SelectionSound1		= 	Game\select_settlement.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Ruined_City_portrait.tgr
+booty_min	 = 50
+booty_max	 = 150
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	5		; militia per company
+MilitiaStart		=	5
+MaxMilitia		=	5		; total max militia
+MilitiaType		=	Slaan		; militia type
+MilitiaGrowth		=	0		; points per second
+
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 0

--- a/TGX Files/Data/ObjectData/buildings/RUINED_CITY.INI
+++ b/TGX Files/Data/ObjectData/buildings/RUINED_CITY.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\Ruined_City_portrait.tgr
-booty_min	 = 50
-booty_max	 = 150
+booty_min	 = 40
+booty_max	 = 65
 
 [BaseData]
 ControlRange		=	8

--- a/TGX Files/Data/ObjectData/buildings/SNOW_PYRAMID.INI
+++ b/TGX Files/Data/ObjectData/buildings/SNOW_PYRAMID.INI
@@ -1,0 +1,29 @@
+[ObjectData]
+ProperName = STRING_4634_Buried_Temple
+Class			= 	0	;enumeration list(int)
+Sprite			=   buildings\Snow_pyramid.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	750	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	7
+Description = STRING_4635_The_icy_remnants_of_a_great_temple_rises_from_the_snow_like_an_immense_gravestone_
+Weight			=	0	;; drp012701 - changed 20 to 15
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\snow_pyramid_portrait.tgr
+booty_min	 = 25
+booty_max	 = 125
+AGClimatesOnly = 1
+
+;[NotUsed]
+;ObjectDisplay		=	1	;enumeration in button.h	
+;ActionScroll    	=   	1	;enumeration in button.h
+;BuildSound			= 	audio\Game\construction.wav
+
+

--- a/TGX Files/Data/ObjectData/buildings/SNOW_PYRAMID.INI
+++ b/TGX Files/Data/ObjectData/buildings/SNOW_PYRAMID.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\snow_pyramid_portrait.tgr
-booty_min	 = 25
-booty_max	 = 125
+booty_min	 = 40
+booty_max	 = 65
 AGClimatesOnly = 1
 
 ;[NotUsed]

--- a/TGX Files/Data/ObjectData/buildings/SNOW_RUIN.INI
+++ b/TGX Files/Data/ObjectData/buildings/SNOW_RUIN.INI
@@ -1,0 +1,29 @@
+[ObjectData]
+ProperName = STRING_4637_Snow_Covered_Ruins
+Class			= 	0	;enumeration list(int)
+Sprite			=   buildings\snow_ruin.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	750	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description = STRING_4638_The_ruins_of_this_once_great_city_lie_dark_and_foreboding_against_its_stark_white_surroundings_
+Weight			=	7	;; drp012701 - changed 20 to 15
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\snow_ruin_portrait.tgr
+booty_min	 = 25
+booty_max	 = 125
+AGClimatesOnly = 1
+
+;[NotUsed]
+;ObjectDisplay		=	1	;enumeration in button.h	
+;ActionScroll    	=   	1	;enumeration in button.h
+;BuildSound			= 	audio\Game\construction.wav
+
+

--- a/TGX Files/Data/ObjectData/buildings/SNOW_RUIN.INI
+++ b/TGX Files/Data/ObjectData/buildings/SNOW_RUIN.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\snow_ruin_portrait.tgr
-booty_min	 = 25
-booty_max	 = 125
+booty_min	 = 40
+booty_max	 = 65
 AGClimatesOnly = 1
 
 ;[NotUsed]


### PR DESCRIPTION
_Definition: Ruins are neutral buildings that give a reward when a company's zone of control comes into contact with them. They have no militia, and once the reward is given, they are inert and have no function._

### _Changelog:_

Monolith explicitly changed to explorable ruin (no militia data anymore)

Megalith changed to lair (dark wolves militia)

Ruins that have had their bounties set to 40g minimum 65g maximum (40-65)

1. Abandoned Ruins
2. Ancient Ruin
3. Crystal Ruin
4. Lost Temple
5. Monolith
6. Ruined City
7. Snow Pyramid
8. Snow Ruin