### PR TITLE
Ahriman citadel

### DIFF
--- a/TGX Files/Data/ModInfo.ini
+++ b/TGX Files/Data/ModInfo.ini
@@ -1,6 +1,6 @@
 [ModInfo]
 TwoCharacterIdentifier=KG
-Version=0.5.2
+Version=0.7.0
 Author=KohanCitadel
 Author_www=https://discord.gg/U4K4vPS
 Author_email=

--- a/TGX Files/Data/ObjectData/buildings/AHRIMAN_CITADEL.INI
+++ b/TGX Files/Data/ObjectData/buildings/AHRIMAN_CITADEL.INI
@@ -1,0 +1,59 @@
+[ObjectData]
+ProperName = STRING_2154_Ahriman_s_Citadel
+Class			= 	1	;enumeration list(int)
+Sprite			=   buildings\Ahriman_Citadel.tgr
+BoundingRadius		=	6	;tiles (float)
+ClearOut		=   	4	;tiles
+MaxHitPoints		=	50000	;health rating(float)
+DetectionRadius		=	30	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	9999	;seconds(float)
+Captureable		=	0
+
+Description		= 	STRING_2154_Ahriman_s_Citadel
+Faction			=	Ceyah
+Weight			=	0
+
+SelectionSound1	= 	Game\select_mana_mine.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\ahriman_citadel_portrait.tgr
+DestructionAnimation = Art\Objects\Buildings\Animations\Ceyah_citadel_destroy.tgr
+;NameList		=	CeyahCities
+GoldProduction		=	100		;int
+IronProduction		=	50		;int
+WoodProduction		=	50		;int
+StoneProduction		=	50		;int
+ManaProduction		=	25		;int
+booty_min	 = 0
+booty_max	 = 0
+
+[BaseData]
+ControlRange		=   	9			;tiles (float)
+SupplyRange		=	24			; tiles (float)
+CompanySize		=	6			; militia per company
+MaxMilitia		=	18			; total max militia
+MilitiaType		=	Shadow_Militia		; militia type
+MilitiaGrowth		=	0.025			; points per second
+CompanyLimit		=	20			; companies allowed per settlement
+
+[SettlementData]
+ComponentLimit		=	7
+GoldLimitModifier		= 5000
+
+;[NotUsed]
+;ObjectDisplay		=	1	;enumeration in button.h	
+;ActionScroll   	=  	1	;enumeration in button.h
+;BuildSound		= 	audio\Game\construction.wav
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 0			;should the animation cycle be randomly started
+Frames = 12
+BaseFrame = 0

--- a/TGX Files/Data/ObjectData/buildings/AHRIMAN_CITADEL.INI
+++ b/TGX Files/Data/ObjectData/buildings/AHRIMAN_CITADEL.INI
@@ -4,13 +4,13 @@ Class			= 	1	;enumeration list(int)
 Sprite			=   buildings\Ahriman_Citadel.tgr
 BoundingRadius		=	6	;tiles (float)
 ClearOut		=   	4	;tiles
-MaxHitPoints		=	50000	;health rating(float)
+MaxHitPoints		=	20000	;health rating(float)
 DetectionRadius		=	30	;tiles(float)
 Defense			=	0	;number (float)
 RotTime			=	9999	;seconds(float)
 Captureable		=	0
 
-Description		= 	STRING_2154_Ahriman_s_Citadel
+Description     = STRING_4628_Ahriman_s_newly_risen_citadel_floats_menacingly_above_the_corrupt_earth__The_focal_point_of_his_power_is_hidden_deep_within_its_shadowy_halls_
 Faction			=	Ceyah
 Weight			=	0
 
@@ -21,11 +21,12 @@ DeathSound1		=	Game\building_destroyed.wav
 Icon			=	Portraits\Buildings\ahriman_citadel_portrait.tgr
 DestructionAnimation = Art\Objects\Buildings\Animations\Ceyah_citadel_destroy.tgr
 ;NameList		=	CeyahCities
-GoldProduction		=	100		;int
-IronProduction		=	50		;int
-WoodProduction		=	50		;int
-StoneProduction		=	50		;int
-ManaProduction		=	25		;int
+IconIndex 		= 	8
+GoldProduction		=	25		;int
+IronProduction		=	0		;int
+WoodProduction		=	0		;int
+StoneProduction		=	0		;int
+ManaProduction		=	12		;int
 booty_min	 = 0
 booty_max	 = 0
 
@@ -36,11 +37,11 @@ CompanySize		=	6			; militia per company
 MaxMilitia		=	18			; total max militia
 MilitiaType		=	Shadow_Militia		; militia type
 MilitiaGrowth		=	0.025			; points per second
-CompanyLimit		=	20			; companies allowed per settlement
+CompanyLimit		=	10			; companies allowed per settlement
 
 [SettlementData]
 ComponentLimit		=	7
-GoldLimitModifier		= 5000
+GoldLimitModifier		= 1200
 
 ;[NotUsed]
 ;ObjectDisplay		=	1	;enumeration in button.h	


### PR DESCRIPTION
### _Changelog:_

Included the data file for Ahriman's Citadel and replaced it with the stats from New_Ahrimans_Citadel from the expansion campaign. This frees up the new citadel to be used for other things, since all instances of the citadel in campaigns will be the original. 