### PR TITLE
Hasanko rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
+++ b/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
@@ -4,13 +4,14 @@ Class			= 	2			;enumeration list(int)
 Sprite			=	units\dragoon.tgr
 BoundingRadius		=	0.35		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	480			;health rating(float)
+MaxHitPoints		=	550			;health rating(float)
 CostGold		=	0			;int
 UpkeepGold		=	0			;int
 UpkeepMana		=	0			;int
 BuildTime		=	0			;seconds(float)
-Defense			=	10			;number (float)
+Defense			=	12			;number (float)
 DieTime			=	1			;seconds(float)
+OverwriteColor					=	10
 Faction			=	Ceyah
 
 Moveable		=	1			;BOOLEAN
@@ -27,12 +28,6 @@ CommandSound1		=	Game\agm_hero5_evil_command1.wav
 CommandSound2		=	Game\agm_hero5_evil_command2.wav
 CommandSound3		=	Game\agm_hero5_evil_command3.wav
 
-[SpellData]
-MaxMana 		=	60 	;the max amount that mana can be for the unit
-ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
-Spell0			=	Mystic Armor
-Spell1			=	Shadow's Blessing
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Dragoon_icon.tgr
@@ -45,16 +40,21 @@ MeleeFX			= necromancer_hitfx
 CombatValue		= 15
 Description		= Hasanko is a dangerous and power-hungry Ceyah who sees himself rising above the even the first Ceyah Lords. Despite being dedicated to Ahriman, he constantly plots against his brethren. He always appears in the field of combat as a monstrous spectral knight, although it is unknown how he does this, whether through illusion or other means.
 
+[SpellData]
+MaxMana 		=	50 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	2	;the amount of mana that gets regenerated sec.
+Spell0			=	Spectral Form
+
 [Attack1]
-AttackTime		=	1			; seconds(float) per animation cycle
-DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
-ReloadTime		=	0			; seconds (float)
-AttackRange		=	1			; tiles (float)
-AttackType		=	MELEE		; enumeration list (int)
-Damage			=	18		;number (float)
-DamageType		=	MAGIC
-Sound1			=	Game\axe2.wav
-Animation		=	0	
+AttackTime			=	1
+DamagePoint			=	0.5
+ReloadTime			=	1.3		; 65% AS
+AttackRange			=	1
+AttackType			=	MELEE
+Damage			=	52
+DamageType			=	NORMAL
+MoraleDamage			=	0.2
+Sound1		=   Game\axe2.wav
 
 [Attack2]
 AttackTime		=	1			; seconds(float) per animation cycle
@@ -64,9 +64,11 @@ AttackType		=	CAST		; enumeration list (int)
 Animation		=	0
 
 [ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	=	0.75
 
 [SupportBonus]
-DAMAGE_TAKEN_FROM_KHALDUNITE	= .9
+ATTACK_BONUS_TO_NONSHADOW		=	2
+DAMAGE_TAKEN_FROM_KHALDUNITE	=	.9
 
 ;==========Enlightened==========
 

--- a/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
+++ b/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
@@ -1,8 +1,8 @@
 [ObjectData]
 ProperName = Hasanko
 Class			= 	2			;enumeration list(int)
-Sprite			=   units\wraith.tgr
-BoundingRadius		=	0.25		;tiles(float)
+Sprite			=	units\dragoon.tgr
+BoundingRadius		=	0.35		;tiles(float)
 RotTime			=	30			;seconds(float)
 MaxHitPoints		=	480			;health rating(float)
 CostGold		=	0			;int
@@ -19,7 +19,7 @@ Blocking		=	1			;BOOLEAN
 Land			=	1			;BOOLEAN
 Water			=	0			;BOOLEAN
 
-DeathSound1		=	Game\wraith_death.wav
+DeathSound1		=	Game\paladin_death.wav
 SelectionSound1		=	Game\agm_hero5_evil_select1.wav
 SelectionSound2		=	Game\agm_hero5_evil_select2.wav
 SelectionSound3		=	Game\agm_hero5_evil_select3.wav
@@ -27,34 +27,23 @@ CommandSound1		=	Game\agm_hero5_evil_command1.wav
 CommandSound2		=	Game\agm_hero5_evil_command2.wav
 CommandSound3		=	Game\agm_hero5_evil_command3.wav
 
-[UnitData]
-Type			=	HERO
-Icon			=   Portraits\Unit Icons\Wraith_icon.tgr
-Portrait		=	Portraits\Heroes\Hasanko_portrait.tgr
-IdleTime		=	2		;seconds(float)
-MovementRate		=	34		;movement points(float)
-WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
-ResupplyRate		=	10		; health / second (float)
-MeleeFX			= wraith_hitfx
-CombatValue		= 15
-Description = STRING_4696_Hasanko_is_a_dangerous_and_power_hungry_Ceyah_who_sees_himself_rising_above_the_even_the_first_Ceyah_Lords__Despite_being_dedicated_to_Ahriman__he_constantly_plots_against_his_brethren__He_always_appears_in_the_field_of_combat_as_a_monstrous_wraith__although_it_is_unknown_how_he_does_this__whether_through_illusion_or_other_means_
-
 [SpellData]
 MaxMana 		=	60 	;the max amount that mana can be for the unit
 ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Mystic Armor
 Spell1			=	Shadow's Blessing
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_4697_Hasanko
-
-[ElementBonus]
-
-[SupportBonus]
-DAMAGE_TAKEN_FROM_KHALDUNITE	= .9
-
-[CompanyData]
+[UnitData]
+Type			=	HERO
+Icon			=   Portraits\Unit Icons\Dragoon_icon.tgr
+Portrait		=	Portraits\Heroes\Hasanko_portrait.tgr
+IdleTime		=	2		;seconds(float)
+MovementRate		=	34		;movement points(float)
+WalkDistance		=   	0.77		;tiles (float) how far does unit move in one animation cycle
+ResupplyRate		=	10		; health / second (float)
+MeleeFX			= necromancer_hitfx
+CombatValue		= 15
+Description		= Hasanko is a dangerous and power-hungry Ceyah who sees himself rising above the even the first Ceyah Lords. Despite being dedicated to Ahriman, he constantly plots against his brethren. He always appears in the field of combat as a monstrous spectral knight, although it is unknown how he does this, whether through illusion or other means.
 
 [Attack1]
 AttackTime		=	1			; seconds(float) per animation cycle
@@ -64,7 +53,7 @@ AttackRange		=	1			; tiles (float)
 AttackType		=	MELEE		; enumeration list (int)
 Damage			=	18		;number (float)
 DamageType		=	MAGIC
-Sound1			= 	spells\wizard_attack.wav
+Sound1			=	Game\axe2.wav
 Animation		=	0	
 
 [Attack2]
@@ -72,49 +61,67 @@ AttackTime		=	1			; seconds(float) per animation cycle
 DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
 ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
-Animation		=	1
+Animation		=	0
+
+[ElementBonus]
+
+[SupportBonus]
+DAMAGE_TAKEN_FROM_KHALDUNITE	= .9
+
+;==========Enlightened==========
 
 [Level1]
 MaxHitPoints		=	600
 
-[Level2]
-MaxHitPoints		=	720
-Defense			=	12
-
-[Level3]
-MaxHitPoints		=	840
-Defense			=	14
-
-[Attack0Data1]
-Damage			=	22
-
-[Attack0Data2]
-Damage			=	26
-
-[Attack0Data3]
-Damage			=	30
-
 [SpellData1]
 ManaRegenerationRate 	=	4
 
-[SpellData2]
-Spell1			=	Spectral Form
-
-[SpellData3]
-MaxMana 		=	70
-Spell0			=	Ahriman's Gift
+[Attack0Data1]
+Damage			=	22
 
 [ElementBonus1]
 
 [SupportBonus1]
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
 
+
+;==========Restored==========
+
+[Level2]
+MaxHitPoints		=	720
+Defense			=	12
+
+[SpellData2]
+Spell1			=	Spectral Form
+
+[Attack0Data2]
+Damage			=	26
+
 [ElementBonus2]
 
 [SupportBonus2]
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .65
 
+
+;==========Ascended==========
+
+[Level3]
+MaxHitPoints		=	840
+Defense			=	14
+
+[SpellData3]
+MaxMana 		=	70
+Spell0			=	Ahriman's Gift
+
+[Attack0Data3]
+Damage			=	30
+
 [ElementBonus3]
 
 [SupportBonus3]
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .5
+
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_4697_Hasanko

--- a/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
+++ b/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
@@ -64,7 +64,7 @@ AttackType		=	CAST		; enumeration list (int)
 Animation		=	0
 
 [ElementBonus]
-DAMAGE_TAKEN_FROM_RANGED	=	0.75
+DAMAGE_TAKEN_FROM_RANGED	=	0.65
 
 [SupportBonus]
 ATTACK_BONUS_TO_NONSHADOW		=	2
@@ -82,7 +82,7 @@ Defense				=	13
 Damage			=	58
 
 [ElementBonus1]
-DAMAGE_TAKEN_FROM_RANGED	=	0.75
+DAMAGE_TAKEN_FROM_RANGED	=	0.65
 
 [SupportBonus1]
 ATTACK_BONUS_TO_NONSHADOW		=	4
@@ -102,7 +102,7 @@ Spell0			=	Spectral Veil
 Damage			=	62
 
 [ElementBonus2]
-DAMAGE_TAKEN_FROM_RANGED	=	0.75
+DAMAGE_TAKEN_FROM_RANGED	=	0.65
 
 [SupportBonus2]
 ATTACK_BONUS_TO_NONSHADOW		=	4
@@ -122,7 +122,7 @@ Damage			=	66
 
 [ElementBonus3]
 IMMUNITY_TO_ENCHANTMENT		=	1
-DAMAGE_TAKEN_FROM_RANGED	=	0.75
+DAMAGE_TAKEN_FROM_RANGED	=	0.65
 
 [SupportBonus3]
 ATTACK_BONUS_TO_NONSHADOW		=	6

--- a/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
+++ b/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
@@ -11,7 +11,7 @@ UpkeepMana		=	0			;int
 BuildTime		=	0			;seconds(float)
 Defense			=	12			;number (float)
 DieTime			=	1			;seconds(float)
-OverwriteColor					=	10
+OverwriteColor	=	10
 Faction			=	Ceyah
 
 Moveable		=	1			;BOOLEAN
@@ -112,19 +112,20 @@ DAMAGE_TAKEN_FROM_KHALDUNITE	= .75
 ;==========Ascended==========
 
 [Level3]
-MaxHitPoints		=	840
+MaxHitPoints		=	1250
 Defense			=	14
 
 [SpellData3]
-MaxMana 		=	70
-Spell0			=	Ahriman's Gift
 
 [Attack0Data3]
-Damage			=	30
+Damage			=	66
 
 [ElementBonus3]
+IMMUNITY_TO_ENCHANTMENT		=	1
+DAMAGE_TAKEN_FROM_RANGED	=	0.75
 
 [SupportBonus3]
+ATTACK_BONUS_TO_NONSHADOW		=	6
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .5
 
 

--- a/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
+++ b/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
@@ -2,7 +2,7 @@
 ProperName = Hasanko
 Class			= 	2			;enumeration list(int)
 Sprite			=	units\dragoon.tgr
-BoundingRadius		=	0.35		;tiles(float)
+BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
 MaxHitPoints		=	550			;health rating(float)
 CostGold		=	0			;int
@@ -36,7 +36,7 @@ IdleTime		=	2		;seconds(float)
 MovementRate		=	34		;movement points(float)
 WalkDistance		=   	0.77		;tiles (float) how far does unit move in one animation cycle
 ResupplyRate		=	10		; health / second (float)
-MeleeFX			= necromancer_hitfx
+MeleeFX			= dreadlord_hitfx
 CombatValue		= 15
 Description		= Hasanko is a dangerous and power-hungry Ceyah who sees himself rising above the even the first Ceyah Lords. Despite being dedicated to Ahriman, he constantly plots against his brethren. He always appears in the field of combat as a monstrous spectral knight, although it is unknown how he does this, whether through illusion or other means.
 

--- a/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
+++ b/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
@@ -85,26 +85,28 @@ Damage			=	58
 DAMAGE_TAKEN_FROM_RANGED	=	0.75
 
 [SupportBonus1]
-TTACK_BONUS_TO_NONSHADOW		=	4
+ATTACK_BONUS_TO_NONSHADOW		=	4
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
 
 
 ;==========Restored==========
 
 [Level2]
-MaxHitPoints		=	720
-Defense			=	12
+MaxHitPoints		=	1000
+Defense			=	14
 
 [SpellData2]
-Spell1			=	Spectral Form
+Spell0			=	Spectral Veil
 
 [Attack0Data2]
-Damage			=	26
+Damage			=	62
 
 [ElementBonus2]
+DAMAGE_TAKEN_FROM_RANGED	=	0.75
 
 [SupportBonus2]
-DAMAGE_TAKEN_FROM_KHALDUNITE	= .65
+ATTACK_BONUS_TO_NONSHADOW		=	4
+DAMAGE_TAKEN_FROM_KHALDUNITE	= .75
 
 
 ;==========Ascended==========

--- a/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
+++ b/TGX Files/Data/ObjectData/Heroes/HASANKO.INI
@@ -73,17 +73,19 @@ DAMAGE_TAKEN_FROM_KHALDUNITE	=	.9
 ;==========Enlightened==========
 
 [Level1]
-MaxHitPoints		=	600
+MaxHitPoints		=	720
+Defense				=	13
 
 [SpellData1]
-ManaRegenerationRate 	=	4
 
 [Attack0Data1]
-Damage			=	22
+Damage			=	58
 
 [ElementBonus1]
+DAMAGE_TAKEN_FROM_RANGED	=	0.75
 
 [SupportBonus1]
+TTACK_BONUS_TO_NONSHADOW		=	4
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .8
 
 

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -320,25 +320,25 @@ ATTACK_BONUS_TO_ROUTED = 3
 [15]
 Name = Spectral Form
 ProperName = STRING_4493_Spectral_Form
-Description = STRING_4494_The_black_magic_of_this_spell_temporarily_turn_the_target_into_a_ghostly_shade__immaterial__and_virtually_immune_to_the_weapons_of_mortals_
+Description = STRING_4494_The_black_magicks_of_this_spell_temporarily_turn_the_target_into_a_ghostly_shade__immaterial__and_virtually_immune_to_the_weapons_of_mortals_
 Mana_Cost = 25
-Type = Single
-Special =	Holy
+Type = Personal
 Offensive =	0	;DEFENSIVE or OFFENSIVE
-Range = 10
 Heal = 0
 Morale = 0
 BonusSection = SpectralBonuses
 CasterStartEffect0 = None
 TargetDoCastEffect0 = spectral_form
 TargetLoopEffect0 = spectral_fade
-Duration = 60
+Duration = 90
 Sound = spells\spectral_form.wav
 
 [SpectralBonuses]
-DAMAGE_TAKEN_FROM_RANGED	= .25
-DAMAGE_TAKEN_FROM_MELEE		= .25
+CAUSE_MAGIC_DAMAGE			= 1
 IGNORE_TERRAIN_BONUS		= 1
+DAMAGE_TAKEN_FROM_MAGIC		= 1.15
+DAMAGE_TAKEN_FROM_NON_MAGIC	= .75
+
 
 [16]
 Name = Shadow's Hunter ;'
@@ -928,3 +928,20 @@ RELOAD_TIME_BONUS		=	.75
 DEFENSE_BONUS_VS_ANY	=	-2
 ATTACK_BONUS_TO_ROUTED	=	4
 ATTACK_BONUS_TO_ANY		=	4
+
+
+[48]
+Name = Spectral Veil
+ProperName = Spectral Veil
+Description = The black magicks of this spell temporarily turn the caster's comrades into ghostly shades, immaterial, and virtually immune to the weapons of mortals.
+Mana_Cost = 25
+Type = Group
+Offensive =	0	;DEFENSIVE or OFFENSIVE
+Heal = 0
+Morale = 0
+BonusSection = SpectralBonuses
+CasterStartEffect0 = None
+TargetDoCastEffect0 = spectral_form
+TargetLoopEffect0 = spectral_fade
+Duration = 90
+Sound = spells\spectral_form.wav

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -320,7 +320,7 @@ ATTACK_BONUS_TO_ROUTED = 3
 [15]
 Name = Spectral Form
 ProperName = STRING_4493_Spectral_Form
-Description = STRING_4494_The_black_magicks_of_this_spell_temporarily_turn_the_target_into_a_ghostly_shade__immaterial__and_virtually_immune_to_the_weapons_of_mortals_
+Description = The black magic of this spell temporarily turns the caster into a ghostly shade, immaterial, and virtually immune to the weapons of mortals.
 Mana_Cost = 25
 Type = Personal
 Offensive =	0	;DEFENSIVE or OFFENSIVE


### PR DESCRIPTION
### **_Changelog:_**
### All Levels:
```
Switched sprite to Dragoon and updated sounds, animation timings and description to match
Changed sprite color to 10
Increased RT from 0s to 1.3s (65% AS)
Changed Damage Type from MAGIC to NORMAL
Added 0.2 Morale Damage
Added Range Resistance (Personal) 65% (This comes out to ~50% when stacked with Spectral Form)
Removed Spell Shadow's Blessing
Removed Spell Mystic Armor
Removed Spell Ahriman's Gift
Set Max Mana to 50
Set Mana Regeneration to 2
```
### Awakened:
```
Increased HP from 480 to 550
Increased DV from 10 to 12
Increased AV from 18 to 52
Added Spell Spectral Form
Added Lightbane (Provided) +2
```
### Enlightened:
```
Increased HP from 600 to 720
Increased DV from 10 to 13
Increased AV from 22 to 58
Added Lightbane (Provided) +4
```
### Restored:
```
Increased HP from 720 to 1000
Increased DV from 12 to 14
Increased AV from 26 to 62
Replaced Spell Spectral Form with Spectral Veil
Reduced Khaldunite Resistance (Provided) from 65% to 75%
Added Lightbane (Provided) +4
```
### Ascended:
```
Increased HP from 840 to 1250
Increased Av from 30 to 66
Added Spell Immunity (Personal)
Added Ligthbane (Provided) +6
```

### Spells_KE:
```
Changed Spectral Form to be personal, duration 90s, and provide:
Armored 75%
Magic Vulnerable 115%
Trailblazing
Magic Damage Type

Added Spectral Veil, which is a Group version of Spectral Form
```