### PR TITLE
Vashti rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/VASHTI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VASHTI.INI
@@ -104,7 +104,7 @@ ZONE_OF_CONTROL_BONUS				=	1.20
 ;==========Ascended==========
 
 [Level3]
-AttachedFX                          =   orange_sparkle
+;;AttachedFX                          =   orange_sparkle
 MaxHitPoints                        =   820
 Defense								=	12
 

--- a/TGX Files/Data/ObjectData/Heroes/VASHTI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VASHTI.INI
@@ -63,6 +63,7 @@ AttackType                          =   CAST
 [ElementBonus]
 
 [SupportBonus]
+ZONE_OF_CONTROL_BONUS				=	1.15
 
 [Level1]
 MaxHitPoints                        =   560

--- a/TGX Files/Data/ObjectData/Heroes/VASHTI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VASHTI.INI
@@ -101,20 +101,28 @@ DAMAGE_TAKEN_FROM_RANGED			=	0.75
 [SupportBonus2]
 ZONE_OF_CONTROL_BONUS				=	1.20
 
+;==========Ascended==========
+
 [Level3]
 AttachedFX                          =   orange_sparkle
-MaxHitPoints                        =   780
+MaxHitPoints                        =   820
+Defense								=	12
 
 [SpellData3]
 Spell0                              =   Summon Darkwolves
+Spell1								=	Sea of Pain
 
 [Attack0Data3]
 Damage                              =   44
 
 [ElementBonus3]
 REVERSE_DAMAGE_WHEN_HIT             =   12
+DAMAGE_TAKEN_FROM_MAGIC				=	0.5
+DAMAGE_TAKEN_FROM_RANGED			=	0.5
 
 [SupportBonus3] 
+ZONE_OF_CONTROL_BONUS				=	1.25
+
 
 [HeroData]
 AwakenCost                          =   50

--- a/TGX Files/Data/ObjectData/Heroes/VASHTI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VASHTI.INI
@@ -65,12 +65,14 @@ AttackType                          =   CAST
 [SupportBonus]
 ZONE_OF_CONTROL_BONUS				=	1.15
 
+;==========Enlightened===========
+
 [Level1]
-MaxHitPoints                        =   560
+MaxHitPoints                        =   600
 
 [SpellData1]
 MaxMana                             =   70
-ManaRegenerationRate                =   5
+ManaRegenerationRate                =   4
 
 [Attack0Data1]
 Damage                              =   40
@@ -78,6 +80,7 @@ Damage                              =   40
 [ElementBonus1]
 
 [SupportBonus1]
+ZONE_OF_CONTROL_BONUS				=	1.20
 
 [Level2]
 MaxHitPoints                        =   670

--- a/TGX Files/Data/ObjectData/Heroes/VASHTI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VASHTI.INI
@@ -82,17 +82,24 @@ Damage                              =   40
 [SupportBonus1]
 ZONE_OF_CONTROL_BONUS				=	1.20
 
+;==========Restored=========
+
 [Level2]
-MaxHitPoints                        =   670
+MaxHitPoints                        =   730
 
 [SpellData2]
+ManaRegenerationRate                =   5
+Spell0								=	Summon Shadeling Swarm
 Spell1                              =   Wash of Pain
 
 [Attack0Data2]
 
 [ElementBonus2]
+DAMAGE_TAKEN_FROM_MAGIC				=	0.75
+DAMAGE_TAKEN_FROM_RANGED			=	0.75
 
 [SupportBonus2]
+ZONE_OF_CONTROL_BONUS				=	1.20
 
 [Level3]
 AttachedFX                          =   orange_sparkle


### PR DESCRIPTION
### **_Changelog:_**
### Awakened:
```
Added Dominion 115%
```
### Enlightened:
```
Increased HP from 560 to 600
Reduced Mana Rgeneration Rate from 5 to 4
Added Dominion 120%
```
### Restored:
```
Increased HP from 670 to 730
Replaced Spell "Summon Shadelings" with "Summon Shadeling Swarm"
Added Range Resistance (Personal) 75%
Added Magic Resistance (Personal) 75%
Added Dominion 120%
```
### Ascended:
```
Increased HP from 780 to 820
Increased DV from 10 to 12
Replaced Spell "Summon Shadeling Swarm" with "Summon Dark Wolves"
Replaced Spell "Wash of Pain" with "Sea of Pain"
Added Range Resistance (Personal) 50%
Added Magic Resistance (Personal) 50%
Added Dominion 125%
Removed orange_sparkle as it is broken. Will replace with new sprite for all ceyah passive reverse damage effects (Vashti, Lazarus, Gideon)

```