### PR TITLE
Dylan rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/DYLAN_GARWOOD.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DYLAN_GARWOOD.INI
@@ -4,12 +4,12 @@ Class			= 	2			;enumeration list(int)
 Sprite			=   units\battle_priest.tgr
 BoundingRadius		=	0.25		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	430			;health rating(float)
+MaxHitPoints		=	450			;health rating(float)
 CostGold		=	0			;int
 UpkeepGold		=	0			;int
 UpkeepMana		=	0			;int
 BuildTime		=	0			;seconds(float)
-Defense			=	8			;number (float)
+Defense			=	10			;number (float)
 DieTime			=	1			;seconds(float)
 Faction			=	Royalist
 
@@ -43,19 +43,10 @@ ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Protection
 Spell1			=	Courage
 
-
-
-[ElementBonus]
-
-[SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
-
-[CompanyData]
-
 [Attack1]
 AttackTime		=	1			; seconds(float) per animation cycle
 DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
-ReloadTime		=	1			; seconds (float)
+ReloadTime		=	0.5			; seconds (float)
 AttackRange		=	1			; tiles (float)
 AttackType		=	MELEE		; enumeration list (int)
 Damage			=	36		;number (float)
@@ -69,6 +60,11 @@ DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation 		=	1
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	=	0.8
+
+[SupportBonus]
 
 
 ;==========Enlightened==========
@@ -104,7 +100,7 @@ Spell1			= Valor
 MORALE_RECOVERY_RATE_BONUS	= 1.2
 
 
-;==========Ascenede==========
+;==========Ascended==========
 
 [Level3]
 MaxHitPoints		=	760

--- a/TGX Files/Data/ObjectData/Heroes/DYLAN_GARWOOD.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DYLAN_GARWOOD.INI
@@ -70,7 +70,8 @@ DAMAGE_TAKEN_FROM_RANGED	=	0.8
 ;==========Enlightened==========
 
 [Level1]
-MaxHitPoints		=	540
+MaxHitPoints		=	600
+Defense				=	12
 
 [SpellData1]
 
@@ -81,7 +82,6 @@ Damage			=	40
 
 [SupportBonus1]
 MORALE_RECOVERY_RATE_BONUS	= 1.1
-DEFENSE_BONUS_VS_ANY = 0
 
 
 ;==========Restored==========

--- a/TGX Files/Data/ObjectData/Heroes/DYLAN_GARWOOD.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DYLAN_GARWOOD.INI
@@ -87,16 +87,17 @@ MORALE_RECOVERY_RATE_BONUS	= 1.1
 ;==========Restored==========
 
 [Level2]
-MaxHitPoints		=	650
+MaxHitPoints		=	750
 
 [SpellData2]
-Spell1			= Valor
 
 [Attack0Data2]
+Damage				=	44
 
 [ElementBonus2]
 
 [SupportBonus2]
+DEFENSE_BONUS_VS_ANY		=	2
 MORALE_RECOVERY_RATE_BONUS	= 1.2
 
 

--- a/TGX Files/Data/ObjectData/Heroes/DYLAN_GARWOOD.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DYLAN_GARWOOD.INI
@@ -43,9 +43,7 @@ ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Protection
 Spell1			=	Courage
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_2375_Dylan_Garwood
+
 
 [ElementBonus]
 
@@ -72,30 +70,16 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation 		=	1
 
+
+;==========Enlightened==========
+
 [Level1]
 MaxHitPoints		=	540
 
-[Level2]
-MaxHitPoints		=	650
-
-[Level3]
-MaxHitPoints		=	760
-
+[SpellData1]
 
 [Attack0Data1]
 Damage			=	40
-
-[Attack0Data2]
-
-[Attack0Data3]
-Damage			=	46
-
-[SpellData1]
-
-[SpellData2]
-Spell1			= Valor
-
-[SpellData3]
 
 [ElementBonus1]
 
@@ -103,13 +87,40 @@ Spell1			= Valor
 MORALE_RECOVERY_RATE_BONUS	= 1.1
 DEFENSE_BONUS_VS_ANY = 0
 
+
+;==========Restored==========
+
+[Level2]
+MaxHitPoints		=	650
+
+[SpellData2]
+Spell1			= Valor
+
+[Attack0Data2]
+
 [ElementBonus2]
 
 [SupportBonus2]
 MORALE_RECOVERY_RATE_BONUS	= 1.2
+
+
+;==========Ascenede==========
+
+[Level3]
+MaxHitPoints		=	760
+
+[SpellData3]
+
+[Attack0Data3]
+Damage			=	46
 
 [ElementBonus3]
 
 [SupportBonus3]
 DEFENSE_BONUS_VS_ANY		= 2
 MORALE_RECOVERY_RATE_BONUS	= 1.25
+
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_2375_Dylan_Garwood

--- a/TGX Files/Data/ObjectData/Heroes/DYLAN_GARWOOD.INI
+++ b/TGX Files/Data/ObjectData/Heroes/DYLAN_GARWOOD.INI
@@ -104,16 +104,18 @@ MORALE_RECOVERY_RATE_BONUS	= 1.2
 ;==========Ascended==========
 
 [Level3]
-MaxHitPoints		=	760
+MaxHitPoints		=	900
 
 [SpellData3]
+Spel1				=	Valor
 
 [Attack0Data3]
-Damage			=	46
+Damage			=	52
 
 [ElementBonus3]
 
 [SupportBonus3]
+DAMAGE_TAKEN_FROM_KHALDUNITE	=	0.8
 DEFENSE_BONUS_VS_ANY		= 2
 MORALE_RECOVERY_RATE_BONUS	= 1.25
 


### PR DESCRIPTION
### **_Changelog:_**
### All Levels:
```
Increased Melee AS from 75% to 100%
Added Range Resistance (Personal) 80%
```
### Awakened:
```
Increased HP from 430 to 450
Increased Dv from 8 to 10
Removed -1DV (Provided)
```
### Enlightened:
```
Increased HP from 540 to 600
Increased DV from 8 to 12
```
### Restored:
```
Increased HP from 650 to 750
Increased DV from 8 to 12
Replaced Valor with Courage
Increased AV from 40 to 44
Added +2DV (Provided)
```
### Ascended:
```
Increased HP from 760 to 900
Increased DV from 8 to 12
Increased AV from 46 to 52
Added Khaldunite Resistance (Provided) 80%
```