### PR TITLE
Jamsheed rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/JAMSHEED_AVISHAI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JAMSHEED_AVISHAI.INI
@@ -4,7 +4,7 @@ Class                       =   2
 Sprite                      =   units\Dragoon.tgr
 BoundingRadius              =   0.25
 RotTime                     =   30
-MaxHitPoints                =   620
+MaxHitPoints                =   650
 CostGold                    =   0
 BuildTime                   =   5
 DetectionRadius             =   100
@@ -47,7 +47,7 @@ DamagePoint                 =   0.5
 ReloadTime                  =   0.5
 AttackRange                 =   0.75
 AttackType                  =   MELEE
-Damage                      =   42
+Damage                      =   44
 DamageType                  =   NORMAL
 [Attack2]
 AttackTime                  =   1

--- a/TGX Files/Data/ObjectData/Heroes/JAMSHEED_AVISHAI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JAMSHEED_AVISHAI.INI
@@ -81,19 +81,24 @@ IMMUNITY_TO_ENCHANTMENT     =   1
 [SupportBonus1]
 MORALE_BONUS                =   4
 
+
+;==========Restored==========
+
 [Level2]
-MaxHitPoints                =   1060
+MaxHitPoints                =   1100
 
 [SpellData2]
 
 [Attack0Data2]
-Damage                      =   50
+Damage                      =   52
+DamageType                  =   KHALDUNITE
 
 [ElementBonus2]
 DAMAGE_TAKEN_FROM_RANGED    =   .5
 IMMUNITY_TO_ENCHANTMENT     =   1
 
 [SupportBonus2]
+RECOVERY_RATE_BONUS			=	1.1
 MORALE_BONUS                =   6
 
 [Level3]
@@ -104,6 +109,7 @@ Spell0                      =   Valor
 
 [Attack0Data3]
 Damage                      =   56
+
 
 [ElementBonus3]
 DAMAGE_TAKEN_FROM_RANGED    =   .5

--- a/TGX Files/Data/ObjectData/Heroes/JAMSHEED_AVISHAI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JAMSHEED_AVISHAI.INI
@@ -101,14 +101,16 @@ IMMUNITY_TO_ENCHANTMENT     =   1
 RECOVERY_RATE_BONUS			=	1.1
 MORALE_BONUS                =   6
 
+
+;==========Ascended==========
+
 [Level3]
-MaxHitPoints                =   1280
+MaxHitPoints                =   1350
 
 [SpellData3]
-Spell0                      =   Valor
 
 [Attack0Data3]
-Damage                      =   56
+Damage                      =   58
 
 
 [ElementBonus3]
@@ -116,7 +118,8 @@ DAMAGE_TAKEN_FROM_RANGED    =   .5
 IMMUNITY_TO_ENCHANTMENT     =   1
 
 [SupportBonus3]
-MORALE_BONUS                =   6
+RECOVERY_RATE_BONUS			=	1.2
+MORALE_BONUS                =   8
 
 [HeroData]
 AwakenCost                  =   50

--- a/TGX Files/Data/ObjectData/Heroes/JAMSHEED_AVISHAI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JAMSHEED_AVISHAI.INI
@@ -63,13 +63,16 @@ IMMUNITY_TO_ENCHANTMENT     =   1
 [SupportBonus]
 MORALE_BONUS                =   2
 
+
+;==========Enlightened==========
+
 [Level1]
-MaxHitPoints                =   840
+MaxHitPoints                =   850
 
 [SpellData1]
 
 [Attack0Data1]
-Damage                      =   46
+Damage                      =   48
 
 [ElementBonus1]
 DAMAGE_TAKEN_FROM_RANGED    =   .5


### PR DESCRIPTION
### **_Changelog:_**
### Awakened:
```
Increased HP from 620 to 650
Increaed AV from 42 to 44
```
### Enlightened:
```
Increased HP from 840 to 850
Increaed AV from 46 to 48
```
### Restored:
```
Increased HP from 1060 to 1100
Increaed Av from 50 to 52
Changed Damage Type to Khaldunite
Added Quicker Recovery 110%
```
### Ascended:
```
Increased HP from 1280 to 1350
Increaed Av from 56 to 58
Increased BRavery from +6 to +8
Added Quicker Recovery 120%
Replaced Spell Valor with Courage
```