### PR TITLE
Sar Lashkar rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
@@ -124,4 +124,4 @@ DEFENSE_BONUS_VS_ANY                    =   4
 
 [HeroData]
 AwakenCost                              =   50
-TranslatedName                          =   Sar Lashkar
+TranslatedName                          =   STRING_0091_Sar_Lashkar

--- a/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
@@ -1,110 +1,119 @@
 [ObjectData]
-ProperName = Sar Lashkar
-Class			= 	2			;enumeration list(int)
-Sprite			=   units\Drauga_berserker.tgr
-BoundingRadius		=	0.25		;tiles(float)
-RotTime			=	30			;seconds(float)
-MaxHitPoints		=	2500			;health rating(float)
-CostGold		=	0			;int
-UpkeepGold		=	0			;int
-UpkeepMana		=	0			;int
-BuildTime		=	0			;seconds(float)
-Defense			=	12			;number (float)
-DieTime			=	1			;seconds(float)
-Faction			=	Ceyah
+ProperName                              =   Lord Sar Lashkar ;This is the skirmish/MP version of the hero
+Class                                   =   2
+Sprite                                  =   units\Drauga_berserker.tgr
+BoundingRadius                          =   0.25
+RotTime                                 =   30
+MaxHitPoints                            =   800
+CostGold                                =   0
+BuildTime                               =   0
+Defense                                 =   8
+DieTime                                 =   1
+Faction                                 =   Ceyah
 
-Moveable		=	1			;BOOLEAN
-Selectable		=	1			;BOOLEAN
-Blocking		=	1			;BOOLEAN
-Land			=	1			;BOOLEAN
-Water			=	0			;BOOLEAN
+Moveable                                =   1
+Selectable                              =   1
+Blocking                                =   1
+Land                                    =   1
+Water                                   =   0
 
-DeathSound1		=	Game\berserker_death.wav
-SelectionSound1		=	Game\m_heroD_select1.wav
-SelectionSound2		=	Game\m_heroD_select_evil.wav
-CommandSound1		=	Game\m_heroD_command1.wav
-CommandSound2		=	Game\m_heroD_command_evil.wav
+DeathSound1                             =   Game\berserker_death.wav
+SelectionSound1                         =   Game\agm_hero4_evil_select1.wav
+SelectionSound2                         =   Game\agm_hero4_evil_select2.wav
+SelectionSound3                         =   Game\agm_hero4_evil_select3.wav
+CommandSound1                           =   Game\agm_hero4_evil_command1.wav
+CommandSound2                           =   Game\agm_hero4_evil_command2.wav
+CommandSound3                           =   Game\agm_hero4_evil_command3.wav
 
 [UnitData]
-Type			=	HERO
-Icon			=   Portraits\Unit Icons\Berserker_icon.tgr
-Portrait		=	Portraits\Heroes\Sar_Lashkar_Portrait.tgr
-IdleTime		=	2		;seconds(float)
-MovementRate		=	34		;movement points(float)
-WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
-ResupplyRate		=	10		; health / second (float)
-MeleeFX			= 	Necromancer_hitfx
-CombatValue		= 25
-Description = STRING_2407_Sar_Lashkar_was_a_virtually_unknown__lesser_member_of_Kohan_society__He_had_little_influence_and_little_power__The_Cataclysm_was_his_big_chance_to_gain_power__It_did_not_work__of_course__and_he_was_banished_with_the_rest_of_the_Ceyah__Sar_Lashkar_spent_the_rest_of_his_days_wandering_in_the_far_south__across_barren__frozen_lands__The_bitter_cold_matched_his_bitter_heart_and_Sar_Lashkar_became_more_brutal_and_violent_with_each_passing_year__He_appears_in_a_Kohan_war_form_that_has_been_taken_to_the_extreme__He_is_very_large__very_hairy__and_possesses_great_strength__He_uses_his_strength_to_prey_upon_all_the_weaker_creatures_that_cross_his_path_
-
-[HeroData]
-AwakenCost		= 9999
-Boss			= 1
-TranslatedName = STRING_0091_Sar_Lashkar
-
-[BuildHierarchy]
-
-[ElementBonus]
-IMMUNITY_TO_ENCHANTMENT	= 1
-
-[SupportBonus]
-DEFENSE_BONUS_VS_ANY	= 4
+Type                                    =   HERO
+Icon                                    =   Portraits\Unit Icons\Berserker_icon.tgr
+Portrait                                =   Portraits\Heroes\Sar_Lashkar_Portrait.tgr
+IdleTime                                =   2
+MovementRate                            =   34
+WalkDistance                            =   0.85
+ResupplyRate                            =   10
+MeleeFX                                 =   Necromancer_hitfx
+CombatValue                             =   25
+Description                             =   STRING_4717_Lord_Sar_Lashkar_was_a_virtually_unknown__lesser_member_of_Kohan_society__He_had_little_influence_and_little_power__The_Cataclysm_was_his_big_chance_to_gain_power__It_did_not_work__of_course__and_he_was_banished_with_the_rest_of_the_Ceyah__Lord_Sar_Lashkar_spent_the_rest_of_his_days_wandering_in_the_far_south__across_barren__frozen_lands__The_bitter_cold_matched_his_bitter_heart_and_Sar_Lashkar_became_more_brutal_and_violent_with_each_passing_year__He_appears_in_a_Kohan_war_form_that_has_been_taken_to_the_extreme__He_is_very_large__very_hairy__and_possesses_great_strength__He_uses_his_strength_to_prey_upon_all_who_try_to_avoid_Ahriman_s_will_
 
 [SpellData]
-MaxMana 		=	60 	;the max amount that mana can be for the unit
-ManaRegenerationRate 	=	2	;the amount of mana that gets regenerated sec.
-Spell0			=	Unholy Strength
+MaxMana                                 =   60
+ManaRegenerationRate                    =   2
+Spell0                                  =   Shadow's Blessing ;'
 
 [Attack1]
-AttackTime		=	1			; seconds(float) per animation cycle
-DamagePoint		=	0.65		; at what point (percentage) in attack animation to shoot fireball
-ReloadTime		=	1			; seconds (float)
-AttackRange		=	1			; tiles (float)
-AttackType		=	MELEE		; enumeration list (int)
-Damage			=	90		;number (float)
-DamageType		=	NORMAL
-Sound1			=	Game\axe2.wav
+Sound1                                  =   Game\axe2.wav
+AttackTime                              =   1
+DamagePoint                             =   0.65
+ReloadTime                              =   1
+AttackRange                             =   1
+AttackType                              =   MELEE
+Damage                                  =   50
+DamageType                              =   NORMAL
 
 [Attack2]
-AttackTime		=	1			; seconds(float) per animation cycle
-DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
-ReloadTime		=	3			; seconds (float)
-AttackType		=	CAST		; enumeration list (int)
-Animation = 0
+AttackTime                              =   1
+DamagePoint                             =   0.5
+ReloadTime                              =   3
+AttackType                              =   CAST
+Animation                               =   0
+
+[ElementBonus]
+IMMUNITY_TO_ENCHANTMENT                 =   1
+
+[SupportBonus]
+
+
+;==========Enlightened==========
 
 [Level1]
-
-[Level2]
-
-[Level3]
-;Technology		= SampleTech
-
-[Attack0Data1]
-
-[Attack0Data2]
-
-[Attack0Data3]
-
-[Attack1Data1]
-
-[Attack1Data2]
-
-[Attack1Data3]
+MaxHitPoints                            =   1000
 
 [SpellData1]
 
-[SpellData2]
-
-[SpellData3]
+[Attack0Data1]
+Damage                                  =   60
 
 [ElementBonus1]
+IMMUNITY_TO_ENCHANTMENT                 =   1
 
 [SupportBonus1]
+DEFENSE_BONUS_VS_ANY                    =   2
+
+
+;==========Restored===========
+
+[Level2]
+MaxHitPoints                            =   1250
+Defense                                 =   10
+
+[SpellData2]
+Spell0                                  =   Unholy Strength
+
+[Attack0Data2]
 
 [ElementBonus2]
 
 [SupportBonus2]
+DEFENSE_BONUS_VS_ANY                    =   4
+
+
+;==========Ascended===========
+
+[Level3]
+MaxHitPoints                            =   1500
+
+[SpellData3]
+
+[Attack0Data3]
+Damage                                  =   70
 
 [ElementBonus3]
 
 [SupportBonus3]
+
+
+[HeroData]
+AwakenCost                              =   50
+TranslatedName                          =   Lord Sar Lashkar

--- a/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
@@ -1,5 +1,5 @@
 [ObjectData]
-ProperName                              =   Lord Sar Lashkar ;This is the skirmish/MP version of the hero
+ProperName                              =   Sar Lashkar
 Class                                   =   2
 Sprite                                  =   units\Drauga_berserker.tgr
 BoundingRadius                          =   0.25
@@ -35,7 +35,7 @@ WalkDistance                            =   0.85
 ResupplyRate                            =   10
 MeleeFX                                 =   Necromancer_hitfx
 CombatValue                             =   25
-Description                             =   STRING_4717_Lord_Sar_Lashkar_was_a_virtually_unknown__lesser_member_of_Kohan_society__He_had_little_influence_and_little_power__The_Cataclysm_was_his_big_chance_to_gain_power__It_did_not_work__of_course__and_he_was_banished_with_the_rest_of_the_Ceyah__Lord_Sar_Lashkar_spent_the_rest_of_his_days_wandering_in_the_far_south__across_barren__frozen_lands__The_bitter_cold_matched_his_bitter_heart_and_Sar_Lashkar_became_more_brutal_and_violent_with_each_passing_year__He_appears_in_a_Kohan_war_form_that_has_been_taken_to_the_extreme__He_is_very_large__very_hairy__and_possesses_great_strength__He_uses_his_strength_to_prey_upon_all_who_try_to_avoid_Ahriman_s_will_
+Description								=	STRING_2407_Sar_Lashkar_was_a_virtually_unknown__lesser_member_of_Kohan_society__He_had_little_influence_and_little_power__The_Cataclysm_was_his_big_chance_to_gain_power__It_did_not_work__of_course__and_he_was_banished_with_the_rest_of_the_Ceyah__Sar_Lashkar_spent_the_rest_of_his_days_wandering_in_the_far_south__across_barren__frozen_lands__The_bitter_cold_matched_his_bitter_heart_and_Sar_Lashkar_became_more_brutal_and_violent_with_each_passing_year__He_appears_in_a_Kohan_war_form_that_has_been_taken_to_the_extreme__He_is_very_large__very_hairy__and_possesses_great_strength__He_uses_his_strength_to_prey_upon_all_the_weaker_creatures_that_cross_his_path_
 
 [SpellData]
 MaxMana                                 =   60
@@ -124,4 +124,4 @@ DEFENSE_BONUS_VS_ANY                    =   4
 
 [HeroData]
 AwakenCost                              =   50
-TranslatedName                          =   Lord Sar Lashkar
+TranslatedName                          =   Sar Lashkar

--- a/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
@@ -74,9 +74,10 @@ MaxHitPoints                            =   1000
 [SpellData1]
 
 [Attack0Data1]
-Damage                                  =   60
+Damage                                  =   56
 
 [ElementBonus1]
+DAMAGE_TAKEN_FROM_RANGED				=	.5
 IMMUNITY_TO_ENCHANTMENT                 =   1
 
 [SupportBonus1]

--- a/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
@@ -106,15 +106,20 @@ DEFENSE_BONUS_VS_ANY                    =   4
 
 [Level3]
 MaxHitPoints                            =   1500
+Defense									=	10
 
 [SpellData3]
+Spell0									=	Immortal Fury
 
 [Attack0Data3]
-Damage                                  =   70
+Damage                                  =   68
 
 [ElementBonus3]
+DAMAGE_TAKEN_FROM_RANGED				=	.5
+IMMUNITY_TO_ENCHANTMENT                 =   1
 
 [SupportBonus3]
+DEFENSE_BONUS_VS_ANY                    =   4
 
 
 [HeroData]

--- a/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
@@ -88,14 +88,15 @@ DEFENSE_BONUS_VS_ANY                    =   2
 
 [Level2]
 MaxHitPoints                            =   1250
-Defense                                 =   10
 
 [SpellData2]
-Spell0                                  =   Unholy Strength
 
 [Attack0Data2]
+Damage									=	64
 
 [ElementBonus2]
+DAMAGE_TAKEN_FROM_RANGED				=	.5
+IMMUNITY_TO_ENCHANTMENT                 =   1
 
 [SupportBonus2]
 DEFENSE_BONUS_VS_ANY                    =   4

--- a/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR.INI
@@ -60,6 +60,7 @@ AttackType                              =   CAST
 Animation                               =   0
 
 [ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED				=	.5
 IMMUNITY_TO_ENCHANTMENT                 =   1
 
 [SupportBonus]

--- a/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR2.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SAR_LASHKAR2.INI
@@ -1,5 +1,5 @@
 [ObjectData]
-ProperName                              =   Lord Sar Lashkar ;This is the skirmish/MP version of the hero
+ProperName                              =   UNUSED_002
 Class                                   =   2
 Sprite                                  =   units\Drauga_berserker.tgr
 BoundingRadius                          =   0.25
@@ -105,5 +105,6 @@ Damage                                  =   70
 [SupportBonus3]
 
 [HeroData]
+Boss		=	1
 AwakenCost                              =   50
-TranslatedName                          =   Lord Sar Lashkar
+TranslatedName                          =   UNUSED_002


### PR DESCRIPTION
### **_Changelog:_**
### All Levels:
```
Added Range Resistance (Personal) 50%
```
### Awakened:
```
None
```
### Enlightened:
```
Decreased AV from 60 to 56
```
### Restored:
```
Reduced DV from 10 to 8
Increased AV from 60 to 64
Replaced Spell 'Unholy Strength' with 'Shadow's Blessing'
```
### Ascended:
```
Decreased AV from 70 to 68
Replaced Spell 'Shadow's Blessing' with 'Immortal Fury'

```