### PR TITLE
Vargus cast speed

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/VARGUS.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VARGUS.INI
@@ -52,7 +52,7 @@ Sound1				=	Game\club2.wav
 [Attack2]
 AttackTime			=	1
 DamagePoint			=	0.25
-ReloadTime			=	1
+ReloadTime			=	0.2
 AttackType			=	CAST
 Animation			=	0
 


### PR DESCRIPTION
Reduced Vargus' cast time to 1.2s to match other melee kohan with short-duration self-buff spells