### PR TITLE
Dali Azade Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/DALI_AZADE.ini
+++ b/TGX Files/Data/ObjectData/Heroes/DALI_AZADE.ini
@@ -85,13 +85,8 @@ ManaRegenerationRate                                    =   3
 Damage                                                  =   42
 
 [ElementBonus1]
-ATTACK_BONUS_TO_MOUNTED                                 =   4
-DEFENSE_BONUS_VS_MOUNTED                                =   2
-IGNORE_TERRAIN_BONUS                                    =   1
-IMMUNITY_TO_ENCHANTMENT                                 =   1
 
 [SupportBonus1]
-DEFENSE_BONUS_VS_ANY                                    =   0
 ATTACK_BONUS_TO_MOUNTED                                 =   2
 MORALE_LOSS_RATE_BONUS                                  =   .85
 

--- a/TGX Files/Data/ObjectData/Heroes/DALI_AZADE.ini
+++ b/TGX Files/Data/ObjectData/Heroes/DALI_AZADE.ini
@@ -92,19 +92,13 @@ MORALE_LOSS_RATE_BONUS                                  =   .85
 
 [Level2]
 MaxHitPoints                                            =   950
-Defense                                                 =   16
 
 [SpellData2]
-Spell0                                                  =   Holy Strength
 
 [Attack0Data2]
+Damage                                                  =   44
 
 [ElementBonus2]
-ATTACK_BONUS_TO_MOUNTED                                 =   4
-DEFENSE_BONUS_VS_MOUNTED                                =   2
-IGNORE_TERRAIN_BONUS                                    =   1
-IMMUNITY_TO_ENCHANTMENT                                 =   1
-RELOAD_TIME_BONUS                                       =   .9
 
 [SupportBonus2]
 ATTACK_BONUS_TO_MOUNTED                                 =   6

--- a/TGX Files/Data/ObjectData/Heroes/DALI_AZADE.ini
+++ b/TGX Files/Data/ObjectData/Heroes/DALI_AZADE.ini
@@ -39,14 +39,14 @@ Description                                             =   A tall, athletic wom
 
 [SpellData]
 MaxMana                                                 =   50
-ManaRegenerationRate                                    =   1
+ManaRegenerationRate                                    =   2
 Spell0                                                  =   Blessing
 
 [Attack1]
 Sound1                                                  =   Game\sword3.wav
 AttackTime                                              =   1
 DamagePoint                                             =   0.4
-ReloadTime                                              =   0.5
+ReloadTime                                              =   0.36
 AttackRange                                             =   0.75
 AttackType                                              =   Melee
 Damage                                                  =   40
@@ -69,9 +69,9 @@ ATTACK_BONUS_TO_MOUNTED                                 =   4
 DEFENSE_BONUS_VS_MOUNTED                                =   2
 IGNORE_TERRAIN_BONUS                                    =   1
 IMMUNITY_TO_ENCHANTMENT                                 =   1
+DAMAGE_TAKEN_FROM_RANGED                                =   .8
 
 [SupportBonus]
-DEFENSE_BONUS_VS_ANY                                    =   -1
 MORALE_LOSS_RATE_BONUS                                  =   .95
 
 [Level1]

--- a/TGX Files/Data/ObjectData/Heroes/DALI_AZADE.ini
+++ b/TGX Files/Data/ObjectData/Heroes/DALI_AZADE.ini
@@ -106,6 +106,7 @@ MORALE_LOSS_RATE_BONUS                                  =   .75
 
 [Level3]
 MaxHitPoints                                            =   1150
+Defense                                                 =   16
 
 [SpellData3]
 
@@ -113,13 +114,9 @@ MaxHitPoints                                            =   1150
 Damage                                                  =   46
 
 [ElementBonus3]
-ATTACK_BONUS_TO_MOUNTED                                 =   4
-DEFENSE_BONUS_VS_MOUNTED                                =   2
-IGNORE_TERRAIN_BONUS                                    =   1
-IMMUNITY_TO_ENCHANTMENT                                 =   1
-RELOAD_TIME_BONUS                                       =   .9
 
 [SupportBonus3]
+RELOAD_TIME_BONUS                                       =   .9
 ATTACK_BONUS_TO_MOUNTED                                 =   8
 MORALE_LOSS_RATE_BONUS                                  =   .7
 


### PR DESCRIPTION
### All Levels:

	Increased Attack Speed from 100% to 110%

	Added Ranged Resistance 80% (Personal)

### Awakened

	Increased Mana Regen from 1 to 2 

### Enlightened
	
### Restored

	Decreased DV from 16 to 14
	Increased AV from 42 to 44
	
	Spell0: Retained Blessing spell instead of Holy Strength
	
	Removed Haste 90%
	
### Ascended

	Moved Haste 90% from Personal to Provided
