### PR TITLE
Turreted Ramparts

### DIFF
--- a/TGX Files/Data/ObjectData/Components.ini
+++ b/TGX Files/Data/ObjectData/Components.ini
@@ -444,3 +444,4 @@ BuildTime                   =   20
 [TurretedRampartsBonuses]
 UPGRADE_BONUS_MILITIA_MAX   =   1.25
 UPGRADE_BONUS_SUPPLY_RANGE  =   1.15
+UPGRADE_BONUS_MILITIA_DV    =   2


### PR DESCRIPTION
### _Changelog:_

Added bonus 2 DV to militia on Turreted Ramparts to make it the true midway point between Watch Towers and Fortified Walls.