### PR TITLE
New lair addition

### DIFF
--- a/TGX Files/Data/ObjectData/buildings/NEW_AHRIMAN_CITADEL.INI
+++ b/TGX Files/Data/ObjectData/buildings/NEW_AHRIMAN_CITADEL.INI
@@ -1,60 +1,46 @@
 [ObjectData]
-ProperName = STRING_2154_Ahriman_s_Citadel
-Class			= 	1	;enumeration list(int)
-Sprite			=   buildings\Ahriman_Citadel.tgr
-BoundingRadius		=	6	;tiles (float)
-ClearOut		=   	4	;tiles
-MaxHitPoints		=	10000	;health rating(float)
-DetectionRadius		=	30	;tiles(float)
-Defense			=	0	;number (float)
-RotTime			=	9999	;seconds(float)
-Captureable		=	0
+ProperName = STRING_2176_Dark_Chasm
+Class				= 	2	;enumeration list(int)
+Sprite				=   buildings\Dark_Chasm.tgr
+BoundingRadius			=	3	;tiles (float)
+ClearOut			=   	2	;tiles
+MaxHitPoints			=	10000	;health rating(float)
+DetectionRadius			=	16	;tiles(float)
+Defense				=	0	;number (float)
+DieTime				=	1
+RotTime			=	120	;seconds(float)
+Description			=	STRING_3009_A_great_rent_in_the_earth_pulsating_with_dark_energy__the_dark_chasm_is_a_breeding_ground_for_creatures_of_evil_
+CostGold			=	0
 
-Description = STRING_4628_Ahriman_s_newly_risen_citadel_floats_menacingly_above_the_corrupt_earth__The_focal_point_of_his_power_is_hidden_deep_within_its_shadowy_halls_
-Faction			=	Ceyah
-Weight			=	0
-
-SelectionSound1	= 	Game\select_mana_mine.wav
 DeathSound1		=	Game\building_destroyed.wav
+SelectionSound1		= 	Game\select_mana_mine.wav
 
 [BuildingData]
-Icon			=	Portraits\Buildings\ahriman_citadel_portrait.tgr
-DestructionAnimation = Art\Objects\Buildings\Animations\Ceyah_citadel_destroy.tgr
-;NameList		=	CeyahCities
-IconIndex 		= 	8
-GoldProduction		=	25		;int
-IronProduction		=	0		;int
-WoodProduction		=	0		;int
-StoneProduction		=	0		;int
-ManaProduction		=	12		;int
+Icon			=	Portraits\Buildings\Dark_Chasm_portrait.tgr
+;ConstructionAnimation 	= Art\Objects\Buildings\Animations\counciloutpost_build.tgr
+;DestructionAnimation 	= Art\Objects\Buildings\Animations\counciloutpost_Destroyed.tgr
+ManaProduction			=	20		;int
 booty_min	 = 0
 booty_max	 = 0
 
+
 [BaseData]
-ControlRange		=   	9			;tiles (float)
-SupplyRange		=	24			; tiles (float)
-CompanySize		=	6			; militia per company
-MaxMilitia		=	18			; total max militia
-MilitiaType		=	Shadow_Militia		; militia type
-MilitiaGrowth		=	0.025			; points per second
-CompanyLimit		=	10			; companies allowed per settlement
-
-[SettlementData]
-ComponentLimit		=	7
-GoldLimitModifier		= 500
-
-;[NotUsed]
-;ObjectDisplay		=	1	;enumeration in button.h	
-;ActionScroll   	=  	1	;enumeration in button.h
-;BuildSound		= 	audio\Game\construction.wav
+ControlRange			=   	8		;tiles (float)
+SupplyRange			=	20		; tiles (float)
+MilitiaStart			=	24
+CompanySize			=	6		; militia per company
+MaxMilitia			=	24		; total max militia
+MilitiaType			=	Shadeling	; militia type
+MilitiaGrowth			=	0		; points per second
 
 ;Animations are drawn in order of declaration in INI file (1,2,3,...)
 [AnimationData]
 NumAnimations = 1
 
 [Animation0]
-FrameRate = 200		;ms
-alwaysdraw = 1
+FrameRate = 180		;ms
 Random = 0			;should the animation cycle be randomly started
-Frames = 12
-BaseFrame = 0
+Frames = 10
+
+
+

--- a/TGX Files/Data/ObjectData/buildings/NEW_AHRIMAN_CITADEL.INI
+++ b/TGX Files/Data/ObjectData/buildings/NEW_AHRIMAN_CITADEL.INI
@@ -1,0 +1,60 @@
+[ObjectData]
+ProperName = STRING_2154_Ahriman_s_Citadel
+Class			= 	1	;enumeration list(int)
+Sprite			=   buildings\Ahriman_Citadel.tgr
+BoundingRadius		=	6	;tiles (float)
+ClearOut		=   	4	;tiles
+MaxHitPoints		=	10000	;health rating(float)
+DetectionRadius		=	30	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	9999	;seconds(float)
+Captureable		=	0
+
+Description = STRING_4628_Ahriman_s_newly_risen_citadel_floats_menacingly_above_the_corrupt_earth__The_focal_point_of_his_power_is_hidden_deep_within_its_shadowy_halls_
+Faction			=	Ceyah
+Weight			=	0
+
+SelectionSound1	= 	Game\select_mana_mine.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\ahriman_citadel_portrait.tgr
+DestructionAnimation = Art\Objects\Buildings\Animations\Ceyah_citadel_destroy.tgr
+;NameList		=	CeyahCities
+IconIndex 		= 	8
+GoldProduction		=	25		;int
+IronProduction		=	0		;int
+WoodProduction		=	0		;int
+StoneProduction		=	0		;int
+ManaProduction		=	12		;int
+booty_min	 = 0
+booty_max	 = 0
+
+[BaseData]
+ControlRange		=   	9			;tiles (float)
+SupplyRange		=	24			; tiles (float)
+CompanySize		=	6			; militia per company
+MaxMilitia		=	18			; total max militia
+MilitiaType		=	Shadow_Militia		; militia type
+MilitiaGrowth		=	0.025			; points per second
+CompanyLimit		=	10			; companies allowed per settlement
+
+[SettlementData]
+ComponentLimit		=	7
+GoldLimitModifier		= 500
+
+;[NotUsed]
+;ObjectDisplay		=	1	;enumeration in button.h	
+;ActionScroll   	=  	1	;enumeration in button.h
+;BuildSound		= 	audio\Game\construction.wav
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 0			;should the animation cycle be randomly started
+Frames = 12
+BaseFrame = 0

--- a/TGX Files/Data/ObjectData/buildings/NEW_AHRIMAN_CITADEL.INI
+++ b/TGX Files/Data/ObjectData/buildings/NEW_AHRIMAN_CITADEL.INI
@@ -1,36 +1,34 @@
 [ObjectData]
-ProperName = STRING_2176_Dark_Chasm
-Class				= 	2	;enumeration list(int)
+ProperName = Ancient Abyss
+Class				= 	3	;enumeration list(int)
 Sprite				=   buildings\Dark_Chasm.tgr
 BoundingRadius			=	3	;tiles (float)
 ClearOut			=   	2	;tiles
-MaxHitPoints			=	10000	;health rating(float)
+MaxHitPoints			=	1500	;health rating(float)
 DetectionRadius			=	16	;tiles(float)
 Defense				=	0	;number (float)
 DieTime				=	1
 RotTime			=	120	;seconds(float)
-Description			=	STRING_3009_A_great_rent_in_the_earth_pulsating_with_dark_energy__the_dark_chasm_is_a_breeding_ground_for_creatures_of_evil_
-CostGold			=	0
+Description			=	A remnant of a Cataclysm in an age long past, infested with evil protecting their forgotten treasures. Only the prepared or foolish would dare venture near it.
+Weight			=	4
 
 DeathSound1		=	Game\building_destroyed.wav
 SelectionSound1		= 	Game\select_mana_mine.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\Dark_Chasm_portrait.tgr
-;ConstructionAnimation 	= Art\Objects\Buildings\Animations\counciloutpost_build.tgr
-;DestructionAnimation 	= Art\Objects\Buildings\Animations\counciloutpost_Destroyed.tgr
-ManaProduction			=	20		;int
-booty_min	 = 0
-booty_max	 = 0
+booty_min	 = 150
+booty_max	 = 175
+ExtraReward = 1
 
 
 [BaseData]
-ControlRange			=   	8		;tiles (float)
-SupplyRange			=	20		; tiles (float)
-MilitiaStart			=	24
-CompanySize			=	6		; militia per company
-MaxMilitia			=	24		; total max militia
-MilitiaType			=	Shadeling	; militia type
+ControlRange			=   	6		;tiles (float)
+SupplyRange			=	0		; tiles (float)
+MilitiaStart			=	1
+CompanySize			=	1		; militia per company
+MaxMilitia			=	1		; total max militia
+MilitiaType			=	Shadow_Lord	; militia type
 MilitiaGrowth			=	0		; points per second
 
 ;Animations are drawn in order of declaration in INI file (1,2,3,...)

--- a/TGX Files/Data/ObjectData/units/SHADOW_LORD.INI
+++ b/TGX Files/Data/ObjectData/units/SHADOW_LORD.INI
@@ -11,7 +11,7 @@ UpkeepGold		=	0			;int
 UpkeepIron		=	0			;int
 UpkeepMana		=	0			;int
 BuildTime		=	10			;seconds(float)
-Defense			=	16			;number (float)
+Defense			=	14			;number (float)
 DieTime			= 	2
 
 Moveable		=	1			;BOOLEAN
@@ -46,9 +46,9 @@ Spell0 			= Summon Shadow Demons
 Spell1          = Lethargy
 
 [ElementBonus]
-MELEE_UNHOLY_DAMAGE		= 10
-DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.5
+ATTACK_BONUS_TO_NONSHADOW		= 10
 REVERSE_DAMAGE_WHEN_HIT		= 8
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.5
 DAMAGE_TAKEN_FROM_RANGED	= .5
 IMMUNITY_TO_ENCHANTMENT		= 1
 IGNORE_TERRAIN_BONUS 		= 1
@@ -61,13 +61,15 @@ Berserk			= 1
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
-ReloadTime		=	0.5		;seconds(float)
+ReloadTime		=	1.5		;seconds(float)
 AttackRange		=	1.25		;tiles (float)
-AttackType		=	MELEE	;enumeration list(int)	
-Damage			=	50		;number (float)
+AttackType		=	Projectile	;enumeration list(int)
+Projectile      =   maelstrom_blast	
+Damage			=	60		;number (float)
 DamageType		=	MAGIC
+AreaRadius      =   1.5
 Sound1			= 	Game\shadow_lord_attack.wav
-Animation = 0
+Animation       = 0
 
 [Attack2]
 AttackTime		=	1			; seconds(float) per animation cycle


### PR DESCRIPTION
### _Changelog:_

Added Ancient Abyss.

- Spawn weight of 4 for random maps
- Rewards between 150 and 175 gold
- Has a chance of giving an extra reward (like a tech, if it's enabled)
- Guard/control zone radius of 6

### Units:

Shadow Lord:

Other changes from Kohan-Citadel/kohangold-KG-#76 still apply

	Decreased DV from 16 to 14
	Increased AV from 50 to 60
	Attack speed decreased from 100% to 60% (1.5 seconds to 2.5 seconds)
	Attack type changed to projectile, 1.25 range.
	Attacks have an area radius of 1.5 (area damage)
	
	Unholy damage 10 changed to Lightbane 10 (extra unholy damage can't apply to ranged attacks)

