### PR TITLE
Sarai rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SARAI_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SARAI_JAVIDAN.INI
@@ -70,7 +70,6 @@ DAMAGE_TAKEN_FROM_UNHOLY = 0.75
 MaxHitPoints		=	520
 
 [SpellData1]
-MaxMana 		=	70
 
 [Attack0Data1]
 Damage			=	38
@@ -78,7 +77,8 @@ Damage			=	38
 [ElementBonus1]
 
 [SupportBonus1]
-DEFENSE_BONUS_VS_ANY = 0
+ATTACK_BONUS_TO_SHADOW = 2
+DAMAGE_TAKEN_FROM_UNHOLY = 0.75
 
 
 ;==========Restored==========

--- a/TGX Files/Data/ObjectData/Heroes/SARAI_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SARAI_JAVIDAN.INI
@@ -107,16 +107,17 @@ DAMAGE_TAKEN_FROM_UNHOLY = 0.75
 MaxHitPoints		=	700
 
 [SpellData3]
-Spell0			=	Spirit of Battle
 
 [Attack0Data3]
 Damage			=	42
 
 [ElementBonus3]
-ATTACK_BONUS_TO_SHADOW		= 6
 
 [SupportBonus3]
-
+MORALE_LOSS_RATE_BONUS = 0.8
+ATTACK_BONUS_TO_ANY = 4
+ATTACK_BONUS_TO_SHADOW = 4
+DAMAGE_TAKEN_FROM_UNHOLY = 0.75
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/SARAI_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SARAI_JAVIDAN.INI
@@ -88,14 +88,17 @@ MaxHitPoints		=	610
 
 [SpellData2]
 Spell1			=	Renewal
-ManaRegenerationRate 	=	4
 
 [Attack0Data2]
+Damage			=	40
 
 [ElementBonus2]
-ATTACK_BONUS_TO_SHADOW		= 4
 
 [SupportBonus2]
+MORALE_LOSS_RATE_BONUS = 0.9
+ATTACK_BONUS_TO_ANY = 2
+ATTACK_BONUS_TO_SHADOW = 3
+DAMAGE_TAKEN_FROM_UNHOLY = 0.75
 
 
 ;==========Ascended===========

--- a/TGX Files/Data/ObjectData/Heroes/SARAI_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SARAI_JAVIDAN.INI
@@ -37,7 +37,7 @@ Description = STRING_2408_Sarai_was_well_known_in_Kohan_society_for_her_compassi
 
 [SpellData]
 MaxMana 		=	60 	;the max amount that mana can be for the unit
-ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
+ManaRegenerationRate 	=	4	;the amount of mana that gets regenerated sec.
 Spell0			=	Protection
 Spell1			=	Recovery
 
@@ -61,7 +61,7 @@ AttackType		=	CAST		; enumeration list (int)
 [ElementBonus]
 
 [SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
+DAMAGE_TAKEN_FROM_UNHOLY = 0.75
 
 
 ;==========Enlightened==========

--- a/TGX Files/Data/ObjectData/Heroes/SARAI_JAVIDAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SARAI_JAVIDAN.INI
@@ -23,11 +23,6 @@ SelectionSound2		=	Game\f_hero5_select_good.wav
 CommandSound1		=	Game\f_hero5_command.wav
 CommandSound2		=	Game\f_hero5_command_good.wav
 
-[ElementBonus]
-
-[SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Priestess_icon.tgr
@@ -46,10 +41,6 @@ ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Protection
 Spell1			=	Recovery
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0047_Sarai_Marusek
-
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
@@ -67,44 +58,63 @@ DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 
+[ElementBonus]
+
+[SupportBonus]
+DEFENSE_BONUS_VS_ANY = -1
+
+
+;==========Enlightened==========
+
 [Level1]
 MaxHitPoints		=	520
-
-[Level2]
-MaxHitPoints		=	610
-
-[Level3]
-MaxHitPoints		=	700
-
-[Attack0Data1]
-Damage			=	38
-
-[Attack0Data2]
-
-[Attack0Data3]
-Damage			=	42
 
 [SpellData1]
 MaxMana 		=	70
 
-[SpellData2]
-Spell1			=	Renewal
-ManaRegenerationRate 	=	4
-
-[SpellData3]
-Spell0			=	Spirit of Battle
+[Attack0Data1]
+Damage			=	38
 
 [ElementBonus1]
 
 [SupportBonus1]
 DEFENSE_BONUS_VS_ANY = 0
 
+
+;==========Restored==========
+
+[Level2]
+MaxHitPoints		=	610
+
+[SpellData2]
+Spell1			=	Renewal
+ManaRegenerationRate 	=	4
+
+[Attack0Data2]
+
 [ElementBonus2]
 ATTACK_BONUS_TO_SHADOW		= 4
 
 [SupportBonus2]
 
+
+;==========Ascended===========
+
+[Level3]
+MaxHitPoints		=	700
+
+[SpellData3]
+Spell0			=	Spirit of Battle
+
+[Attack0Data3]
+Damage			=	42
+
 [ElementBonus3]
 ATTACK_BONUS_TO_SHADOW		= 6
 
 [SupportBonus3]
+
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0047_Sarai_Marusek


### PR DESCRIPTION
* #107 
### **_Changelog:_**
### All Levels:
```
Added Unholy Resistance (Provided) 75%
```
### Awakened:
```
Increased Mana Regeneration Rate from 3 to 4
Removed DV (Provided) -1
```
### Enlightened:
```
Reduced Max Mana from 70 to 60
Increased Mana Regeneration Rate from 3 to 4
Removed DV (Provided) +0
Added Shadowbane (Provided) +2
```
### Restored:
```
Increased AV from 38 to 40
Removed Shadowbane (Personal) +4
Added Courageous 90%
Added AV (Provided) +2
Added Shadowbane (Provided) +3
```
### Ascended:
```
Replaced Spell 'Spirit of Battle' with Spell 'Protection'
Added Courageous 80%
Added AV (Provided) +4
Added Shadowbane (Provided) +4
Removed Shadowbane (Personal) +6
```