### PR TITLE
Lazarus rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/LAZARUS.INI
+++ b/TGX Files/Data/ObjectData/Heroes/LAZARUS.INI
@@ -9,7 +9,7 @@ CostGold		=	0			;int
 UpkeepGold		=	0			;int
 UpkeepMana		=	0			;int
 BuildTime		=	0			;seconds(float)
-Defense			=	10			;number (float)
+Defense			=	8			;number (float)
 DieTime			=	1			;seconds(float)
 Faction			=	Ceyah
 
@@ -40,7 +40,7 @@ Description = STRING_2394_Lazarus_is_a_man_wholly_dedicated_to_the_power_of_the_
 [SpellData]
 MaxMana 		=	60 	;the max amount that mana can be for the unit
 ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
-Spell0			=	Shadow's Blessing
+Spell0			=	Shadow's Blessing ;'
 Spell1			=	Lethargy
 
 [Attack1]

--- a/TGX Files/Data/ObjectData/Heroes/LAZARUS.INI
+++ b/TGX Files/Data/ObjectData/Heroes/LAZARUS.INI
@@ -43,16 +43,6 @@ ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Shadow's Blessing
 Spell1			=	Lethargy
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0045_Lazarus
-
-[ElementBonus]
-
-[SupportBonus]
-
-[CompanyData]
-
 [Attack1]
 AttackTime		=	1			; seconds(float) per animation cycle
 DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
@@ -71,45 +61,62 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation		=	1
 
+[ElementBonus]
+
+[SupportBonus]
+
+
+;==========Enlightened===========
+
 [Level1]
 MaxHitPoints		=	560
 AttachedFX0		=	orange_sparkle
 
-[Level2]
-MaxHitPoints		=	690
-AttachedFX0		=	orange_sparkle
-
-[Level3]
-MaxHitPoints		=	820
-AttachedFX0		=	orange_sparkle
+[SpellData1]
 
 [Attack0Data1]
 Damage			=	36
-
-[Attack0Data2]
-Damage			=	42
-
-[Attack0Data3]
-
-[SpellData1]
-
-[SpellData2]
-Spell1			=	Vulnerability
-
-[SpellData3]
 
 [ElementBonus1]
 REVERSE_DAMAGE_WHEN_HIT		= 6
 
 [SupportBonus1]
 
+
+;===========Restored==========
+
+[Level2]
+MaxHitPoints		=	690
+AttachedFX0		=	orange_sparkle
+
+[SpellData2]
+Spell1			=	Vulnerability
+
+[Attack0Data2]
+Damage			=	42
+
 [ElementBonus2]
 REVERSE_DAMAGE_WHEN_HIT		= 12
 
 [SupportBonus2]
+
+
+;=========Ascended==========
+
+[Level3]
+MaxHitPoints		=	820
+AttachedFX0		=	orange_sparkle
+
+[SpellData3]
+
+[Attack0Data3]
 
 [ElementBonus3]
 REVERSE_DAMAGE_WHEN_HIT		= 18
 
 [SupportBonus3]
 
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0045_Lazarus

--- a/TGX Files/Data/ObjectData/Heroes/LAZARUS.INI
+++ b/TGX Files/Data/ObjectData/Heroes/LAZARUS.INI
@@ -108,16 +108,18 @@ REVERSE_DAMAGE_WHEN_HIT = 4
 
 [Level3]
 MaxHitPoints		=	820
-AttachedFX0		=	orange_sparkle
+;AttachedFX0		=	orange_sparkle
 
 [SpellData3]
 
 [Attack0Data3]
 
 [ElementBonus3]
-REVERSE_DAMAGE_WHEN_HIT		= 18
+ATTACK_BONUS_TO_NONSHADOW = 6
 
 [SupportBonus3]
+MELEE_UNHOLY_DAMAGE = 2
+REVERSE_DAMAGE_WHEN_HIT = 6
 
 
 [HeroData]

--- a/TGX Files/Data/ObjectData/Heroes/LAZARUS.INI
+++ b/TGX Files/Data/ObjectData/Heroes/LAZARUS.INI
@@ -89,7 +89,7 @@ REVERSE_DAMAGE_WHEN_HIT = 2
 
 [Level2]
 MaxHitPoints		=	690
-AttachedFX0		=	orange_sparkle
+;AttachedFX0		=	orange_sparkle
 
 [SpellData2]
 Spell1			=	Vulnerability
@@ -98,9 +98,10 @@ Spell1			=	Vulnerability
 Damage			=	42
 
 [ElementBonus2]
-REVERSE_DAMAGE_WHEN_HIT		= 12
+ATTACK_BONUS_TO_NONSHADOW = 4
 
 [SupportBonus2]
+REVERSE_DAMAGE_WHEN_HIT = 4
 
 
 ;=========Ascended==========

--- a/TGX Files/Data/ObjectData/Heroes/LAZARUS.INI
+++ b/TGX Files/Data/ObjectData/Heroes/LAZARUS.INI
@@ -70,7 +70,8 @@ Animation		=	1
 
 [Level1]
 MaxHitPoints		=	560
-AttachedFX0		=	orange_sparkle
+Defense				=	10
+;AttachedFX0		=	orange_sparkle
 
 [SpellData1]
 
@@ -78,9 +79,10 @@ AttachedFX0		=	orange_sparkle
 Damage			=	36
 
 [ElementBonus1]
-REVERSE_DAMAGE_WHEN_HIT		= 6
+ATTACK_BONUS_TO_NONSHADOW = 2
 
 [SupportBonus1]
+REVERSE_DAMAGE_WHEN_HIT = 2
 
 
 ;===========Restored==========


### PR DESCRIPTION
* #102
### **_Changelog:_**
### Awakened:
```
Reduced DV from 10 to 8
```
### Enlightened:
```
Removed Reverse Damage (Personal) +6
Added Lightbane (Personal) +2
Added Reverse Damage (Provided) +2
Removed AttachedFX 'orange_sparkle'
```
### Restored:
```
Removed Reverse Damage (Personal) +12
Added Lightbane (Personal) +4
Added Reverse Damage (Provided) +4
Removed AttachedFX 'orange_sparkle'
```
### Ascended:
```
Removed Reverse Damage (Personal) +18
Added Lightbane (Personal) +6
Added Reverse Damage (Provided) +6
Added Unholy Damage (Provided) +2
Removed AttachedFX 'orange_sparkle'
```