### PR TITLE
Jilla Jannat Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/JILLA_JANNAT.ini
+++ b/TGX Files/Data/ObjectData/Heroes/JILLA_JANNAT.ini
@@ -101,8 +101,10 @@ DEFENSE_BONUS_VS_ARCHER     =   4
 MORALE_BONUS                =   6
 
 [Level3]
+MaxHitPoints                =   630
 
 [SpellData3]
+ManaRegenerationRate        =   5
 
 [Attack0Data3]
 Damage                      =   44
@@ -110,6 +112,7 @@ Damage                      =   44
 [ElementBonus3]
 
 [SupportBonus3]
+ATTACK_BONUS_TO_ANY         =   2
 DEFENSE_BONUS_VS_ANY        =   4
 DEFENSE_BONUS_VS_ARCHER     =   6
 MORALE_BONUS                =   6

--- a/TGX Files/Data/ObjectData/Heroes/JILLA_JANNAT.ini
+++ b/TGX Files/Data/ObjectData/Heroes/JILLA_JANNAT.ini
@@ -85,6 +85,7 @@ MORALE_BONUS                =   4
 MaxHitPoints                =   570
 
 [SpellData2]
+MaxMana                     =   70
 ManaRegenerationRate        =   4
 Spell0                      =   Magic Vulnerability
 
@@ -94,7 +95,8 @@ Damage                      =   40
 [ElementBonus2]
 
 [SupportBonus2]
-DEFENSE_BONUS_VS_ANY        =   4
+ATTACK_BONUS_TO_ANY         =   2
+DEFENSE_BONUS_VS_ANY        =   3
 DEFENSE_BONUS_VS_ARCHER     =   4
 MORALE_BONUS                =   6
 

--- a/TGX Files/Data/ObjectData/Heroes/JILLA_JANNAT.ini
+++ b/TGX Files/Data/ObjectData/Heroes/JILLA_JANNAT.ini
@@ -4,7 +4,7 @@ Class                       =   2
 Sprite                      =   units\sorceress.tgr
 BoundingRadius              =   0.25
 RotTime                     =   30
-MaxHitPoints                =   350
+MaxHitPoints                =   380
 CostGold                    =   0
 BuildTime                   =   5
 DetectionRadius             =   100
@@ -49,7 +49,7 @@ DamagePoint                 =   0.5
 ReloadTime                  =   0.5
 AttackRange                 =   0.75
 AttackType                  =   Melee
-Damage                      =   36
+Damage                      =   34
 DamageType                  =   Magic
 MoraleDamage                =   0
 MoraleDamageType            =   Normal
@@ -66,7 +66,6 @@ MoraleDamageType            =   Normal
 [ElementBonus]
 
 [SupportBonus]
-DEFENSE_BONUS_VS_ANY        =   -1
 
 [Level1]
 MaxHitPoints                =   460

--- a/TGX Files/Data/ObjectData/Heroes/JILLA_JANNAT.ini
+++ b/TGX Files/Data/ObjectData/Heroes/JILLA_JANNAT.ini
@@ -68,17 +68,16 @@ MoraleDamageType            =   Normal
 [SupportBonus]
 
 [Level1]
-MaxHitPoints                =   460
+MaxHitPoints                =   450
 
 [SpellData1]
 Spell1                      =   Conflagration
 
 [Attack0Data1]
-
+Damage                      =   36
 [ElementBonus1]
 
 [SupportBonus1]
-DEFENSE_BONUS_VS_ANY        =   0
 DEFENSE_BONUS_VS_ARCHER     =   2
 MORALE_BONUS                =   4
 


### PR DESCRIPTION
### _Changelog:_

### Awakened

	Increased HP from 350 to 380
	Decreased AV from 36 to 34
	
	Removed -1 DV (Provided)

### Enlightened

	Decreased HP from 460 to 450
	Retained 36 AV
	
	Removed 0 DV (Provided)
### Restored

	Increased MaxMana from 60 to 70
	
	Decreased Bonus DV from 4 to 3 (Provided)
	Added Bonus AV 2 (Provided)
	
### Ascended

	Increased HP from 570 to 630
	
	Increased Mana Regen from  4 to 5
	
	Retained Bonus  AV 2 from Restored (Provided)
