### PR TITLE
Naava Daishan Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/NAAVA_DAISHAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/NAAVA_DAISHAN.INI
@@ -47,7 +47,7 @@ DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	0.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	30		;number (float)
+Damage			=	32		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\battle_priest_melee.wav
 Sound2			= 	Game\club2.wav
@@ -62,7 +62,6 @@ AttackType		=	CAST		; enumeration list (int)
 MELEE_HOLY_DAMAGE	= 2
 
 [SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
 
 [Level1]
 MaxHitPoints		=	500

--- a/TGX Files/Data/ObjectData/Heroes/NAAVA_DAISHAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/NAAVA_DAISHAN.INI
@@ -93,7 +93,7 @@ MELEE_HOLY_DAMAGE	= 4
 MELEE_HOLY_DAMAGE	= 2
 
 [Level3]
-MaxHitPoints		=	660
+MaxHitPoints		=	700
 
 [SpellData3]
 Spell1			=	Mystic Immunity
@@ -103,11 +103,11 @@ MaxMana 		=	70
 Damage			=	38
 
 [ElementBonus3]
-MELEE_HOLY_DAMAGE	= 8
+MELEE_HOLY_DAMAGE	= 4
 
 [SupportBonus3]
+DEFENSE_BONUS_VS_ANY	= 6
 MELEE_HOLY_DAMAGE	= 4
-DEFENSE_BONUS_VS_ANY	= 4
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/NAAVA_DAISHAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/NAAVA_DAISHAN.INI
@@ -78,17 +78,19 @@ MELEE_HOLY_DAMAGE	= 4
 [SupportBonus1]
 
 [Level2]
-MaxHitPoints		=	580
+MaxHitPoints		=	620
 
 [SpellData2]
 Spell0			=	True Healing
 
 [Attack0Data2]
+Damage          =   36
 
 [ElementBonus2]
-MELEE_HOLY_DAMAGE	= 6
+MELEE_HOLY_DAMAGE	= 4
 
 [SupportBonus2]
+MELEE_HOLY_DAMAGE	= 2
 
 [Level3]
 MaxHitPoints		=	660

--- a/TGX Files/Data/ObjectData/Heroes/NAAVA_DAISHAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/NAAVA_DAISHAN.INI
@@ -23,12 +23,6 @@ SelectionSound2		=	Game\f_hero3_select_good.wav
 CommandSound1		=	Game\f_hero3_command.wav
 CommandSound2		=	Game\f_hero3_command_good.wav
 
-[ElementBonus]
-MELEE_HOLY_DAMAGE	= 2
-
-[SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Priestess_icon.tgr
@@ -47,10 +41,6 @@ ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Heal
 Spell1			=	Protection
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0042_Naava_Daishan
-
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
@@ -68,32 +58,20 @@ DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 
+[ElementBonus]
+MELEE_HOLY_DAMAGE	= 2
+
+[SupportBonus]
+DEFENSE_BONUS_VS_ANY = -1
+
 [Level1]
 MaxHitPoints		=	500
-
-[Level2]
-MaxHitPoints		=	580
-
-[Level3]
-MaxHitPoints		=	660
-
-[Attack0Data1]
-Damage			=	34
-
-[Attack0Data2]
-
-[Attack0Data3]
-Damage			=	38
 
 [SpellData1]
 ManaRegenerationRate 	=	4
 
-[SpellData2]
-Spell0			=	True Healing
-
-[SpellData3]
-Spell1			=	Mystic Immunity
-MaxMana 		=	70
+[Attack0Data1]
+Damage			=	34
 
 [ElementBonus1]
 MELEE_HOLY_DAMAGE	= 4
@@ -101,10 +79,28 @@ MELEE_HOLY_DAMAGE	= 4
 [SupportBonus1]
 DEFENSE_BONUS_VS_ANY = 0
 
+[Level2]
+MaxHitPoints		=	580
+
+[SpellData2]
+Spell0			=	True Healing
+
+[Attack0Data2]
+
 [ElementBonus2]
 MELEE_HOLY_DAMAGE	= 6
 
 [SupportBonus2]
+
+[Level3]
+MaxHitPoints		=	660
+
+[SpellData3]
+Spell1			=	Mystic Immunity
+MaxMana 		=	70
+
+[Attack0Data3]
+Damage			=	38
 
 [ElementBonus3]
 MELEE_HOLY_DAMAGE	= 8
@@ -112,3 +108,7 @@ MELEE_HOLY_DAMAGE	= 8
 [SupportBonus3]
 MELEE_HOLY_DAMAGE	= 4
 DEFENSE_BONUS_VS_ANY	= 4
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0042_Naava_Daishan

--- a/TGX Files/Data/ObjectData/Heroes/NAAVA_DAISHAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/NAAVA_DAISHAN.INI
@@ -64,7 +64,7 @@ MELEE_HOLY_DAMAGE	= 2
 [SupportBonus]
 
 [Level1]
-MaxHitPoints		=	500
+MaxHitPoints		=	520
 
 [SpellData1]
 ManaRegenerationRate 	=	4
@@ -76,7 +76,6 @@ Damage			=	34
 MELEE_HOLY_DAMAGE	= 4
 
 [SupportBonus1]
-DEFENSE_BONUS_VS_ANY = 0
 
 [Level2]
 MaxHitPoints		=	580


### PR DESCRIPTION
### _Changelog:_

### Awakened
	
	AV from 30 to 32
	Removed -1 DV (Provided)
	
### Enlightened

	HP from 500 to 520
	
	Removed 0DV (Provided)
### Restored

	Increased HP from 580 to 620
	Increased AV from 34 to 36
	
	Decreased holy damage from 6 to 4 (Personal)
	
	Added holy damage 2 (Provided)
	
### Ascended

	Increased HP from 660 to 700
	
	Decreased holy damage from 8 to 4 (Personal)
	
	Increased Bonus DV from 4 to 6 (Provided)
