### PR TITLE
Sadira Bahhrum Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
@@ -23,11 +23,6 @@ SelectionSound2		=	Game\f_hero1_select_good.wav
 CommandSound1		=	Game\f_hero1_command.wav
 CommandSound2		=	Game\f_hero1_command_good.wav
 
-[ElementBonus]
-
-[SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
-
 [UnitData]
 Type			=	HERO
 Icon			=   Portraits\Unit Icons\Sorceress_icon.tgr
@@ -47,10 +42,6 @@ ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Blessing
 Spell1			=	Lightning
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0085_Sadira_Bahhrum
-
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
@@ -67,43 +58,52 @@ DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 
+[ElementBonus]
+
+[SupportBonus]
+DEFENSE_BONUS_VS_ANY = -1
+
 [Level1]
 MaxHitPoints		=	520
-
-[Level2]
-MaxHitPoints		=	610
-
-[Level3]
-MaxHitPoints		=	700
-;Technology		= SampleTech
-
-[Attack0Data1]
-
-[Attack0Data2]
-Damage			=	42
-
-[Attack0Data3]
 
 [SpellData1]
 ManaRegenerationRate 	=	5
 
-[SpellData2]
-Spell1			=	Heaven's Bolt
-
-[SpellData3]
-Spell0			=	True Blessing
+[Attack0Data1]
 
 [ElementBonus1]
 
 [SupportBonus1]
 DEFENSE_BONUS_VS_ANY = 0
 
+[Level2]
+MaxHitPoints		=	610
+
+[SpellData2]
+Spell1			=	Heaven's Bolt ;'
+
+[Attack0Data2]
+Damage			=	42
+
 [ElementBonus2]
 DEFENSE_BONUS_VS_SHADOW		= 3
 
 [SupportBonus2]
 
+[Level3]
+MaxHitPoints		=	700
+;Technology		= SampleTech
+
+[SpellData3]
+Spell0			=	True Blessing
+
+[Attack0Data3]
+
 [ElementBonus3]
 DEFENSE_BONUS_VS_SHADOW		= 6
 
 [SupportBonus3]
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0085_Sadira_Bahhrum

--- a/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
@@ -8,7 +8,7 @@ MaxHitPoints		=	430			;health rating(float)
 CostGold		=	0			;int
 BuildTime		=	5			;seconds(float)
 DetectionRadius		=	100			;movement points(float)
-Defense			=	10			;number (float)
+Defense			=	8			;number (float)
 Faction			=	Nationalist
 
 Moveable		=	1			;BOOLEAN

--- a/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
@@ -81,15 +81,17 @@ DEFENSE_BONUS_VS_SHADOW = 2
 MaxHitPoints		=	610
 
 [SpellData2]
-Spell1			=	Heaven's Bolt ;'
+MaxMana         =   70
+Spell0			=	Heaven's Gift ;'
 
 [Attack0Data2]
-Damage			=	42
+Damage			=	40
 
 [ElementBonus2]
-DEFENSE_BONUS_VS_SHADOW		= 3
 
 [SupportBonus2]
+DEFENSE_BONUS_VS_ANY        =   1
+DEFENSE_BONUS_VS_SHADOW		= 4
 
 [Level3]
 MaxHitPoints		=	700

--- a/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
@@ -61,20 +61,21 @@ AttackType		=	CAST		; enumeration list (int)
 [ElementBonus]
 
 [SupportBonus]
-DEFENSE_BONUS_VS_ANY = -1
 
 [Level1]
 MaxHitPoints		=	520
+Defense             =   10
 
 [SpellData1]
-ManaRegenerationRate 	=	5
+ManaRegenerationRate 	=	4
 
 [Attack0Data1]
+Damage                  =   38
 
 [ElementBonus1]
 
 [SupportBonus1]
-DEFENSE_BONUS_VS_ANY = 0
+DEFENSE_BONUS_VS_SHADOW = 2
 
 [Level2]
 MaxHitPoints		=	610

--- a/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
@@ -95,17 +95,19 @@ DEFENSE_BONUS_VS_SHADOW		= 4
 
 [Level3]
 MaxHitPoints		=	700
-;Technology		= SampleTech
 
 [SpellData3]
-Spell0			=	True Blessing
+Spell1			=	Forked Lightning
 
 [Attack0Data3]
+Damage                      =   44
 
 [ElementBonus3]
-DEFENSE_BONUS_VS_SHADOW		= 6
 
 [SupportBonus3]
+MORALE_RECOVERY_RATE_BONUS  =   1.1
+DEFENSE_BONUS_VS_ANY        =   2
+DEFENSE_BONUS_VS_SHADOW		= 4
 
 [HeroData]
 AwakenCost		=	50


### PR DESCRIPTION
### _Changelog:_
*   #106
### Awakened
	
	Decreased DV from 10 to 8
	
	Removed -1 DV (Provided)
	
### Enlightened

	Retained 10 DV
	Reduced Mana Regeneration from 5 to 4
	Increased AV from 34 to 38
	
	Removed 0 DV (Provided)
	Added Shadow Resist 2 (Provided)
	
### Restored
	
	Reduced AV from 42 to 40
	
	Retained Lightning Bolt (No Heaven's Bolt)
	Blessing replaced with Heaven's Gift
	
	Removed Shadow Resist3 (Personal)
	
	Added 1 DV (Provided)
	Added Shadow Resist 4 (Provided)
	
### Ascended
	
	Increased AV from 42 to 44
	
	Retained Heaven's Gift (No True Blessing)
	Lightning replaced with Forked Lightning
	
	Removed Shadow Resist 6 (Personal)
	
	Added Inspiration 110% (Provided)
	Added 2 DV (Provided)
	Added Shadow Resist4 (Provided)
