### PR TITLE
Addressed a typo

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SADIRA_BAHHRUM.INI
@@ -82,7 +82,7 @@ MaxHitPoints		=	610
 
 [SpellData2]
 MaxMana         =   70
-Spell0			=	Heaven's Gift ;'
+Spell0			=	Heavens Gift 
 
 [Attack0Data2]
 Damage			=	40


### PR DESCRIPTION
### _Changelog:_

Addressed a typo preventing the game from starting. While it may appear as Heaven's Gift in-game, it is actually Heavens Gift in the ini files.