### PR TITLE
Sebak Rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SEBAK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SEBAK.INI
@@ -40,8 +40,8 @@ CombatValue		= 15
 Description = STRING_4719_Sebak_is__simply_put__insane__He_is_prone_to_erratic_decisions_and_actions_too_chaotic_to_be_understood__Few_of_the_other_Ceyah_are_willing_to_deal_with_him_for_any_prolonged_length_of_time__He_has_even_been_known_to_fall_into_hysterical_fits_of_destruction__killing_his_own_followers_and_eventually_himself__His_amulet_is_often_lost_for_ages_before_another_poor_fool_awakens_him_in_hopes_of_a_new_ally_
 
 [SpellData]
-MaxMana 		=	60 	;the max amount that mana can be for the unit
-ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
+MaxMana 		=	55 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	2	;the amount of mana that gets regenerated sec.
 Spell0			=	Poison Cloud
 Spell1			=	Shadow's Blessing ;'
 
@@ -66,6 +66,9 @@ Animation		=	1
 [ElementBonus]
 
 [SupportBonus]
+ENTRENCHMENT_RATE_BONUS =   0.25
+ZONE_OF_CONTROL_BONUS   =   0.85
+ATTACK_BONUS_TO_ROUTED  =   4
 
 [Level1]
 MaxHitPoints		=	570

--- a/TGX Files/Data/ObjectData/Heroes/SEBAK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SEBAK.INI
@@ -74,6 +74,8 @@ ATTACK_BONUS_TO_ROUTED  =   4
 MaxHitPoints		=	570
 
 [SpellData1]
+MaxMana             =   60
+ManaRegenerationRate    =   3
 
 [Attack0Data1]
 Damage			=	38
@@ -81,7 +83,9 @@ Damage			=	38
 [ElementBonus1]
 
 [SupportBonus1]
-ATTACK_BONUS_TO_ROUTED		= 2
+ENTRENCHMENT_RATE_BONUS =   0.25
+ZONE_OF_CONTROL_BONUS   =   0.85
+ATTACK_BONUS_TO_ROUTED  =   6
 
 [Level2]
 MaxHitPoints		=	710

--- a/TGX Files/Data/ObjectData/Heroes/SEBAK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SEBAK.INI
@@ -43,17 +43,7 @@ Description = STRING_4719_Sebak_is__simply_put__insane__He_is_prone_to_erratic_d
 MaxMana 		=	60 	;the max amount that mana can be for the unit
 ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Poison Cloud
-Spell1			=	Shadow's Blessing
-
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_4720_Sebak
-
-[ElementBonus]
-
-[SupportBonus]
-
-[CompanyData]
+Spell1			=	Shadow's Blessing ;'
 
 [Attack1]
 AttackTime		=	1			; seconds(float) per animation cycle
@@ -73,42 +63,50 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation		=	1
 
+[ElementBonus]
+
+[SupportBonus]
+
 [Level1]
 MaxHitPoints		=	570
 
-[Level2]
-MaxHitPoints		=	710
-
-[Level3]
-MaxHitPoints		=	840
-Defense			=	10
+[SpellData1]
 
 [Attack0Data1]
 Damage			=	38
-
-[Attack0Data2]
-Damage			=	44
-
-[Attack0Data3]
-
-[SpellData1]
-
-[SpellData2]
-Spell1			=	Unholy Strength
-
-[SpellData3]
 
 [ElementBonus1]
 
 [SupportBonus1]
 ATTACK_BONUS_TO_ROUTED		= 2
 
+[Level2]
+MaxHitPoints		=	710
+
+[SpellData2]
+Spell1			=	Unholy Strength
+
+[Attack0Data2]
+Damage			=	44
+
 [ElementBonus2]
 
 [SupportBonus2]
 ATTACK_BONUS_TO_ROUTED		= 4
 
+[Level3]
+MaxHitPoints		=	840
+Defense			=	10
+
+[SpellData3]
+
+[Attack0Data3]
+
 [ElementBonus3]
 
 [SupportBonus3]
 ATTACK_BONUS_TO_ROUTED		= 6
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_4720_Sebak

--- a/TGX Files/Data/ObjectData/Heroes/SEBAK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SEBAK.INI
@@ -91,15 +91,17 @@ ATTACK_BONUS_TO_ROUTED  =   6
 MaxHitPoints		=	710
 
 [SpellData2]
-Spell1			=	Unholy Strength
+Spell1			=	Immortal Fury
 
 [Attack0Data2]
-Damage			=	44
+Damage			=	40
 
 [ElementBonus2]
 
 [SupportBonus2]
-ATTACK_BONUS_TO_ROUTED		= 4
+ENTRENCHMENT_RATE_BONUS =   0.25
+ZONE_OF_CONTROL_BONUS   =   0.85
+ATTACK_BONUS_TO_ROUTED  =   8
 
 [Level3]
 MaxHitPoints		=	840

--- a/TGX Files/Data/ObjectData/Heroes/SEBAK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SEBAK.INI
@@ -104,17 +104,22 @@ ZONE_OF_CONTROL_BONUS   =   0.85
 ATTACK_BONUS_TO_ROUTED  =   8
 
 [Level3]
-MaxHitPoints		=	840
+MaxHitPoints		=	810
 Defense			=	10
 
 [SpellData3]
 
 [Attack0Data3]
+Damage			=	44
 
 [ElementBonus3]
+DAMAGE_TAKEN_FROM_MELEE     =   0.8
+DAMAGE_TAKEN_FROM_RANGED    =   0.5
 
 [SupportBonus3]
-ATTACK_BONUS_TO_ROUTED		= 6
+ENTRENCHMENT_RATE_BONUS =   0.25
+ZONE_OF_CONTROL_BONUS   =   0.85
+ATTACK_BONUS_TO_ROUTED  =   10
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -58,7 +58,7 @@ CasterStartEffect0 = None
 DestinationEffect0 = poison_cloud
 TargetLoopEffect0 = poison_cloud_fade
 BonusSection = PoisonCloudBonuses
-Duration = 30
+Duration = 25
 Projectile = spell_arrow
 Sound = spells\poison_cloud.wav
 


### PR DESCRIPTION
### _Changelog:_
* #125 
* #126 Duration reduced from 30 to 25
### Awakened
	
	Reduced Max mana from 60 to 55
	Reduced Mana regen from 3 to 2
	 
	Added Slow entrenchment 25% (Provided)
	Added Poor Control 85% (Provided)
	Added Bloodlust 4 (Provided) 
	
### Enlightened

	Retained max mana 60
	Retained mana regen 3
	
	Added Slow entrenchment 25% (Provided)
	Added Poor Control 85% (Provided)
	Increased Bloodlust from 2 to 6 (Provided)
	
### Restored
	
	AV reduced from 44 to 40
	
	Shadow's Blessing replaced with Immortal Fury (No Unholy Strength)
	
	Added Slow entrenchment 25% (Provided)
	Added Poor Control 85% (Provided)
	Increased Bloodlust from 4 to 8 (Provided)
	
### Ascended
	
	Reduced HP from 840 to 810
	Retained AV 44

	Added Melee Resistance 80%
	Added Ranged Resistance 50%
	
	Added Slow entrenchment 25% (Provided)
	Added Poor Control 85% (Provided)
	Increased Bloodlust from 6 to 10 (Provided)
