### PR TITLE
Vulgari rework

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/VULGARI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VULGARI.INI
@@ -98,16 +98,15 @@ MELEE_UNHOLY_DAMAGE	= 4
 
 [Level3]
 MaxHitPoints		=	690
+Defense             =   10
 
 [SpellData3]
-Spell1			=	Unholy Strength
-ManaRegenerationRate 	=	4
 
 [Attack0Data3]
-Damage			=	36
+Damage			=	38
 
 [ElementBonus3]
-MELEE_UNHOLY_DAMAGE	= 4
+MELEE_UNHOLY_DAMAGE	= 6
 
 [SupportBonus3]
 

--- a/TGX Files/Data/ObjectData/Heroes/VULGARI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VULGARI.INI
@@ -38,9 +38,9 @@ CombatValue		= 15
 Description = STRING_2421_Vulgari_is_a_dangerous_Ceyah_mage__one_that_knows_no_limits_to_his_greed_and_avarice__He_will_let_no_one__not_even_the_Dark_Master__stand_in_his_way_when_he_decides_he_wants_something__Many_of_the_other_Ceyah_deal_with_him_very_carefully_so_as_not_to_be_perceived_as_an_obstacle_
 
 [SpellData]
-MaxMana 		=	60 	;the max amount that mana can be for the unit
+MaxMana 		=	50 	;the max amount that mana can be for the unit
 ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
-Spell0			=	Shadowshock
+Spell0			=	Shadowstun
 
 [Attack1]
 AttackTime		=	1			; seconds(float) per animation cycle
@@ -48,7 +48,7 @@ DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fi
 ReloadTime		=	1			; seconds (float)
 AttackRange		=	1			; tiles (float)
 AttackType		=	MELEE		; enumeration list (int)
-Damage			=	28		;number (float)
+Damage			=	30		;number (float)
 DamageType		=	MAGIC
 Sound1			=	spells\necro_attack.wav
 Animation		=	1	
@@ -61,6 +61,7 @@ AttackType		=	CAST		; enumeration list (int)
 Animation		=	0			; warmage animations are backwards in TGS
 
 [ElementBonus]
+MELEE_UNHOLY_DAMAGE         =   2
 
 [SupportBonus]
 

--- a/TGX Files/Data/ObjectData/Heroes/VULGARI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VULGARI.INI
@@ -69,12 +69,14 @@ MELEE_UNHOLY_DAMAGE         =   2
 MaxHitPoints		=	510
 
 [SpellData1]
+MaxMana         =   55
+Spell0			=	Shadowshock
 Spell1			=	Shadow's Blessing ;'
 
 [Attack0Data1]
+Damage              =   32
 
 [ElementBonus1]
-MELEE_UNHOLY_DAMAGE	= 2
 
 [SupportBonus1]
 

--- a/TGX Files/Data/ObjectData/Heroes/VULGARI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VULGARI.INI
@@ -84,13 +84,15 @@ Damage              =   32
 MaxHitPoints		=	600
 
 [SpellData2]
-Spell0			=	Summon Shadow Beasts
+MaxMana         =   60
+ManaRegenerationRate    =   4
+Spell0			=	Shadow's Sleep ;'
 
 [Attack0Data2]
-Damage			=	32
+Damage			=	36
 
 [ElementBonus2]
-MELEE_UNHOLY_DAMAGE	= 2
+MELEE_UNHOLY_DAMAGE	= 4
 
 [SupportBonus2]
 

--- a/TGX Files/Data/ObjectData/Heroes/VULGARI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/VULGARI.INI
@@ -42,16 +42,6 @@ MaxMana 		=	60 	;the max amount that mana can be for the unit
 ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
 Spell0			=	Shadowshock
 
-[HeroData]
-AwakenCost		=	50
-TranslatedName = STRING_0023_Vulgari
-
-[ElementBonus]
-
-[SupportBonus]
-
-[CompanyData]
-
 [Attack1]
 AttackTime		=	1			; seconds(float) per animation cycle
 DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
@@ -70,44 +60,52 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation		=	0			; warmage animations are backwards in TGS
 
+[ElementBonus]
+
+[SupportBonus]
+
 [Level1]
 MaxHitPoints		=	510
 
-[Level2]
-MaxHitPoints		=	600
-
-[Level3]
-MaxHitPoints		=	690
+[SpellData1]
+Spell1			=	Shadow's Blessing ;'
 
 [Attack0Data1]
-
-[Attack0Data2]
-Damage			=	32
-
-[Attack0Data3]
-Damage			=	36
-
-[SpellData1]
-Spell1			=	Shadow's Blessing
-
-[SpellData2]
-Spell0			=	Summon Shadow Beasts
-
-[SpellData3]
-Spell1			=	Unholy Strength
-ManaRegenerationRate 	=	4
 
 [ElementBonus1]
 MELEE_UNHOLY_DAMAGE	= 2
 
 [SupportBonus1]
 
+[Level2]
+MaxHitPoints		=	600
+
+[SpellData2]
+Spell0			=	Summon Shadow Beasts
+
+[Attack0Data2]
+Damage			=	32
+
 [ElementBonus2]
 MELEE_UNHOLY_DAMAGE	= 2
 
 [SupportBonus2]
 
+[Level3]
+MaxHitPoints		=	690
+
+[SpellData3]
+Spell1			=	Unholy Strength
+ManaRegenerationRate 	=	4
+
+[Attack0Data3]
+Damage			=	36
+
 [ElementBonus3]
 MELEE_UNHOLY_DAMAGE	= 4
 
 [SupportBonus3]
+
+[HeroData]
+AwakenCost		=	50
+TranslatedName = STRING_0023_Vulgari

--- a/TGX Files/Data/Spells.ini
+++ b/TGX Files/Data/Spells.ini
@@ -92,10 +92,10 @@ CasterStartEffect0 = None
 TargetDoCastEffect0 = shadowblessing
 TargetLoopEffect0 = lightning_fade
 Projectile = spell_arrow
-BonusSection = StunBonuses
+BonusSection = ShockBonuses
 Sound = spells\paralyze.wav
 
-[StunBonuses]
+[ShockBonuses]
 PARALYZE_BONUS	= 1
 
 

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -941,7 +941,7 @@ ATTACK_BONUS_TO_ANY		=	4
 [48]
 Name = Spectral Veil
 ProperName = Spectral Veil
-Description = The black magicks of this spell temporarily turn the caster's comrades into ghostly shades, immaterial, and virtually immune to the weapons of mortals.
+Description = The black magicks of this spell temporarily turn the caster's comrades into ghostly shades, immaterial, and virtually immune to the weapons of mortals. ;'
 Mana_Cost = 25
 Type = Group
 Offensive =	0	;DEFENSIVE or OFFENSIVE
@@ -953,3 +953,24 @@ TargetDoCastEffect0 = spectral_form
 TargetLoopEffect0 = spectral_fade
 Duration = 90
 Sound = spells\spectral_form.wav
+
+[49]
+Name = Shadowstun
+ProperName = Shadowstun
+Description = STRING_1416_Caster_throws_a_blast_of_evil_energies_that_stun_all_who_are_hit_
+Mana_Cost = 35
+Type = Single
+Offensive =	1	;DEFENSIVE or OFFENSIVE
+AreaRadius = 1
+Duration = 4
+Range = 10
+Morale = 0
+CasterStartEffect0 = None
+TargetDoCastEffect0 = shadowblessing
+TargetLoopEffect0 = lightning_fade
+Projectile = spell_arrow
+BonusSection = StunBonuses
+Sound = spells\paralyze.wav
+
+[StunBonuses]
+PARALYZE_BONUS	= 1


### PR DESCRIPTION
* #111 #128 

### _Changelog:_

### Awakened
	
	Increased AV from 28 to 30
	Reduced MaxMana from 60 to 50
	Shadowshock changed to Shadowstun
	
	Added unholy damage 2 (Personal)
	
### Enlightened
	
	Increased AV from 28 to 32
	Reduced Max mana from 60 to 55
	Retains Shadowshock
	
	
### Restored
	
	Increased AV from 32 to 36
	
	Retains Max Mana of 60
	Increased mana regen from 3 to 4
	Summon Shadow Beasts changed to Shadow's Sleep
	
	Increased unholy damage from 2 to 4 (Personal)
	
### Ascended
	Increased DV from 8 to 10
	Increased AV from 36 to 38
	
	Retains Shadow's Blessing (No Unholy Strength)
	
	Increased unholy damage from 4 to 6 (Personal)
