### PR TITLE
Adjustments to previously reworked Royalist heroes

### DIFF
--- a/TGX Files/Data/EFFECTDATA/Emitters/BLUE_SPARKLEFX.INI
+++ b/TGX Files/Data/EFFECTDATA/Emitters/BLUE_SPARKLEFX.INI
@@ -1,0 +1,12 @@
+;this ini controls the movement of the 2 emitters
+;this ini specifies the actual emitter to use in AdditionalFX
+[FXData]
+Class =		1	;fireball
+Lifetime =  5	; age of emitter (game seconds)
+Looping  =  0	;does the animation loop
+AdditionalFX = blue_sparkle_trailer
+
+[VariableData]
+variable_data_1	=	.17;.16		;wave width in world coordinates
+variable_data_2	=	2.0		;waves per second
+variable_data_3	= 	0		;allow screen blend

--- a/TGX Files/Data/EFFECTDATA/Emitters/BLUE_SPARKLE_TRAILER.INI
+++ b/TGX Files/Data/EFFECTDATA/Emitters/BLUE_SPARKLE_TRAILER.INI
@@ -1,0 +1,33 @@
+[FXData]
+Class =		0	;emitter
+Lifetime =           10			; age of emitter
+Offset_X =			;offset used only if particle type is defined as pixel below
+Offset_Y =			;otherwise the offset effect comes from the sprite hotspot
+
+[FXSpriteData]
+Sprite =		blue_balls_trailer.tgr
+
+[EmitterData]
+emission_rate		= 20			;particles per second
+
+[ParticleData]
+particle_type			=   0		; 0 -> sprite, 1 -> pixel
+lifetime_start			=   .3		;float
+lifetime_variance		=   .3		;float 
+expiration_age			=	0		;float
+height				=	100		;world_coordinates
+energy_start			=	5		;float
+energy_variance			=	1		;float
+weight_start			=	0		;float
+weight_variance			=	0		;float
+DrawType			=   Regular, ScreenBlend, AdditiveBlend, ColorScreenBlend
+SpecialBlendFrames		=   2		;this is the number of first frames to draw using screen , ColorScreen, or additive blend
+R						=	255		;RGB values are used only if draw type is ColorScreenBlend
+G						=	255		;if particle is a pixel, then this is the color of the pixel
+B						=	255
+
+
+[VariableData]
+variable_data_1	=	1		;fill in gaps
+variable_data_2	=	
+variable_data_3	= 	

--- a/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
@@ -84,6 +84,9 @@ MaxHitPoints		=	1250
 Defense             =   13
 
 [SpellData2]
+MaxMana             = 60
+ManaRegenerationRate    =   1
+Spell0              =   Grit
 
 [Attack0Data2]
 Damage			=	72
@@ -103,9 +106,7 @@ MaxHitPoints		=	1550
 Defense             =   14
 
 [SpellData3]
-MaxMana             = 60
-ManaRegenerationRate    =   1
-Spell0              =   Grit
+
 [Attack0Data3]
 Damage			=	80
 DamageType      =   Khaldunite

--- a/TGX Files/Data/ObjectData/Heroes/JORDAN_AVISHAI.INI
+++ b/TGX Files/Data/ObjectData/Heroes/JORDAN_AVISHAI.INI
@@ -55,12 +55,12 @@ AttackType		=	CAST		; enumeration list (int)
 Animation		= 	0		;animations are backwards
 
 [ElementBonus]
+ATTACK_BONUS_TO_MOUNTED		=   2
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus]
 ATTACK_BONUS_TO_ROUTED		=   -10
 DEFENSE_BONUS_VS_MOUNTED    =   2
-ATTACK_BONUS_TO_MOUNTED		=   2
 ATTACK_BONUS_TO_ARCHER		=   2
 
 [Level1]
@@ -72,13 +72,13 @@ MaxHitPoints		=	850
 Damage			=	52
 
 [ElementBonus1]
+ATTACK_BONUS_TO_MOUNTED		= 3
 DAMAGE_TAKEN_FROM_MELEE     =   0.9
 DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus1]
 ATTACK_BONUS_TO_ROUTED		= -10
 DEFENSE_BONUS_VS_MOUNTED    =   2
-ATTACK_BONUS_TO_MOUNTED		= 3
 ATTACK_BONUS_TO_ARCHER		= 3
 
 [Level2]
@@ -87,17 +87,16 @@ MaxHitPoints		=	1150
 [SpellData2]
 
 [Attack0Data2]
-Damage			=	58
+Damage			=	56
 
 [ElementBonus2]
+ATTACK_BONUS_TO_MOUNTED		= 4
 DAMAGE_TAKEN_FROM_MELEE     =   0.75
 DAMAGE_TAKEN_FROM_RANGED	= .5
-
 
 [SupportBonus2]
 ATTACK_BONUS_TO_ROUTED		= -10
 DEFENSE_BONUS_VS_MOUNTED    =   4
-ATTACK_BONUS_TO_MOUNTED		= 4
 DEFENSE_BONUS_VS_ARCHER     =   2
 ATTACK_BONUS_TO_ARCHER		= 4
 
@@ -111,11 +110,13 @@ Defense             =   14
 Damage			=	62
 
 [ElementBonus3]
+ATTACK_BONUS_TO_MOUNTED		= 6
+DAMAGE_TAKEN_FROM_MELEE     =   0.75
+DAMAGE_TAKEN_FROM_RANGED	= .5
 
 [SupportBonus3]
 ATTACK_BONUS_TO_ROUTED		= -10
 DEFENSE_BONUS_VS_MOUNTED    =   6
-ATTACK_BONUS_TO_MOUNTED		= 6
 DEFENSE_BONUS_VS_ARCHER     =   4
 ATTACK_BONUS_TO_ARCHER		= 6
 

--- a/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
@@ -57,7 +57,7 @@ MoraleDamageType                =   Normal
 [Attack2]
 AttackTime                      =   1
 DamagePoint                     =   0.5
-ReloadTime                      =   3
+ReloadTime                      =   1
 AttackType                      =   Cast
 Animation                       =   0
 DamageType                      =   Normal

--- a/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
@@ -4,7 +4,7 @@ Class                           =   2
 Sprite                          =   units\sorceress.tgr
 BoundingRadius                  =   0.25
 RotTime                         =   30
-MaxHitPoints                    =   480
+MaxHitPoints                    =   490
 CostGold                        =   0
 BuildTime                       =   0
 Defense                         =   8
@@ -37,8 +37,9 @@ Description                     =   Mausallas Bahram possesses an unusual beauty
 
 [SpellData]
 MaxMana                         =   50
-ManaRegenerationRate            =   2
+ManaRegenerationRate            =   3
 Spell0                          =   Storm Shield
+Spell1                          =   Cantrip
 
 [Attack1]
 Sound1                          =   Game\ranger_attack.wav
@@ -47,7 +48,7 @@ DamagePoint                     =   0.5
 ReloadTime                      =   0.5
 AttackRange                     =   1
 AttackType                      =   Melee
-Damage                          =   22
+Damage                          =   24
 DamageType                      =   Vorpal
 Animation                       =   1
 MoraleDamage                    =   0
@@ -64,30 +65,31 @@ MoraleDamage                    =   0
 MoraleDamageType                =   Normal
 
 [ElementBonus]
-DEFENSE_BONUS_VS_ARCHER         =   6
+DEFENSE_BONUS_VS_ARCHER         =   4
 
 [SupportBonus]
+DEFENSE_BONUS_VS_ARCHER         =   2
 MORALE_BONUS                    =   4
 
 [Level1]
-MaxHitPoints                    =   600
+MaxHitPoints                    =   610
 Defense                         =   10
 
 [SpellData1]
 MaxMana                         =   60
-Spell1                          =   Lightning
 
 [Attack0Data1]
 Damage                          =   32
 
 [ElementBonus1]
+DEFENSE_BONUS_VS_ARCHER         =   5
 
 [SupportBonus1]
-DEFENSE_BONUS_VS_ARCHER         =   2
+DEFENSE_BONUS_VS_ARCHER         =   3
 MORALE_BONUS                    =   5
 
 [Level2]
-MaxHitPoints                    =   740
+MaxHitPoints                    =   750
 
 [SpellData2]
 Spell1                          =   Lightning Vestments
@@ -97,13 +99,14 @@ ManaRegenerationRate            =   3
 Damage                          =   38
 
 [ElementBonus2]
+DEFENSE_BONUS_VS_ARCHER         =   6
 
 [SupportBonus2]
-DEFENSE_BONUS_VS_ARCHER         =   3
+DEFENSE_BONUS_VS_ARCHER         =   4
 MORALE_BONUS                    =   6
 
 [Level3]
-MaxHitPoints                    =   860
+MaxHitPoints                    =   870
 
 [SpellData3]
 MaxMana                         =   75
@@ -114,7 +117,7 @@ Damage                          =   44
 [ElementBonus3]
 
 [SupportBonus3]
-DEFENSE_BONUS_VS_ARCHER         =   5
+DEFENSE_BONUS_VS_ARCHER         =   4
 MORALE_BONUS                    =   8
 
 [HeroData]

--- a/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
+++ b/TGX Files/Data/ObjectData/Heroes/MAUSALLAS_BAHRAM.ini
@@ -31,7 +31,7 @@ IdleTime                        =   2
 MovementRate                    =   34
 WalkDistance                    =   0.85
 ResupplyRate                    =   10
-MeleeFX                         =   Necromancer_hitfx
+MeleeFX			                =   paladin_hitfx
 CombatValue                     =   15
 Description                     =   Mausallas Bahram possesses an unusual beauty, her unkempt shock of reddish-blonde hair and prominent nose conflicting with her serene brown eyes and ruby-red lips. Her beauty belies her intense intelligence and commanding grasp of the realm of magic. She is an accomplished warrior-mage, often found leading the charge against the forces of the Shadow, as well as wreaking havoc with her command of lightning. In melee, Mausallas wields a blackened longblade called Sta'archan that slices through the armor of her enemies with frightening ease. ;'
 
@@ -50,7 +50,7 @@ AttackRange                     =   1
 AttackType                      =   Melee
 Damage                          =   24
 DamageType                      =   Vorpal
-Animation                       =   1
+Animation                       =   0
 MoraleDamage                    =   0
 MoraleDamageType                =   Normal
 
@@ -59,7 +59,7 @@ AttackTime                      =   1
 DamagePoint                     =   0.5
 ReloadTime                      =   1
 AttackType                      =   Cast
-Animation                       =   0
+Animation                       =   1
 DamageType                      =   Normal
 MoraleDamage                    =   0
 MoraleDamageType                =   Normal

--- a/TGX Files/Data/ObjectData/Projectiles/MAGIC_MISSILE.INI
+++ b/TGX Files/Data/ObjectData/Projectiles/MAGIC_MISSILE.INI
@@ -1,0 +1,18 @@
+[ObjectData]
+ProperName = Magic Missile
+Class			= 	1;5	; 5 = leech ball
+Sprite			=   	Projectiles\blue_balls.tgr
+BoundingRadius		=	0.5		;tiles (float) explosion/hit distance from center
+DieTime			=	2		;seconds(float)
+
+[ProjectileData]
+WalkDistance		=  	0.5		;tiles (float) how far does unit move in one animation cycle
+MovementRate		=	10		;movement points(float)
+Acceleration		=	50		;movement points/s^2
+AttachedFX		=	blue_sparklefx
+
+;ArcVelocity			=	1.7		; tiles/s, 0 means don't arc.  Ignored if you define TargetHeight.
+InitialHeight		=	0		; tiles (1 tile = 2 meters)
+;TargetHeight		=	-1		; if defined, it will adjust arc velocity to hit target
+
+

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -1009,3 +1009,16 @@ BonusSection = EntangleBonuses
 Duration = 7
 Projectile = spell_arrow
 Sound = spells\mass_entangle.wav
+
+[52]
+Name = Cantrip
+ProperName = Cantrip
+Description = A controlled burst of energy erupts from the caster's fingertips and flies towards an enemy. ;'
+Mana_Cost = 30
+Type = Projectile
+Range = 10
+Damage = 65
+Morale = 0
+Projectile = magic_missile
+TargetDoCastEffect0 = invigorate
+Sound = spells\shower_of_light.wav

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -1013,7 +1013,7 @@ Sound = spells\mass_entangle.wav
 [52]
 Name = Cantrip
 ProperName = Cantrip
-Description = A controlled burst of energy erupts from the caster's fingertips and flies towards an enemy. ;'
+Description = A controlled burst of energy erupts from the mage's fingertips and flies towards an enemy. ;'
 Mana_Cost = 30
 Type = Projectile
 Range = 10


### PR DESCRIPTION
* #141 #142 #114 #118 
### _Changelog:_
### Heroes:

**Mausallas Bahram**

	Increased HP by 10 (490, 610, 750, 870)
	Reduced reload time on casting from 3 to 1 (Not a pure melee hero, but a melee hero nonetheless)

* _Awakened_

		Mana Regen increased from 2 to 3
		Added Cantrip spell
		Reduced Archer Resist from 6 to 4 (Personal)
		Added Archer Resist 2 (Provided)
* _Enlightened_

		Cantrip replaces Lightning
		Reduced Archer Resist from 6 to 5 (Personal)
		Increased Archer Resist from 2 to 3 (Provided)
* _Restored_

		Increased Archer Resist from 3 to 4 (Provided)
* _Ascended_
	
		Reduced Archer Resist from 5 to 4 (Provided)

**Jordan Avishai**

	Reduced Restored AV from 58 to 56
	All provided Cavalry Foe bonuses moved to Personal

**Garadun Payne**

	Grit moved from Ascended to Restored

### Spells

**Cantrip Added**

	Identical stats to Fireball (mana cost, range etc)
	Deals 65 damage