### PR TITLE
Adjustments to previously reworked Nationalist heroes

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/BALTHASAR_ASWAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/BALTHASAR_ASWAN.INI
@@ -62,6 +62,7 @@ Animation		=	0			; warmage animations are backwards in TGS
 [ElementBonus]
 
 [SupportBonus]
+VISUAL_RANGE_BONUS      =   1.15
 
 ;========Enlightened========
 
@@ -78,6 +79,7 @@ Damage			=	42
 [ElementBonus1]
 
 [SupportBonus1]
+VISUAL_RANGE_BONUS      =   1.2
 
 ;========Restored========
 
@@ -93,6 +95,7 @@ Damage			=	44
 [ElementBonus2]
 
 [SupportBonus2]
+VISUAL_RANGE_BONUS      =   1.25
 
 ;========Ascended========
 
@@ -111,6 +114,7 @@ Damage			=	50
 [ElementBonus3]
 
 [SupportBonus3]
+VISUAL_RANGE_BONUS      =   1.3
 
 [HeroData]
 AwakenCost		=	50

--- a/TGX Files/Data/ObjectData/Heroes/LAILA_ASWAN.INI
+++ b/TGX Files/Data/ObjectData/Heroes/LAILA_ASWAN.INI
@@ -44,7 +44,7 @@ DamagePoint		=	0.8			;seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	0.5			;seconds(float)
 AttackRange		=	7			;tiles (float)
 AttackType		=	PROJECTILE		;enumeration list(int)
-Damage			=	32		;number (float)
+Damage			=	34		;number (float)
 DamageType		=	NORMAL
 Sound1			=	Game\bow2.wav
 
@@ -73,7 +73,7 @@ MaxHitPoints		=	630
 [SpellData1]
 
 [Attack0Data1]
-Damage			=	36
+Damage			=	38
 
 [Attack1Data1]
 Damage			=	34
@@ -94,7 +94,7 @@ MaxHitPoints		=	740
 [SpellData2]
 
 [Attack0Data2]
-Damage			=	40
+Damage			=	42
 
 [Attack1Data2]
 Damage			=	38
@@ -114,7 +114,7 @@ MaxHitPoints		=	850
 [SpellData3]
 
 [Attack0Data3]
-Damage			=	44
+Damage			=	46
 
 [Attack1Data3]
 Damage			=	42

--- a/TGX Files/Data/ObjectData/Heroes/MOGGOK.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MOGGOK.INI
@@ -42,7 +42,7 @@ DamagePoint                         =   0.6
 ReloadTime                          =   0.5
 AttackRange                         =   0.75
 AttackType                          =   MELEE
-Damage                              =   50
+Damage                              =   48
 DamageType                          =   Khaldunite
 
 [Attack2]
@@ -60,7 +60,6 @@ IMMUNITY_TO_ENCHANTMENT             =   1
 
 [SupportBonus]
 ATTACK_BONUS_TO_BUILDING            =   2
-MORALE_BONUS                        =   2
 ENTRENCHMENT_RATE_BONUS             =   .66
 
 [Level1]
@@ -85,7 +84,7 @@ MaxHitPoints                        =   1150
 Defense                             =   14
 
 [Attack0Data2]
-Damage                              =   60
+Damage                              =   58
 
 [SpellData2]
 
@@ -99,10 +98,10 @@ ENTRENCHMENT_RATE_BONUS             =   .5
 
 [Level3]
 MaxHitPoints                        =   1400
-Defense                             =   16
+Defense                             =   14
 
 [Attack0Data3]
-Damage                              =   72
+Damage                              =   66
 
 [SpellData3]
 


### PR DESCRIPTION
### _Changelog:_
* #115  #116 #117 	
### Heroes

Moggok
	
	Reduced AV to 48-54-58-66 (Enlightened AV retained)
	Removed Bravery 2 at Awakened
	
Ilyana Aswan

	Increased AV to 34-38-42-46
	
Balthazar Aswan
	
	Added Recon 115% - 120% - 125% - 130%
