### PR TITLE
Nationalist upgrade cost

### DIFF
--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_CITY.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_CITY.INI
@@ -39,7 +39,7 @@ CompanyLimit	=	3			; companies allowed per settlement
 UpgradeCost		=	300	;800
 UpgradeTime		= 120
 ComponentLimit		=	6
-ComponentsRequiredToLevel = 	5
+ComponentsRequiredToLevel = 	6
 UpgradesRequiredToLevel = 1
 GoldLimitModifier		= 700
 

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_TOWN.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_TOWN.INI
@@ -39,7 +39,7 @@ CompanyLimit	=	2			; companies allowed per settlement
 UpgradeCost		=	320
 UpgradeTime		= 90
 ComponentLimit		=	4
-ComponentsRequiredToLevel = 	3
+ComponentsRequiredToLevel = 	4
 UpgradesRequiredToLevel = 0
 GoldLimitModifier		= 600
 

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_TOWN.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_TOWN.INI
@@ -36,7 +36,7 @@ NextLevel		= 	Nationalist_City
 CompanyLimit	=	2			; companies allowed per settlement
 
 [SettlementData]
-UpgradeCost		=	320
+UpgradeCost		=	300
 UpgradeTime		= 90
 ComponentLimit		=	4
 ComponentsRequiredToLevel = 	4

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_VILLAGE.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_VILLAGE.INI
@@ -38,7 +38,7 @@ NextLevel		=	Nationalist_Town
 CompanyLimit	=	1			; companies allowed per settlement
 
 [SettlementData]
-UpgradeCost		=	180 ;150
+UpgradeCost		=	150
 UpgradeTime		= 	45
 ComponentLimit		=	2
 ComponentsRequiredToLevel = 	2

--- a/TGX Files/Data/ObjectData/buildings/NATIONALIST_VILLAGE.INI
+++ b/TGX Files/Data/ObjectData/buildings/NATIONALIST_VILLAGE.INI
@@ -39,9 +39,9 @@ CompanyLimit	=	1			; companies allowed per settlement
 
 [SettlementData]
 UpgradeCost		=	180 ;150
-UpgradeTime		= 	30
+UpgradeTime		= 	45
 ComponentLimit		=	2
-ComponentsRequiredToLevel = 	1
+ComponentsRequiredToLevel = 	2
 UpgradesRequiredToLevel = 	0
 GoldLimitModifier	= 	500
 


### PR DESCRIPTION
* #190 

### _Changelog:_

Nationalist changes in

* #9 #17 #47

Have been reverted.

### Buildings

_Nationalist Village:_

	Upgrade time reverted to 45 seconds (was 30)
	Components required to upgrade reverted to 2 (was 1)
	Upgrade cost decreased from 180 to 150
	
_Nationalist Town_

	Components required to upgrade reverted to 4 (was 3)
	Upgrade cost decreased from 320 to 300
	
_Nationalist City:_

	Components required to upgrade reverted to 6 (was 5)
	Retained upgrade cost of 300
