### PR TITLE
Disciple Kick Fix Testing

### DIFF
--- a/TGX Files/Data/ObjectData/units/DISCIPLE_LONG_KICK.INI
+++ b/TGX Files/Data/ObjectData/units/DISCIPLE_LONG_KICK.INI
@@ -1,0 +1,83 @@
+[ObjectData]
+ProperName = Disciple Long Kick
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\disciple.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	280 ;260		;health rating(float)
+CostGold		=	8			;int
+UpkeepMana		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	7			;number (float)
+DieTime			=	1			;seconds(float)
+	
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+OverwriteColor = 9
+
+DeathSound1		=	Game\footman_death.wav
+SelectionSound1		=	Game\disciple_select1.wav
+SelectionSound2		=	Game\disciple_select2.wav
+SelectionSound3		=	Game\disciple_select3.wav
+CommandSound1		=	Game\disciple_command1.wav
+CommandSound2		=	Game\disciple_command2.wav
+CommandSound3		=	Game\disciple_command3.wav
+
+[UnitData]
+Type			=	FRONT
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\disciple_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	26			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.5		; SAI combat rating (float)
+BannerFrame		=	25
+ResupplyRate		=	11		; health / second (float)
+Description 		= STRING_4751_Disciples_are_a_fanatic_sect_of_temple_warriors_dedicated_to_the_will_of_the_church__They_are_fearless_and_quick_on_their_feet__but_lack_the_defensive_armor_of_other_warriors__To_make_up_for_this_they_wear_Khaldunite_infused_gauntlets__enabling_them_to_inflict_Khaldunite_damage_upon_their_enemies_
+Group1			= 10
+
+[BuildHierarchy]
+OnlyFaction		=	Nationalist
+Race			=	Mareten
+Component1		=	barracks
+Component2		=	temple
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_MAGIC		= .65
+
+[SupportBonus]
+ATTACK_BONUS_TO_SHADOW		= 2
+
+[CompanyData]
+Morale			= 50
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 3
+Berserk			= 1
+
+[Attack2]
+AttackTime		=	1.2		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.3		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	30		;number (float)
+DamageType		=	KHALDUNITE
+Sound1			= 	Game\disciple_punching.wav
+Animation		=	0
+
+;; drp051301 - uncommented
+[Attack1] 
+AttackTime		=	1.2		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.8		;seconds(float)
+AttackRange		=	1.15		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	50		;number (float)
+DamageType		=	KHALDUNITE
+Sound1			= 	Game\disciple_kick.wav
+Animation		=	1
+

--- a/TGX Files/Data/ObjectData/units/DISCIPLE_RANGED_KICK.INI
+++ b/TGX Files/Data/ObjectData/units/DISCIPLE_RANGED_KICK.INI
@@ -1,0 +1,87 @@
+[ObjectData]
+ProperName = Disciple Ranged Kick
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\disciple.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	280 ;260		;health rating(float)
+CostGold		=	8			;int
+UpkeepMana		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	7			;number (float)
+DieTime			=	1			;seconds(float)
+	
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+OverwriteColor = 8
+
+DeathSound1		=	Game\footman_death.wav
+SelectionSound1		=	Game\disciple_select1.wav
+SelectionSound2		=	Game\disciple_select2.wav
+SelectionSound3		=	Game\disciple_select3.wav
+CommandSound1		=	Game\disciple_command1.wav
+CommandSound2		=	Game\disciple_command2.wav
+CommandSound3		=	Game\disciple_command3.wav
+
+[UnitData]
+Type			=	FRONT
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\disciple_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	26			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.5		; SAI combat rating (float)
+BannerFrame		=	25
+ResupplyRate		=	11		; health / second (float)
+Description 		= STRING_4751_Disciples_are_a_fanatic_sect_of_temple_warriors_dedicated_to_the_will_of_the_church__They_are_fearless_and_quick_on_their_feet__but_lack_the_defensive_armor_of_other_warriors__To_make_up_for_this_they_wear_Khaldunite_infused_gauntlets__enabling_them_to_inflict_Khaldunite_damage_upon_their_enemies_
+Group1			= 10
+Archer			=	0
+
+[BuildHierarchy]
+OnlyFaction		=	Nationalist
+Race			=	Mareten
+Component1		=	barracks
+Component2		=	temple
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_MAGIC		= .65
+
+[SupportBonus]
+ATTACK_BONUS_TO_SHADOW		= 2
+
+[CompanyData]
+Morale			= 50
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 3
+Berserk			= 1
+
+
+[Attack1] 
+AttackTime		=	1.2		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.8		;seconds(float)
+AttackRange		=	1.15		;tiles (float)
+AttackType		=	PROJECTILE		;enumeration list(int)	
+Damage			=	50		;number (float)
+DamageType		=	KHALDUNITE
+Projectile		=	spell_arrow
+Sound1			=	Game\disciple_kick.wav
+Animation		=	1
+
+[Attack2]
+AttackTime		=	1.2		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.3		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	30		;number (float)
+DamageType		=	KHALDUNITE
+Sound1			=	Game\disciple_punching.wav
+Animation		=	0
+
+;; drp051301 - uncommented
+

--- a/TGX Files/Data/ObjectData/units/DISCIPLE_SPELL_KICK.INI
+++ b/TGX Files/Data/ObjectData/units/DISCIPLE_SPELL_KICK.INI
@@ -1,0 +1,84 @@
+[ObjectData]
+ProperName = Disciple Spell Kick
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\disciple.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	280 ;260		;health rating(float)
+CostGold		=	8			;int
+UpkeepMana		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	7			;number (float)
+DieTime			=	1			;seconds(float)
+	
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+OverwriteColor = 10
+
+DeathSound1		=	Game\footman_death.wav
+SelectionSound1		=	Game\disciple_select1.wav
+SelectionSound2		=	Game\disciple_select2.wav
+SelectionSound3		=	Game\disciple_select3.wav
+CommandSound1		=	Game\disciple_command1.wav
+CommandSound2		=	Game\disciple_command2.wav
+CommandSound3		=	Game\disciple_command3.wav
+
+[UnitData]
+Type			=	FRONT
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\disciple_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	26			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.5		; SAI combat rating (float)
+BannerFrame		=	25
+ResupplyRate		=	11		; health / second (float)
+Description 		= STRING_4751_Disciples_are_a_fanatic_sect_of_temple_warriors_dedicated_to_the_will_of_the_church__They_are_fearless_and_quick_on_their_feet__but_lack_the_defensive_armor_of_other_warriors__To_make_up_for_this_they_wear_Khaldunite_infused_gauntlets__enabling_them_to_inflict_Khaldunite_damage_upon_their_enemies_
+Group1			= 10
+
+[BuildHierarchy]
+OnlyFaction		=	Nationalist
+Race			=	Mareten
+Component1		=	barracks
+Component2		=	temple
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_MAGIC		= .65
+
+[SupportBonus]
+ATTACK_BONUS_TO_SHADOW		= 2
+
+[CompanyData]
+Morale			= 50
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 3
+Berserk			= 1
+
+[SpellData]
+Spell0					=	Arcane Kick
+ManaRegenerationRate	=	2
+MaxMana					=	30
+
+[Attack1]
+AttackTime		=	1.2		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.3		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	30		;number (float)
+DamageType		=	KHALDUNITE
+Sound1			= 	Game\disciple_punching.wav
+Animation		=	0
+
+;; drp051301 - uncommented
+[Attack2] 
+AttackTime		=	1.2		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.8		;seconds(float)
+AttackType		=	CAST		;enumeration list(int)	
+;Sound1			= 	Game\disciple_kick.wav
+Animation		=	1

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -1022,3 +1022,15 @@ Morale = 0
 Projectile = magic_missile
 TargetDoCastEffect0 = invigorate
 Sound = spells\shower_of_light.wav
+
+
+[53]
+Name			=	Arcane Kick
+ProperName		=	Arcane Kick
+Description		=	A staggering blow with all the power of the body behind it
+Mana_Cost		=	15
+Type			=	Projectile
+Range			=	1.15
+Damage			=	50
+Projectile		=	spell_arrow
+Sound			=	Game\disciple_kick.wav


### PR DESCRIPTION
*  Potential fix for #186 

The three approaches taken here are switching the kick to a PROJECTILE attack (this is what archers use), increasing the range of the MELEE kick attack, and replacing the kick with a spell. All three use a short range of 1.15 which is still greater than the default melee range of 0.75. 

* __Ranged:__ like archers, they will use their range attack until a unit gets too close and they switch to melee. The trick here is to pick a range that allows them to get kicks in when engaging, repositioning, and after they've killed their opponent without allowing them to exclusively spam kicks. This is tricky against actual ranged elements which won't try to engage them in melee, allowing them to stay in kick mode for most of the engagement. Their kick attack will be listed as ranged in the unit pane in-game.
* __Melee:__ I'm not sure what is determining their choice of attack after the initial moment of engagement. The longer range means they will almost always start with a kick, but they will still sometimes kick while in punch distance, and sometimes walk into punch range rather than kicking. Additionally, only their kick attack shows in the unit pane in-game, despite them still having and using 2 attacks.
* __Spell:__ In some ways this is the most intuitive option, though it has its downsides. They will 'kick' until they run out of mana or a unit gets too close, then switch to punching. If they are ever out of melee range, they will 'kick' until they run out of mana again. The approach potentially supplies the clearest 'rules' for playmaking, but strips their kick of khaldunite damage and is thematically confusing, since they are only casting a spell mechanically.

I discovered during testing that if a unit has two attacks, the one with the longer range __*must*__ be Attack1 or the game crashes with this error: 
```TGFATAL Unit secondary attack has the same or longer range. (!unit->HasAttack(1) || unit->GetData()->dual_wield || unit->GetAttackRange(0)>unit->GetAttackRange(1))```
This meant switching the kick to be Attack1 for the ranged and melee variants and switching the animations to match.