### PR TITLE
Lair Gold update

### DIFF
--- a/TGX Files/Data/ObjectData/buildings/BANDIT_CAMP.INI
+++ b/TGX Files/Data/ObjectData/buildings/BANDIT_CAMP.INI
@@ -1,0 +1,36 @@
+[ObjectData]
+ProperName = Cave
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\MONSTER_LAIR.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	1500	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		=   There is something unnatural about this cave.
+Weight			=	5
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\MONSTER_LAIR_PORTRAIT.tgr
+booty_min	 = 90
+booty_max	 = 115
+extraReward  = 1
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	4		; militia per company
+MilitiaStart		=	4
+MaxMilitia		=	4		; total max militia
+MilitiaType		=	elemental	; militia type
+MilitiaGrowth		=	0		; points per second
+
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 0

--- a/TGX Files/Data/ObjectData/buildings/BARBARIAN_VILLAGE.INI
+++ b/TGX Files/Data/ObjectData/buildings/BARBARIAN_VILLAGE.INI
@@ -1,0 +1,44 @@
+[ObjectData]
+ProperName = STRING_4615_Barbarian_Village
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\Barbarian_Camp.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	1200	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	5	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_4616_These_hide_and_wood_huts_provide_shelter_to_the_northern_Drauga_barbarian_clans__distant_cousins_of_the_relatively_more_civilized_Drauga_in_the_south_
+Weight			=	10
+
+SelectionSound1		= 	Game\drauga_barbarian_select.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Barbarian_camp_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\Barbarian_camp_destroy.tgr
+booty_min	 = 25
+booty_max	 = 125
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	6		; militia per company
+MilitiaStart		=	6
+MaxMilitia		=	12		; total max militia
+MilitiaType		=	Barbarian	; militia type
+MilitiaGrowth		=	0.0125		; points per second
+
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+Type = 0
+FrameRate = 150		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 5
+AlwaysDraw = 1
+

--- a/TGX Files/Data/ObjectData/buildings/BARBARIAN_VILLAGE.INI
+++ b/TGX Files/Data/ObjectData/buildings/BARBARIAN_VILLAGE.INI
@@ -18,8 +18,8 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\Barbarian_camp_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Barbarian_camp_destroy.tgr
-booty_min	 = 25
-booty_max	 = 125
+booty_min	 = 65
+booty_max	 = 90
 
 [BaseData]
 ControlRange		=	8

--- a/TGX Files/Data/ObjectData/buildings/BRIGAND_CAMP.INI
+++ b/TGX Files/Data/ObjectData/buildings/BRIGAND_CAMP.INI
@@ -1,0 +1,54 @@
+[ObjectData]
+ProperName = STRING_2161_Bandit_Camp
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\Bandit_Camp.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	1000	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	3	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2160_A_small_arrangement_of_tents_and_crude_defenses_that_house_bandits_waiting_to_prey_upon_the_unwary_
+Weight			=	15
+
+SelectionSound1		= 	Game\select_bandit_camp.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\bandit_camp_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\bandit_camp_destroy.tgr
+booty_min	 = 25
+booty_max	 = 125
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	6		; militia per company
+MilitiaStart		=	6
+MaxMilitia		=	12		; total max militia
+MilitiaType		=	Brigand		; militia type
+MilitiaGrowth		=	0.015		; points per second
+
+;[NotUsed]
+;ObjectDisplay		=	1	;enumeration in button.h	
+;ActionScroll    	=   	1	;enumeration in button.h
+;BuildSound			= 	audio\Game\construction.wav
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 2
+
+[Animation0]
+Type = 0
+FrameRate = 230		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 9
+AlwaysDraw = 0
+
+[Animation1]
+Type = 0
+FrameRate = 230		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 9
+AlwaysDraw = 1

--- a/TGX Files/Data/ObjectData/buildings/BRIGAND_CAMP.INI
+++ b/TGX Files/Data/ObjectData/buildings/BRIGAND_CAMP.INI
@@ -18,8 +18,8 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\bandit_camp_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\bandit_camp_destroy.tgr
-booty_min	 = 25
-booty_max	 = 125
+booty_min	 = 65
+booty_max	 = 90
 
 [BaseData]
 ControlRange		=	8

--- a/TGX Files/Data/ObjectData/buildings/DRAGON_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/DRAGON_LAIR.INI
@@ -1,0 +1,49 @@
+[ObjectData]
+ProperName = STRING_2180_Dragon_Lair
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\dragon_lair.tgr
+BoundingRadius		=	2.5	;tiles (float)
+ClearOut		=   	4	;tiles
+MaxHitPoints		=	1000	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2181_Dark_and_dangerous_looking_cavern__home_of_a_powerful_dragon_and_likely_to_be_filled_with_treasure_
+Weight			=	1
+
+SelectionSound1	= 	Game\Fire_Drake_breathe.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\dragon_lair_portrait.tgr
+booty_min	 = 250
+booty_max	 = 500
+ExtraReward = 1	;; drp042701 - added
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	1		; militia per company
+MilitiaStart		=	1
+MaxMilitia		=	1		; total max militia
+MilitiaType		=	Fire_Dragon	; militia type
+MilitiaGrowth		=	0		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 2
+
+[Animation0]
+Type = 0
+FrameRate = 150		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 16
+AlwaysDraw = 1
+
+[Animation1]
+Type = 0
+FrameRate = 80		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 16
+AlwaysDraw = 1

--- a/TGX Files/Data/ObjectData/buildings/DRAGON_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/DRAGON_LAIR.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\dragon_lair_portrait.tgr
-booty_min	 = 150
-booty_max	 = 175
+booty_min	 = 250
+booty_max	 = 500
 ExtraReward = 1	;; drp042701 - added
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/DRAGON_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/DRAGON_LAIR.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\dragon_lair_portrait.tgr
-booty_min	 = 250
-booty_max	 = 500
+booty_min	 = 150
+booty_max	 = 175
 ExtraReward = 1	;; drp042701 - added
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/GLOWING_TEMPLE.INI
+++ b/TGX Files/Data/ObjectData/buildings/GLOWING_TEMPLE.INI
@@ -18,8 +18,8 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\glowing_temple_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Khaldunite_Lair_destroy.tgr
-booty_min	 = 100
-booty_max	 = 200
+booty_min	 = 75
+booty_max	 = 100
 ExtraReward = 1
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/GLOWING_TEMPLE.INI
+++ b/TGX Files/Data/ObjectData/buildings/GLOWING_TEMPLE.INI
@@ -18,8 +18,8 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\glowing_temple_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Khaldunite_Lair_destroy.tgr
-booty_min	 = 75
-booty_max	 = 100
+booty_min	 = 90
+booty_max	 = 115
 ExtraReward = 1
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/ICE_DRAKE_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/ICE_DRAKE_LAIR.INI
@@ -1,0 +1,49 @@
+[ObjectData]
+ProperName = STRING_4625_Ice_Drake_Lair
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\ice_drake_lair.tgr
+BoundingRadius		=	2.5	;tiles (float)
+ClearOut		=   	4	;tiles
+MaxHitPoints		=	1000	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_4626_A_vast_cavern_sheathed_in_ice_and_snow_houses_the_most_dangerous_creature_in_the_cold_waste__as_well_as_the_treasure_it_protects_
+Weight			=	1
+
+SelectionSound1		= 	Game\Ice_drake_select.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\ice_drake_lair_portrait.tgr
+booty_min	 = 250
+booty_max	 = 500
+AGClimatesOnly = 1
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	1		; militia per company
+MilitiaStart		=	1
+MaxMilitia		=	1		; total max militia
+MilitiaType		=	Ice_Drake	; militia type
+MilitiaGrowth		=	0		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 2
+
+[Animation0]
+Type = 0
+FrameRate = 100		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 10
+AlwaysDraw = 1
+
+[Animation1]
+Type = 0
+FrameRate = 80		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 10
+AlwaysDraw = 1

--- a/TGX Files/Data/ObjectData/buildings/ICE_DRAKE_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/ICE_DRAKE_LAIR.INI
@@ -17,9 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\ice_drake_lair_portrait.tgr
-booty_min	 = 150
-booty_max	 = 175
-ExtraReward  = 1
+booty_min	 = 250
+booty_max	 = 500
 AGClimatesOnly = 1
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/ICE_DRAKE_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/ICE_DRAKE_LAIR.INI
@@ -17,8 +17,9 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\ice_drake_lair_portrait.tgr
-booty_min	 = 250
-booty_max	 = 500
+booty_min	 = 150
+booty_max	 = 175
+ExtraReward  = 1
 AGClimatesOnly = 1
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/MEGALITH.INI
+++ b/TGX Files/Data/ObjectData/buildings/MEGALITH.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\Megalith_portrait.tgr
-booty_min	 = 10
-booty_max	 = 50
+booty_min	 = 40
+booty_max	 = 55
 
 [BaseData]
 ControlRange		=	6

--- a/TGX Files/Data/ObjectData/buildings/MEGALITH.INI
+++ b/TGX Files/Data/ObjectData/buildings/MEGALITH.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\Megalith_portrait.tgr
-booty_min	 = 40
-booty_max	 = 55
+booty_min	 = 50
+booty_max	 = 65
 
 [BaseData]
 ControlRange		=	6

--- a/TGX Files/Data/ObjectData/buildings/NEW_AHRIMAN_CITADEL.INI
+++ b/TGX Files/Data/ObjectData/buildings/NEW_AHRIMAN_CITADEL.INI
@@ -10,7 +10,7 @@ Defense				=	0	;number (float)
 DieTime				=	1
 RotTime			=	120	;seconds(float)
 Description			=	A remnant of a Cataclysm in an age long past, infested with evil protecting their forgotten treasures. Only the prepared or foolish would dare venture near it.
-Weight			=	4
+Weight			=	1
 
 DeathSound1		=	Game\building_destroyed.wav
 SelectionSound1		= 	Game\select_mana_mine.wav

--- a/TGX Files/Data/ObjectData/buildings/RHAKSHA_HIVE.INI
+++ b/TGX Files/Data/ObjectData/buildings/RHAKSHA_HIVE.INI
@@ -1,0 +1,90 @@
+[ObjectData]
+ProperName = STRING_2215_Rhaksha_Hive
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\Rhaksha_Hive.tgr
+BoundingRadius		=	2.5	;tiles (float)
+ClearOut		=   4	;tiles
+MaxHitPoints		=	3000	;health rating(float)
+DetectionRadius		=	10	;tiles(float)
+Defense			=	0	;number (float)
+DieTime			=	1.5
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2216_A_great_pile_of_corruption__The_musty_smell_is_overwhelming_and_the_bones_littering_the_ground_are_testament_to_the_danger_dwelling_within_
+Weight			=	2
+
+SelectionSound1	= 	Game\select_hivemaster.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Rhaksha_Hive_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\Rhaksha_Hive_Destroyed.tgr
+booty_min	 = 150
+booty_max	 = 350
+ExtraReward = 1	;; drp042701 - added
+
+[BaseData]
+ControlRange		=   	8	;tiles (float)
+SupplyRange		=	0	;tiles (float)	
+CompanySize		=	5	; militia per company
+MilitiaStart		=	10
+MaxMilitia		=	25		; total max militia
+MilitiaType		=	rhaksha		; militia type
+MilitiaType2		=	rhaksha_hivemaster
+MilitiaGrowth		=	0.020		; points per second
+
+;;[LairData]
+;;Spawn			=	rhaksha
+;;CompanySize		=	5
+;;StartPopulation		=	3
+;;GrowthRate		=	300	; seconds to grow 1
+;;MaxGrowth		=	10
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 5
+
+[Animation0]
+Type = 0
+FrameRate = 150		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 16
+AlwaysDraw = 0
+
+[Animation1]
+alwaysdraw = 0
+FrameRate = 200		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 7
+MinStillTime = 3000
+MaxStillTime = 8000
+BaseFrame = 0
+
+[Animation2]
+alwaysdraw = 0
+FrameRate = 210		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 7
+MinStillTime = 5000
+MaxStillTime = 10000
+BaseFrame = 0
+
+[Animation3]
+alwaysdraw = 0
+FrameRate = 220		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 7
+MinStillTime = 4000
+MaxStillTime = 7000
+BaseFrame = 0
+
+[Animation4]
+alwaysdraw = 0
+FrameRate = 200		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 7
+MinStillTime = 5000
+MaxStillTime = 9000
+BaseFrame = 0
+
+

--- a/TGX Files/Data/ObjectData/buildings/RHAKSHA_HIVE.INI
+++ b/TGX Files/Data/ObjectData/buildings/RHAKSHA_HIVE.INI
@@ -19,8 +19,8 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\Rhaksha_Hive_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Rhaksha_Hive_Destroyed.tgr
-booty_min	 = 150
-booty_max	 = 350
+booty_min	 = 90
+booty_max	 = 115
 ExtraReward = 1	;; drp042701 - added
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/RHAKSHA_NEST.INI
+++ b/TGX Files/Data/ObjectData/buildings/RHAKSHA_NEST.INI
@@ -1,0 +1,80 @@
+[ObjectData]
+ProperName = STRING_2217_Rhaksha_Nest
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\Rhaksha_Nest.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   4	;tiles
+MaxHitPoints		=	1500	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+DieTime			= 	1.5
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2218_The_foul_stench_of_Rhaksha_wafts_heavily_from_the_many_holes_and_rents_covering_their_mound_like_nest__Best_not_to_get_too_close_
+Weight			= 30
+
+SelectionSound1		= 	Game\select_rhaksha.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Rhaksha_Nest_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\Rhaksha_Nest_Destroyed.tgr
+booty_min	 = 25
+booty_max	 = 75
+
+[BaseData]
+ControlRange		=  	6	;tiles (float)
+SupplyRange		=	0	;tiles (float)	
+CompanySize		=	4			; militia per company
+MilitiaStart		=	4
+MaxMilitia		=	12			; total max militia
+MilitiaType		=	rhaksha		; militia type
+MilitiaGrowth		=	0.0125		; points per second
+NextLevel		=	Rhaksha_Hive
+LairSpread		=	1
+
+;;[LairData]
+;;Spawn			=	rhaksha
+;;CompanySize		=	4
+;;StartPopulation		=	3
+;;GrowthRate		=	3000	; seconds to grow 1
+;;MaxGrowth		=	4	; +1 for split
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 4
+
+[Animation0]
+Type = 0
+FrameRate = 150		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 16
+AlwaysDraw = 0
+
+[Animation1]
+alwaysdraw = 0
+FrameRate = 215		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 7
+MinStillTime = 3000
+MaxStillTime = 8000
+BaseFrame = 0
+
+[Animation2]
+alwaysdraw = 0
+FrameRate = 215		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 7
+MinStillTime = 3000
+MaxStillTime = 8000
+BaseFrame = 0
+
+[Animation3]
+alwaysdraw = 0
+FrameRate = 215		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 7
+MinStillTime = 3000
+MaxStillTime = 8000
+BaseFrame = 0
+

--- a/TGX Files/Data/ObjectData/buildings/RHAKSHA_NEST.INI
+++ b/TGX Files/Data/ObjectData/buildings/RHAKSHA_NEST.INI
@@ -19,7 +19,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\Rhaksha_Nest_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Rhaksha_Nest_Destroyed.tgr
-booty_min	 = 25
+booty_min	 = 50
 booty_max	 = 75
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/RHAKSHA_NEST.INI
+++ b/TGX Files/Data/ObjectData/buildings/RHAKSHA_NEST.INI
@@ -19,7 +19,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\Rhaksha_Nest_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Rhaksha_Nest_Destroyed.tgr
-booty_min	 = 50
+booty_min	 = 60
 booty_max	 = 75
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/RUINED_CITY.INI
+++ b/TGX Files/Data/ObjectData/buildings/RUINED_CITY.INI
@@ -17,7 +17,7 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\Ruined_City_portrait.tgr
-booty_min	 = 40
+booty_min	 = 50
 booty_max	 = 65
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/RUINED_MONUMENT.INI
+++ b/TGX Files/Data/ObjectData/buildings/RUINED_MONUMENT.INI
@@ -1,0 +1,41 @@
+[ObjectData]
+ProperName = STRING_2226_Ruined_Monument
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\ancient_ruin.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	750	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2156_The_crumbled_remains_of_ancient_buildings_are_all_that_are_left_of_a_once_glorious_city_
+Weight			=	14
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Ancient_Ruin_portrait.tgr
+booty_min	 = 50
+booty_max	 = 150
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	5		; militia per company
+MilitiaStart		=	5
+MaxMilitia		=	5		; total max militia
+MilitiaType		=	Undead		; militia type
+MilitiaGrowth		=	0		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 1
+
+[Animation0]
+Type = 0
+FrameRate = 230		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 8
+AlwaysDraw = 1

--- a/TGX Files/Data/ObjectData/buildings/RUINED_MONUMENT.INI
+++ b/TGX Files/Data/ObjectData/buildings/RUINED_MONUMENT.INI
@@ -18,7 +18,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\Ancient_Ruin_portrait.tgr
 booty_min	 = 50
-booty_max	 = 150
+booty_max	 = 65
 
 [BaseData]
 ControlRange		=	8

--- a/TGX Files/Data/ObjectData/buildings/SLAAN_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/SLAAN_LAIR.INI
@@ -1,0 +1,65 @@
+[ObjectData]
+ProperName = STRING_2227_Slaan_Lair
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\slaan_lair.tgr
+BoundingRadius		=	2.5	;tiles (float)
+ClearOut		=   	4	;tiles
+MaxHitPoints		=	1000	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2228_Odd_looking_mud_and_stone_structures_that_house_the_hostile_reptile_men_known_as_the_Slaan_
+Weight			= 15
+
+SelectionSound1		= 	Game\select_slaan.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\slaan_lair_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\slaan_lair_Destroy.tgr
+booty_min	 = 50
+booty_max	 = 150
+
+[BaseData]
+ControlRange		=	6
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	5		; militia per company
+MilitiaStart		=	5
+MaxMilitia		=	10		; total max militia
+MilitiaType		=	slaan		; militia type
+MilitiaGrowth		=	0.02		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 5
+
+[Animation0]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 4
+
+[Animation1]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 4
+
+[Animation2]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 4
+
+[Animation3]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 4
+
+[Animation4]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 4

--- a/TGX Files/Data/ObjectData/buildings/SLAAN_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/SLAAN_LAIR.INI
@@ -19,7 +19,8 @@ DeathSound1		=	Game\building_destroyed.wav
 Icon			=	Portraits\Buildings\slaan_lair_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\slaan_lair_Destroy.tgr
 booty_min	 = 50
-booty_max	 = 150
+booty_max	 = 75
+ExtraReward  = 1
 
 [BaseData]
 ControlRange		=	6

--- a/TGX Files/Data/ObjectData/buildings/SNOW_PYRAMID2.INI
+++ b/TGX Files/Data/ObjectData/buildings/SNOW_PYRAMID2.INI
@@ -1,0 +1,38 @@
+[ObjectData]
+ProperName = STRING_4636_Snow_Temple
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\Snow_pyramid.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	750	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description = STRING_4635_The_icy_remnants_of_a_great_temple_rises_from_the_snow_like_an_immense_gravestone_
+Weight			=	7	;; drp012701 - changed 20 to 15
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\snow_pyramid_portrait.tgr
+booty_min	 = 50
+booty_max	 = 150
+AGClimatesOnly = 1
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	5		; militia per company
+MilitiaStart		=	5
+MaxMilitia		=	5		; total max militia
+MilitiaType		=	Undead		; militia type
+MilitiaGrowth		=	0		; points per second
+
+;[NotUsed]
+;ObjectDisplay		=	1	;enumeration in button.h	
+;ActionScroll    	=   	1	;enumeration in button.h
+;BuildSound			= 	audio\Game\construction.wav
+
+

--- a/TGX Files/Data/ObjectData/buildings/SNOW_PYRAMID2.INI
+++ b/TGX Files/Data/ObjectData/buildings/SNOW_PYRAMID2.INI
@@ -18,7 +18,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\snow_pyramid_portrait.tgr
 booty_min	 = 50
-booty_max	 = 150
+booty_max	 = 65
 AGClimatesOnly = 1
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/SNOW_RUIN2.INI
+++ b/TGX Files/Data/ObjectData/buildings/SNOW_RUIN2.INI
@@ -1,0 +1,38 @@
+[ObjectData]
+ProperName = STRING_4639_Frozen_Ruins
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\snow_ruin.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	750	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description = STRING_4638_The_ruins_of_this_once_great_city_lie_dark_and_foreboding_against_its_stark_white_surroundings_
+Weight			=	7	;; drp012701 - changed 20 to 15
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\snow_ruin_portrait.tgr
+booty_min	 = 50
+booty_max	 = 150
+AGClimatesOnly = 1
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	5		; militia per company
+MilitiaStart		=	5
+MaxMilitia		=	5		; total max militia
+MilitiaType		=	Undead		; militia type
+MilitiaGrowth		=	0		; points per second
+
+;[NotUsed]
+;ObjectDisplay		=	1	;enumeration in button.h	
+;ActionScroll    	=   	1	;enumeration in button.h
+;BuildSound			= 	audio\Game\construction.wav
+
+

--- a/TGX Files/Data/ObjectData/buildings/SNOW_RUIN2.INI
+++ b/TGX Files/Data/ObjectData/buildings/SNOW_RUIN2.INI
@@ -18,7 +18,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\snow_ruin_portrait.tgr
 booty_min	 = 50
-booty_max	 = 150
+booty_max	 = 65
 AGClimatesOnly = 1
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/SPIDER_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/SPIDER_LAIR.INI
@@ -1,0 +1,56 @@
+[ObjectData]
+ProperName = STRING_2231_Giant_Spider_Nest
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\spider_lair.tgr
+BoundingRadius		=	2.5	;tiles (float)
+ClearOut		=   	4	;tiles
+MaxHitPoints		=	1000	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2232_Massive_cocoons_of_silk_pulse_with_arachnid_life__housing_the_brood_of_giant_eight_legged_predators_
+Weight			= 10
+
+SelectionSound1		= 	Game\select_giant_spider.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\spider_lair_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\Spider_lair_Destroy.tgr
+booty_min	 = 100
+booty_max	 = 200
+
+[BaseData]
+ControlRange		=	7
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	3		; militia per company
+MilitiaStart		=	2
+MaxMilitia		=	3		; total max militia
+MilitiaType		=	giant_spider	; militia type
+MilitiaGrowth		=	0.0075		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 4
+
+[Animation0]
+FrameRate = 200		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 8
+
+[Animation1]
+FrameRate = 280		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 10
+
+[Animation2]
+FrameRate = 220		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 7
+
+[Animation3]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 11

--- a/TGX Files/Data/ObjectData/buildings/SPIDER_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/SPIDER_LAIR.INI
@@ -18,8 +18,8 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\spider_lair_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Spider_lair_Destroy.tgr
-booty_min	 = 100
-booty_max	 = 200
+booty_min	 = 80
+booty_max	 = 100
 
 [BaseData]
 ControlRange		=	7

--- a/TGX Files/Data/ObjectData/buildings/SPREADING_SLAAN_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/SPREADING_SLAAN_LAIR.INI
@@ -1,0 +1,67 @@
+[ObjectData]
+ProperName = STRING_2227_Slaan_Lair
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\slaan_lair.tgr
+BoundingRadius		=	2.5	;tiles (float)
+ClearOut		=   	4	;tiles
+MaxHitPoints		=	1000	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2228_Odd_looking_mud_and_stone_structures_that_house_the_hostile_reptile_men_known_as_the_Slaan_
+Weight			= 10
+
+SelectionSound1		= 	Game\select_slaan.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\slaan_lair_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\slaan_lair_Destroy.tgr	;; drp012201 - added
+booty_min	 = 50
+booty_max	 = 150
+
+[BaseData]
+ControlRange		=	6
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	5		; militia per company
+MilitiaStart		=	5
+MaxMilitia		=	10		; total max militia
+MilitiaType		=	slaan		; militia type
+MilitiaGrowth		=	0.015		; points per second
+LairSpread		=	1		;; drp012101 - readded
+;Spread			=	1
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 5
+
+[Animation0]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 4
+
+[Animation1]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 4
+
+[Animation2]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 4
+
+[Animation3]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 4
+
+[Animation4]
+FrameRate = 200		;ms
+alwaysdraw = 1
+Random = 1			;should the animation cycle be randomly started
+Frames = 4

--- a/TGX Files/Data/ObjectData/buildings/SPREADING_SLAAN_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/SPREADING_SLAAN_LAIR.INI
@@ -18,7 +18,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\slaan_lair_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\slaan_lair_Destroy.tgr	;; drp012201 - added
-booty_min	 = 50
+booty_min	 = 55
 booty_max	 = 75
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/SPREADING_SLAAN_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/SPREADING_SLAAN_LAIR.INI
@@ -19,7 +19,7 @@ DeathSound1		=	Game\building_destroyed.wav
 Icon			=	Portraits\Buildings\slaan_lair_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\slaan_lair_Destroy.tgr	;; drp012201 - added
 booty_min	 = 50
-booty_max	 = 150
+booty_max	 = 75
 
 [BaseData]
 ControlRange		=	6

--- a/TGX Files/Data/ObjectData/buildings/SPREADING_SLAAN_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/SPREADING_SLAAN_LAIR.INI
@@ -1,5 +1,5 @@
 [ObjectData]
-ProperName = STRING_2227_Slaan_Lair
+ProperName = Slaan Colony
 Class			= 	3	;enumeration list(int)
 Sprite			=   buildings\slaan_lair.tgr
 BoundingRadius		=	2.5	;tiles (float)

--- a/TGX Files/Data/ObjectData/buildings/STORM_DRAKE_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/STORM_DRAKE_LAIR.INI
@@ -1,0 +1,49 @@
+[ObjectData]
+ProperName = STRING_2233_Storm_Drake_Lair
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\dragon_lair.tgr
+BoundingRadius		=	2.5	;tiles (float)
+ClearOut		=   	4	;tiles
+MaxHitPoints		=	1000	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2181_Dark_and_dangerous_looking_cavern__home_of_a_powerful_dragon_and_likely_to_be_filled_with_treasure_
+Weight			=	1
+
+SelectionSound1	= 	Game\select_storm_drake.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\dragon_lair_portrait.tgr
+booty_min	 = 250
+booty_max	 = 500
+ExtraReward = 1	;; drp042701 - added
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	1		; militia per company
+MilitiaStart		=	1
+MaxMilitia		=	1		; total max militia
+MilitiaType		=	Storm_Drake 	; militia type
+MilitiaGrowth		=	0		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 2
+
+[Animation0]
+Type = 0
+FrameRate = 150		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 16
+AlwaysDraw = 1
+
+[Animation1]
+Type = 0
+FrameRate = 80		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 16
+AlwaysDraw = 1

--- a/TGX Files/Data/ObjectData/buildings/STORM_DRAKE_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/STORM_DRAKE_LAIR.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\dragon_lair_portrait.tgr
-booty_min	 = 150
-booty_max	 = 175
+booty_min	 = 250
+booty_max	 = 500
 ExtraReward = 1	;; drp042701 - added
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/STORM_DRAKE_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/STORM_DRAKE_LAIR.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\dragon_lair_portrait.tgr
-booty_min	 = 250
-booty_max	 = 500
+booty_min	 = 150
+booty_max	 = 175
 ExtraReward = 1	;; drp042701 - added
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/TEMPLE_RUIN.INI
+++ b/TGX Files/Data/ObjectData/buildings/TEMPLE_RUIN.INI
@@ -1,0 +1,35 @@
+[ObjectData]
+ProperName = STRING_2234_Temple_Ruin
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\Temple_Ruin.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   	2	;tiles
+MaxHitPoints		=	1500	;health rating(float)
+DetectionRadius		=	6	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2235_Once_a_great_temple_or_palace__now_this_remnant_of_the_greater_glory_of_the_Kohan_now_lies_decrepit_and_forgotten_
+Weight			=	10
+
+SelectionSound1		= 	Game\select_ruins.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Desert_City2_portrait.tgr
+booty_min	 = 50
+booty_max	 = 150
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	5		; militia per company
+MilitiaStart		=	5
+MaxMilitia		=	5		; total max militia
+MilitiaType		=	dark_wolf	; militia type
+MilitiaGrowth		=	0		; points per second
+
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 0

--- a/TGX Files/Data/ObjectData/buildings/TEMPLE_RUIN.INI
+++ b/TGX Files/Data/ObjectData/buildings/TEMPLE_RUIN.INI
@@ -18,7 +18,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\Desert_City2_portrait.tgr
 booty_min	 = 50
-booty_max	 = 150
+booty_max	 = 65
 
 [BaseData]
 ControlRange		=	8

--- a/TGX Files/Data/ObjectData/buildings/WASP_HIVE.INI
+++ b/TGX Files/Data/ObjectData/buildings/WASP_HIVE.INI
@@ -1,0 +1,92 @@
+[ObjectData]
+ProperName = STRING_4640_Giant_Wasp_Nest
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\Wasp_Nest.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   4	;tiles
+MaxHitPoints		=	1000	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+DieTime			= 	1.5
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description = STRING_4641_Pulsating_with_new_life__the_nests_of_giant_wasps_have_been_springing_up_all_over_the_land_like_mushrooms_after_a_rain_
+Weight			= 0
+
+SelectionSound1		= 	Game\giant_wasp_select.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Wasp_Nest_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\Wasp_Nest_Destroy.tgr
+booty_min	 = 25
+booty_max	 = 75
+
+[BaseData]
+ControlRange		=  	5	;tiles (float)
+SupplyRange		=	0	;tiles (float)	
+CompanySize		=	4			; militia per company
+MilitiaStart		=	4
+MaxMilitia		=	16			; total max militia
+MilitiaType		=	giant_wasp	; militia type
+MilitiaGrowth		=	0.015 ;0.025		; points per second
+
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 6
+
+[Animation0]
+Type = 0
+FrameRate =370		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 17
+maxstilltime =9000
+minstilltime=5000
+AlwaysDraw = 1
+
+[Animation1]
+Type = 0
+FrameRate = 370		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 17
+maxstilltime =9000
+minstilltime=5000
+AlwaysDraw = 1
+
+[Animation2]
+Type = 0
+FrameRate = 370		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 17
+maxstilltime =9000
+minstilltime=5000
+AlwaysDraw = 1
+
+[Animation3]
+Type = 0
+FrameRate = 220		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 26
+maxstilltime =1200
+minstilltime=600
+AlwaysDraw = 1
+
+[Animation4]
+Type = 0
+FrameRate = 220		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 24
+maxstilltime =900
+minstilltime=200
+AlwaysDraw = 1
+
+[Animation5]
+Type = 0
+FrameRate = 220		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 14
+maxstilltime =1200
+minstilltime=850
+AlwaysDraw = 1
+

--- a/TGX Files/Data/ObjectData/buildings/WASP_HIVE.INI
+++ b/TGX Files/Data/ObjectData/buildings/WASP_HIVE.INI
@@ -19,7 +19,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\Wasp_Nest_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Wasp_Nest_Destroy.tgr
-booty_min	 = 50
+booty_min	 = 55
 booty_max	 = 75
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/WASP_HIVE.INI
+++ b/TGX Files/Data/ObjectData/buildings/WASP_HIVE.INI
@@ -19,7 +19,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\Wasp_Nest_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Wasp_Nest_Destroy.tgr
-booty_min	 = 25
+booty_min	 = 50
 booty_max	 = 75
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/WASP_NEST.INI
+++ b/TGX Files/Data/ObjectData/buildings/WASP_NEST.INI
@@ -1,0 +1,93 @@
+[ObjectData]
+ProperName = STRING_4640_Giant_Wasp_Nest
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\Wasp_Nest.tgr
+BoundingRadius		=	3	;tiles (float)
+ClearOut		=   4	;tiles
+MaxHitPoints		=	1000	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+DieTime			= 	1.5
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description = STRING_4641_Pulsating_with_new_life__the_nests_of_giant_wasps_have_been_springing_up_all_over_the_land_like_mushrooms_after_a_rain_
+Weight			= 31
+
+SelectionSound1		= 	Game\giant_wasp_select.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\Wasp_Nest_portrait.tgr
+DestructionAnimation 	= Art\Objects\Buildings\Animations\Wasp_Nest_Destroy.tgr
+booty_min	 = 25
+booty_max	 = 75
+
+[BaseData]
+ControlRange		=  	5	;tiles (float)
+SupplyRange		=	0	;tiles (float)	
+CompanySize		=	4			; militia per company
+MilitiaStart		=	4
+MaxMilitia		=	16			; total max militia
+MilitiaType		=	giant_wasp	; militia type
+MilitiaGrowth		=	0.015 ;0.025		; points per second
+LairSpread		=	1
+NextLevel		=	Wasp_Hive
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 6
+
+[Animation0]
+Type = 0
+FrameRate =370		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 17
+maxstilltime =9000
+minstilltime=5000
+AlwaysDraw = 1
+
+[Animation1]
+Type = 0
+FrameRate = 370		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 17
+maxstilltime =9000
+minstilltime=5000
+AlwaysDraw = 1
+
+[Animation2]
+Type = 0
+FrameRate = 370		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 17
+maxstilltime =9000
+minstilltime=5000
+AlwaysDraw = 1
+
+[Animation3]
+Type = 0
+FrameRate = 220		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 26
+maxstilltime =1200
+minstilltime=600
+AlwaysDraw = 1
+
+[Animation4]
+Type = 0
+FrameRate = 220		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 24
+maxstilltime =900
+minstilltime=200
+AlwaysDraw = 1
+
+[Animation5]
+Type = 0
+FrameRate = 220		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 14
+maxstilltime =1200
+minstilltime=850
+AlwaysDraw = 1
+

--- a/TGX Files/Data/ObjectData/buildings/WASP_NEST.INI
+++ b/TGX Files/Data/ObjectData/buildings/WASP_NEST.INI
@@ -19,7 +19,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\Wasp_Nest_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Wasp_Nest_Destroy.tgr
-booty_min	 = 50
+booty_min	 = 55
 booty_max	 = 75
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/WASP_NEST.INI
+++ b/TGX Files/Data/ObjectData/buildings/WASP_NEST.INI
@@ -19,7 +19,7 @@ DeathSound1		=	Game\building_destroyed.wav
 [BuildingData]
 Icon			=	Portraits\Buildings\Wasp_Nest_portrait.tgr
 DestructionAnimation 	= Art\Objects\Buildings\Animations\Wasp_Nest_Destroy.tgr
-booty_min	 = 25
+booty_min	 = 50
 booty_max	 = 75
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/YOUNG_DRAKE_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/YOUNG_DRAKE_LAIR.INI
@@ -1,0 +1,49 @@
+[ObjectData]
+ProperName = STRING_2236_Young_Dragon_Lair
+Class			= 	3	;enumeration list(int)
+Sprite			=   buildings\dragon_lair.tgr
+BoundingRadius		=	2.5	;tiles (float)
+ClearOut		=   	4	;tiles
+MaxHitPoints		=	1000	;health rating(float)
+DetectionRadius		=	8	;tiles(float)
+Defense			=	0	;number (float)
+RotTime			=	120	;seconds(float)
+Captureable		=	0
+Description		= STRING_2181_Dark_and_dangerous_looking_cavern__home_of_a_powerful_dragon_and_likely_to_be_filled_with_treasure_
+Weight			=	1
+
+SelectionSound1	= 	Game\Fire_Drake_breathe.wav
+DeathSound1		=	Game\building_destroyed.wav
+
+[BuildingData]
+Icon			=	Portraits\Buildings\dragon_lair_portrait.tgr
+booty_min	 = 100
+booty_max	 = 300
+ExtraReward = 1	;; drp042701 - added
+
+[BaseData]
+ControlRange		=	8
+SupplyRange		=	0		;tiles (float)	
+CompanySize		=	1		; militia per company
+MilitiaStart		=	1
+MaxMilitia		=	1		; total max militia
+MilitiaType		=	Young_Dragon	; militia type
+MilitiaGrowth		=	0		; points per second
+
+;Animations are drawn in order of declaration in INI file (1,2,3,...)
+[AnimationData]
+NumAnimations = 2
+
+[Animation0]
+Type = 0
+FrameRate = 150		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 16
+AlwaysDraw = 1
+
+[Animation1]
+Type = 0
+FrameRate = 80		;ms
+Random = 0			;should the animation cycle be randomly started
+Frames = 16
+AlwaysDraw = 1

--- a/TGX Files/Data/ObjectData/buildings/YOUNG_DRAKE_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/YOUNG_DRAKE_LAIR.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\dragon_lair_portrait.tgr
-booty_min	 = 90
-booty_max	 = 115
+booty_min	 = 100
+booty_max	 = 125
 ExtraReward = 1	;; drp042701 - added
 
 [BaseData]

--- a/TGX Files/Data/ObjectData/buildings/YOUNG_DRAKE_LAIR.INI
+++ b/TGX Files/Data/ObjectData/buildings/YOUNG_DRAKE_LAIR.INI
@@ -17,8 +17,8 @@ DeathSound1		=	Game\building_destroyed.wav
 
 [BuildingData]
 Icon			=	Portraits\Buildings\dragon_lair_portrait.tgr
-booty_min	 = 100
-booty_max	 = 300
+booty_min	 = 90
+booty_max	 = 115
 ExtraReward = 1	;; drp042701 - added
 
 [BaseData]


### PR DESCRIPTION
* #160 

### _Changelog:_

Upping the minimums of lairs, and reducing the crazy ranges. Lairs should be guaranteed to be worth your time, and maybe you can get a bit extra. 

_Megalith_

	40-55g Bounty 

_Ruined Monument, Ruined City, Temple Ruin, Pyramid2 & Ruin2_

	50-65g

_Slaan Lair_

	50-70g
	Gives an extra reward

_Wasps (Nest and Hive) & Slaan Lair (Spreading)_

	55-75g
	Spreading Slaan Lair renamed to Slaan Colony

 _Rhaksha Nest_

	60-75g

_Bandit Camp & Barbarian Camp_

	 65-90g

_Spider Lair_

	80-100g

_Glowing Temple, Rhaksha Hive & Elemental Cave (New from 2.0.2)_

	90-115g
	Extra reward

_Young Drake Lair_

	100-125g
	Extra Reward

_Ancient Abyss_

	Reduced spawn rate from 4 to 1

_Dragon Lair (Fire, Ice, Storm)_

	No changes

