### PR TITLE
Disciple Attack Adjustment

### DIFF
--- a/TGX Files/Data/ObjectData/units/DISCIPLE.INI
+++ b/TGX Files/Data/ObjectData/units/DISCIPLE.INI
@@ -63,7 +63,7 @@ DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animati
 ReloadTime		=	0.3		;seconds(float)
 AttackRange		=	.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	30		;number (float)
+Damage			=	40		;number (float)
 DamageType		=	KHALDUNITE
 Sound1			= 	Game\disciple_punching.wav
 

--- a/TGX Files/Data/ObjectData/units/DISCIPLE.INI
+++ b/TGX Files/Data/ObjectData/units/DISCIPLE.INI
@@ -8,7 +8,7 @@ MaxHitPoints		=	280 ;260		;health rating(float)
 CostGold		=	8			;int
 UpkeepMana		=	1			;int
 BuildTime		=	5			;seconds(float)
-Defense			=	7			;number (float)
+Defense			=	6			;number (float)
 DieTime			=	1			;seconds(float)
 	
 Moveable		=	1			;BOOLEAN


### PR DESCRIPTION
### **_Changelog:_**
```Increased Punch AV from 30 to 40```
```Reverted DV from 7 to 6```

This sets the DPS of Punch and Kick attacks to be equal vs 12 DV to help remove randomness from Disciples' DPS

