### PR TITLE
Drauga Berserker Adjustment

### DIFF
--- a/TGX Files/Data/ObjectData/units/DRAUGA_BERSERKER.INI
+++ b/TGX Files/Data/ObjectData/units/DRAUGA_BERSERKER.INI
@@ -56,7 +56,7 @@ DamagePoint		=	0.65		;seconds(float) at what point (percentage) in attack animat
 ReloadTime		=	0.5		;seconds(float)
 AttackRange		=	.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
-Damage			=	30		;number (float)
+Damage			=	27		;number (float)
 DamageType		=	NORMAL
 Sound1			= 	Game\drauga_berserker_attack.wav
 

--- a/TGX Files/Data/ObjectData/units/DRAUGA_BERSERKER.INI
+++ b/TGX Files/Data/ObjectData/units/DRAUGA_BERSERKER.INI
@@ -27,7 +27,7 @@ Type			=	FRONT
 Captain			=	drauga_captain
 Icon			=   Portraits\Unit Icons\Berserker_icon.tgr
 IdleTime		=	2			;seconds(float)
-MovementRate		=	20			;movement points(float)
+MovementRate		=	22			;movement points(float)
 WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
 CombatValue		=	7.5		; SAI combat rating (float)
 BannerFrame		=	11
@@ -53,7 +53,7 @@ EntrenchmentRate	= 1
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.65		;seconds(float) at what point (percentage) in attack animation to apply damage
-ReloadTime		=	0.5		;seconds(float)
+ReloadTime		=	0.2		;seconds(float)
 AttackRange		=	.75		;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
 Damage			=	27		;number (float)


### PR DESCRIPTION
### _Changelog:_

Drauga Berserker
> AV lowered to 27 (30 to 27)
> Reload speed lowered from 0.5 to 0.2 (125% attack speed)
> Increased movement speed by 2 (20 to 22)