### PR TITLE
Beastrider adjustment

### DIFF
--- a/TGX Files/Data/ObjectData/units/DRAUGA_BEASTRIDER.INI
+++ b/TGX Files/Data/ObjectData/units/DRAUGA_BEASTRIDER.INI
@@ -1,0 +1,74 @@
+[ObjectData]
+ProperName = STRING_2464_Beast_Rider
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\drauga_beastrider.tgr
+BoundingRadius		=	0.35		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	280			;health rating(float)
+CostGold		=	10			;int
+UpkeepGold		=	0			;int
+UpkeepWood		=	1			;int
+UpkeepIron		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+DieTime			=	1.3			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\beastrider_death.wav
+SelectionSound1		=	Game\select_beastrider.wav
+CommandSound1		=	Game\command_beastrider.wav
+
+[UnitData]
+Type			=	FRONT
+Mounted			=	1
+Captain			=	drauga_captain
+Icon			=   Portraits\Unit Icons\Beastrider_icon.tgr
+IdleTime		=	1			;seconds(float)
+MovementRate		=	26			;movement points(float)
+WalkDistance		=  	1		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8		; SAI combat rating (float)
+BannerFrame		=	10
+ResupplyRate		=	11		; health / second (float)
+Description 		= STRING_2465_Riding_their_great_warbeasts__the_Drauga_Beastriders_make_powerful_cavalry_elements_
+Group1			= 7
+Group2			= 9
+
+
+[BuildHierarchy]
+Race			=	Drauga
+Component1		=	Blacksmith
+;Component2		=	Barracks
+
+[ElementBonus]
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 45
+VisualRange		= 7
+ControlZone		= 4
+EntrenchmentRate	= 5
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)	
+Damage			=	30		;number (float)
+DamageType		=	NORMAL
+Sound1			=	Game\spear1.wav
+Sound2			= 	Game\spear3.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/DRAUGA_BEASTRIDER.INI
+++ b/TGX Files/Data/ObjectData/units/DRAUGA_BEASTRIDER.INI
@@ -4,7 +4,7 @@ Class			= 	0			;enumeration list(int)
 Sprite			=   units\drauga_beastrider.tgr
 BoundingRadius		=	0.35		;tiles(float)
 RotTime			=	30			;seconds(float)
-MaxHitPoints		=	280			;health rating(float)
+MaxHitPoints		=	300			;health rating(float)
 CostGold		=	10			;int
 UpkeepGold		=	0			;int
 UpkeepWood		=	1			;int
@@ -29,7 +29,7 @@ Mounted			=	1
 Captain			=	drauga_captain
 Icon			=   Portraits\Unit Icons\Beastrider_icon.tgr
 IdleTime		=	1			;seconds(float)
-MovementRate		=	26			;movement points(float)
+MovementRate		=	28			;movement points(float)
 WalkDistance		=  	1		;tiles (float) how far does unit move in one animation cycle
 CombatValue		=	8		; SAI combat rating (float)
 BannerFrame		=	10
@@ -37,6 +37,7 @@ ResupplyRate		=	11		; health / second (float)
 Description 		= STRING_2465_Riding_their_great_warbeasts__the_Drauga_Beastriders_make_powerful_cavalry_elements_
 Group1			= 7
 Group2			= 9
+Group3			= 17
 
 
 [BuildHierarchy]
@@ -45,6 +46,7 @@ Component1		=	Blacksmith
 ;Component2		=	Barracks
 
 [ElementBonus]
+ATTACK_BONUS_TO_ARCHER = 3
 
 [SupportBonus]
 

--- a/TGX Files/Data/ObjectData/units/DRAUGA_CAPTAIN.INI
+++ b/TGX Files/Data/ObjectData/units/DRAUGA_CAPTAIN.INI
@@ -1,0 +1,61 @@
+[ObjectData]
+ProperName = STRING_4062_Drauga_Captain
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\drauga_captain.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	300			;health rating(float)
+CostGold		=	15			;int
+UpkeepGold		=	0			;int
+CostWood		=	1			;int
+CostIron		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+DieTime			=	1.3			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\beastrider_death.wav
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .5
+
+[SupportBonus]
+
+[CompanyData]
+
+[UnitData]
+Type			=	CAPTAIN
+Icon			=   Portraits\Unit Icons\drauga_captain_icon.tgr
+Portrait		=	Portraits\Heroes\drauga_captain_portrait.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	34			;movement points(float)
+WalkDistance		= 	1		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0		; SAI combat rating (float)
+ResupplyRate		=	15			; health / second (float)
+Description 		= STRING_4063_The_Drauga_Captain_is_the_fighting_Beastrider_trained_to_lead_a_company_into_battle_
+Group1			= 7
+Group2			= 9
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)
+Damage			=	30		;number (float)
+DamageType		=	NORMAL
+Sound1			=	Game\spear1.wav
+Sound2			= 	Game\spear3.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/DRAUGA_CAPTAIN.INI
+++ b/TGX Files/Data/ObjectData/units/DRAUGA_CAPTAIN.INI
@@ -40,6 +40,7 @@ ResupplyRate		=	15			; health / second (float)
 Description 		= STRING_4063_The_Drauga_Captain_is_the_fighting_Beastrider_trained_to_lead_a_company_into_battle_
 Group1			= 7
 Group2			= 9
+Group3			= 17
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle


### PR DESCRIPTION
### _Changelog:_

Drauga Beastrider:

> Increased movement speed by 2 (26 to 28)
> Increased HP by 20 (280 to 300)
> Added Archer Foe 3
> Added to Group 17 (Benefits from cavalry techs)

Drauga Captain:

> Added to Group 17 (Benefits from cavalry techs)