### PR TITLE
Adding missing unit INIs

### DIFF
--- a/TGX Files/Data/ObjectData/units/AMON_KOTH'S_CHOSEN.INI
+++ b/TGX Files/Data/ObjectData/units/AMON_KOTH'S_CHOSEN.INI
@@ -1,0 +1,71 @@
+[ObjectData]
+ProperName = STRING_2433_The_Chosen
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\rhaksha_hivemaster.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	350			;health rating(float)
+CostGold		=	0			;int
+CostMana		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\hivemaster_death.wav
+SelectionSound1		=	Game\select_hivemaster.wav
+CommandSound1		=	Game\select_hivemaster.wav
+
+[UnitData]
+Type			=	FRONT
+Captain			=	Rhaksha_Leader
+Icon			=   Portraits\Unit Icons\Hivemaster_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	25			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0 ; 30.0		; SAI combat rating (float)
+ResupplyRate		=	1		; health / second (float)
+BannerFrame		=	10
+Description 		= STRING_2434_Twice_as_large_as_a_normal_Rhaksha__the_Chosen_of_Amon_Koth_are_picked_from_the_most_deadly_Hivemasters_
+Group1			= 16
+
+[BuildHierarchy]
+OnlyFaction		= 	None
+Race		=	None
+
+[ElementBonus]
+ATTACK_BONUS_TO_ROUTED	= 4
+DEFENSE_BONUS_VS_ARCHER	= 8
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 75
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 9999
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	40		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\hivemaster_attack.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/ARCHER.INI
+++ b/TGX Files/Data/ObjectData/units/ARCHER.INI
@@ -1,0 +1,80 @@
+[ObjectData]
+ProperName = STRING_2435_Bowman
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\archer.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	160			;health rating(float)
+CostGold		=	6			;int
+UpkeepGold		=	0			;int
+UpkeepWood		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\archer_death.wav
+SelectionSound1		=	Game\select_archer.wav
+;SelectionSound2		=	Game\select_archer2.wav
+CommandSound1		=	Game\command_archer.wav
+;CommandSound2		=	Game\command_archer2.wav
+
+[UnitData]
+Type			=	FRONT
+Archer			=	1
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\Archer_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	18			;movement points(float)
+WalkDistance		=   	0.72		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	6		; SAI combat rating (float)
+BannerFrame		=	8
+ResupplyRate		=	8			; health / second (float)
+Description 		= STRING_2436_Bowman_fire_volleys_of_deadly_arrows_at_their_targets__They_are_particularly_useful_against_infantry_
+Group1			= 1
+Group2			= 6
+Group3			= 10
+
+[BuildHierarchy]
+Race			=	Mareten
+ExceptFaction		=	Ceyah
+Component1		=	woodmill
+
+[ElementBonus]
+ATTACK_BONUS_TO_BUILDING 	= -20
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 35
+VisualRange		= 7
+ControlZone		= 5
+EntrenchmentRate	= 1.5
+
+[Attack1]
+AttackTime		=	1			;seconds(float) seconds per animation cycle
+Projectile		=   arrow
+DamagePoint		=	0.6			;seconds(float) at what point (percentage) in attack animation to apply damage/shoot projectile
+ReloadTime		=	2			;seconds(float)
+AttackRange		=	6			;tiles (float)
+AttackType		=	PROJECTILE	;enumeration list(int)
+Damage			=	32		;number (float)
+DamageType		=	NORMAL
+Sound1			=	Game\archer_shot.wav
+
+[Attack2]
+AttackTime		=	1			;seconds(float) seconds per animation cycle
+Projectile		=   	0
+DamagePoint		=	0.3			;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5			;seconds(float)
+AttackRange		=	0.75			;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	12		;number (float)
+DamageType		=	NORMAL
+Sound1			=	Game\archer_sword1.wav
+Sound2			=	Game\sword2.wav

--- a/TGX Files/Data/ObjectData/units/ARCHMAGE.INI
+++ b/TGX Files/Data/ObjectData/units/ARCHMAGE.INI
@@ -1,0 +1,70 @@
+[ObjectData]
+ProperName = STRING_0017_Archmage
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\warmage.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	140			;health rating(float)
+CostGold		=	20 ;40			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	3			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	4			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\anvil_death.wav
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Warmage_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	18			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2439_The_powerful_Archmage_is_capable_of_wielding_both_priestly_powers_and_arcane_magic__He_is_both_inspiring_to_the_troops_and_assists_in_healing_them_outside_of_combat_
+MeleeFX			= warmage_hitfx
+Group1			= 12
+
+[SpellData]
+MaxMana =			60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	5	;the amount of mana that gets regenerated sec.
+Spell0			=	True Blessing
+Spell1			=	Fireblast
+
+[BuildHierarchy]
+ExceptFaction		=	Ceyah
+Component1		=	Library
+Component2		=	Temple
+Technology		= 	Archmage
+
+[ElementBonus]
+
+[SupportBonus]
+MORALE_CHECK_BONUS	= 2
+RESUPPLY_RATE_BONUS	= 1.2
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.75			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	32		;number (float)
+DamageType		=	MAGIC
+Animation		=	1			; warmage animations are backwards in TGS
+Sound1			= 	Spells\magician_attack.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0			; warmage animations are backwards in TGS

--- a/TGX Files/Data/ObjectData/units/BARBARIAN.INI
+++ b/TGX Files/Data/ObjectData/units/BARBARIAN.INI
@@ -1,0 +1,67 @@
+[ObjectData]
+ProperName = STRING_4742_Drauga_Barbarian
+MonsterCompanyName = STRING_4743_Barbarians
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\Drauga_Berserker.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	240			;health rating(float)
+CostGold		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	0			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\berserker_death.wav
+SelectionSound1		= 	Game\drauga_barbarian_select.wav
+
+[UnitData]
+Type			=	MONSTER
+Icon			=   Portraits\Unit Icons\Berserker_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	18			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+BannerFrame		=	19
+ResupplyRate		=	1		; health / second (float)
+Description = STRING_4744_The_Drauga_Barbarians_come_from_small_tribes_of_Drauga_that_migrated_north_and_adopted_primitive_ways_of_clan_life__They_care_nothing_for_politics_and_take_what_they_need_from_anyone_weaker_than_themselves_
+CombatValue		=	5.0		; SAI combat rating (float)
+
+[BuildHierarchy]
+BuildingClass		= 1
+
+[ElementBonus]
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 45
+VisualRange		= 5
+ControlZone		= 3
+EntrenchmentRate	= 0
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	24		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\infantry_attack.wav
+Sound2			= 	Game\sword2.wav
+
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/BRIGAND.INI
+++ b/TGX Files/Data/ObjectData/units/BRIGAND.INI
@@ -1,0 +1,68 @@
+[ObjectData]
+ProperName = STRING_2443_Brigand
+MonsterCompanyName = STRING_2631_Brigands
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\Infantry.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	200			;health rating(float)
+CostGold		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	0			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\infantry_death.wav
+SelectionSound1		= 	Game\select_bandit_camp.wav
+
+[UnitData]
+Type			=	MONSTER
+Icon			=   Portraits\Unit Icons\Infantry_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	15			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+BannerFrame		=	19
+ResupplyRate		=	1		; health / second (float)
+Description 		= STRING_2444_Brigands_are_nothing_more_than_mercenary_scoundrels_who_prey_upon_the_weak_when_not_campaigning_
+CombatValue		=	4.5		; SAI combat rating (float)
+
+[BuildHierarchy]
+BuildingClass		= 1
+
+[ElementBonus]
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 35
+VisualRange		= 5
+ControlZone		= 3
+EntrenchmentRate	= 0
+;Berserk			= 1		; drp011301 - removed berserk flag from Brigand
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	18		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\infantry_attack.wav
+Sound2			= 	Game\sword2.wav
+
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/CAPTAIN.INI
+++ b/TGX Files/Data/ObjectData/units/CAPTAIN.INI
@@ -1,0 +1,60 @@
+[ObjectData]
+ProperName = STRING_1637_Captain
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\captain.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	300			;health rating(float)
+CostGold		=	15			;int
+UpkeepGold		=	0			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\infantry_death.wav
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .5
+
+[SupportBonus]
+
+[CompanyData]
+
+[UnitData]
+Type			=	CAPTAIN
+Icon			=   Portraits\Unit Icons\Captain_icon.tgr
+Portrait		=	Portraits\Heroes\Captain_Portrait.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	26			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0 		; SAI combat rating (float)
+ResupplyRate		=	15			; health / second (float)
+Description 		= STRING_2445_The_captain_is_the_fighting_warrior_trained_to_lead_a_company_into_battle_
+Group1			= 8
+Group2			= 11
+Group3			= 9
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	28		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\captain_attack.wav
+Sound2			= 	Game\sword3.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/CAVALIER.INI
+++ b/TGX Files/Data/ObjectData/units/CAVALIER.INI
@@ -1,0 +1,78 @@
+[ObjectData]
+Propername = STRING_0011_Cavalier
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\cavalier.tgr
+BoundingRadius		=	.35	;tiles(float) .45 makes formations easier for scout
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	480			;health rating(float)
+CostGold		=	15			;int
+UpkeepMana		=	2			;int
+UpkeepIron		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	12			;number (float)
+DieTime			=	1.5			;seconds(float)
+OverwriteColor  =	-1
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+
+DeathSound1		=	Game\dragoon_death.wav
+SelectionSound1		=	Game\select_cavalry.wav
+SelectionSound2		=	Game\select_cavalry2.wav
+CommandSound1		=	Game\command_cavalry.wav
+CommandSound2		=	Game\command_cavalry2.wav
+
+[UnitData]
+Type			=	FRONT
+Mounted			=	1
+Captain			=	cavalry_captain
+Icon			=   Portraits\Unit Icons\Cavalier_icon.tgr
+IdleTime		=	2	;seconds(float)
+MovementRate		=	32 ;30	;movement points(float)
+WalkDistance		=  	1.4	;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	14.5		; SAI combat rating (float)
+BannerFrame		=	9
+ResupplyRate		=	15		; health / second (float)
+Description 		= STRING_2446_Cavaliers_are_the_elite_cavalry_elements_of_the_Kohan__They_are_more_dangerous_than_normal_dragoons_and_wield_Khaldunite_weaponry_
+Group1			= 2
+
+[BuildHierarchy]
+Race			=	Mareten
+ExceptFaction		= 	Ceyah
+Component1		=	barracks
+Component2		=	blacksmith
+Component3		=	library
+Component4		=	temple
+Technology		= 	Cavalier
+
+[ElementBonus]
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 50
+VisualRange		= 7
+ControlZone		= 4
+EntrenchmentRate	= 3
+
+[Attack1]
+AttackTime		=	1	;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5 ;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5	;seconds(float)
+AttackRange		=	.75	;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)	
+Damage			=	50		;number (float)
+DamageType		=	KHALDUNITE
+Sound1			=	Game\axe2.wav
+
+[Attack2]
+AttackTime		=	0	;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7	;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0	;seconds(float)
+AttackRange		=	0	;tiles (float)
+AttackType		=	0	;enumeration list(int)	
+DamageType		=	0	;number (float)

--- a/TGX Files/Data/ObjectData/units/CAVALRY_CAPTAIN.INI
+++ b/TGX Files/Data/ObjectData/units/CAVALRY_CAPTAIN.INI
@@ -1,0 +1,62 @@
+[ObjectData]
+ProperName = STRING_2447_Cavalry_Captain
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\cavalry_captain.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	300			;health rating(float)
+CostGold		=	15			;int
+UpkeepGold		=	0			;int
+CostWood		=	1			;int
+CostIron		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+DieTime			=	2			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\dragoon_death.wav
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .5
+
+[SupportBonus]
+
+[CompanyData]
+
+[UnitData]
+Type			=	CAPTAIN
+Icon			=   Portraits\Unit Icons\Cavalry_Captain_icon.tgr
+Portrait		=	Portraits\Heroes\Captain_Portrait.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	34			;movement points(float)
+WalkDistance		= 	1.4		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0		; SAI combat rating (float)
+ResupplyRate		=	15			; health / second (float)
+Description 		= STRING_2445_The_captain_is_the_fighting_warrior_trained_to_lead_a_company_into_battle_
+Group1			= 8
+Group2			= 11
+Group3			= 9
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	28		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\sword3.wav
+Sound2			= 	Game\sword4.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/CHANNELER.INI
+++ b/TGX Files/Data/ObjectData/units/CHANNELER.INI
@@ -1,0 +1,69 @@
+[ObjectData]
+ProperName = STRING_2448_Channeler
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\priestess.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	120		;health rating(float)
+CostGold		=	12 ;24			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	1			;int
+CostMana		=	0			;int
+UpkeepMana		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\Priestess_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Priestess_icon.tgr
+IdleTime		=	2		;seconds(float)
+MovementRate		=	16		;movement points(float)
+WalkDistance		=   0.85	;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2449_Channelers_are_a_type_of_priest_that_specialize_in_healing_their_troops_enmasse__They_also_help_heal_wounded_troops_out_of_combat_
+Group1			= 12
+
+[SpellData]
+MaxMana 		= 60 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
+Spell0 			= Protection
+Spell1			= Heal
+
+[BuildHierarchy]
+Component1		=	TempleoftheOverseers
+
+[ElementBonus]
+
+[SupportBonus]
+RESUPPLY_RATE_BONUS	= 1.25
+MELEE_HOLY_DAMAGE	= 2
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)	
+Damage			=	10		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\battle_priest_melee.wav
+Sound2			= 	Game\club2.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.25		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+

--- a/TGX Files/Data/ObjectData/units/CONJUROR.INI
+++ b/TGX Files/Data/ObjectData/units/CONJUROR.INI
@@ -1,0 +1,68 @@
+[ObjectData]
+ProperName = STRING_0014_Conjuror
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\warmage.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	130			;health rating(float)
+CostGold		=	16 ;32			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	3			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	4			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\anvil_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Warmage_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2454_Conjurors_have_delved_into_the_dark_side_of_summoning__able_to_summon_creatures_of_shadow_to_fight_for_them__Outside_of_combat_they_use_small_nature_spirits_to_aid_in_scouting_their_surroundings__increasing_their_company_s_visual_range_
+Group1			= 12
+MeleeFX			= wizard_hitfx
+
+[SpellData]
+MaxMana 		=	60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	5	;the amount of mana that gets regenerated sec.
+Spell0			=		Summon Shadeling Swarm
+Spell1			=		Lightning
+
+[BuildHierarchy]
+Component1		=	AstrologyHall
+Technology		= 	Conjuror
+
+[ElementBonus]
+
+[SupportBonus]
+VISUAL_RANGE_BONUS	= 1.2
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.5			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	28		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	spells\wizard_attack.wav
+Animation		=	1			; warmage animations are backwards in TGS
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.75		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0			; warmage animations are backwards in TGS

--- a/TGX Files/Data/ObjectData/units/DAEVAI.INI
+++ b/TGX Files/Data/ObjectData/units/DAEVAI.INI
@@ -1,0 +1,67 @@
+[ObjectData]
+ProperName = STRING_2457_Ceyahdev
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\Ceyahdev.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	1.3			;seconds(float)
+MaxHitPoints		=	5000		;health rating(float)
+CostGold		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	0			;int
+UpkeepMana		=	0			;int
+BuildTime		=	10			;seconds(float)
+Defense			=	20			;number (float)
+DieTime			=	.6			
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\Ceyahdev_death.wav
+SelectionSound1		=	Game\select_Ceyahdev.wav
+CommandSound1		=	Game\select_Ceyahdev.wav
+
+[UnitData]
+Type			=	SOLO
+Shadow			=	1
+Portrait		=	Portraits\Heroes\Ceyahdev_Portrait.tgr
+Icon			=   	Portraits\Unit Icons\Rhaksha_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	22			;movement points(float)
+WalkDistance		=   	1.2		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	100.0		; SAI combat rating (float)
+ResupplyRate		=	10		; health / second (float)
+Description 		= STRING_2458_Ceyahdev_was_one_of_the_first_Kohan_Council_members_to_turn_her_back_on_the_rest_of_the_council__She_was_a_powerful_and_respected_leader_in_the_council__many_other_Kohan_looked_up_to_her__Many_council_members_felt_that_her_dissention_had_the_greatest_impact_on_the_society_s_inability_to_counter_the_first_cataclysm__She_has_grown_more_and_more_embittered_over_her_role_in_the_cataclysm_and_feels_betrayed_from_all_sides__She_trusts_no_one_and_prefers_total_isolation_over_any_form_of_contact_with_living_creatures__To_this_end_she_has_deformed_into_a_shadowy__demonic_beast_that_lives_deep_within_a_dark_chasm__She_destroys_all_creatures_that_wander_near_her_lair_
+
+
+[SpellData]
+MaxMana 		= 60 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 6		;the amount of mana that gets regenerated per update (30 times/sec)
+Spell0			= Earthshock
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.25
+DAMAGE_TAKEN_FROM_MAGIC		= 1.25
+DAMAGE_TAKEN_FROM_RANGED	= .75
+IMMUNITY_TO_ENCHANTMENT		= 1
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)	
+Damage			=	150		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\Ceyahdev_attack.wav
+Animation = 0
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/DARK_WOLF.INI
+++ b/TGX Files/Data/ObjectData/units/DARK_WOLF.INI
@@ -1,0 +1,63 @@
+[ObjectData]
+ProperName = STRING_2459_Dark_Wolf
+MonsterCompanyName = STRING_3015_Dark_Wolves
+Class			= 	0			;enumeration list(int)
+Sprite			=   	units\Dark_wolf.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	200			;health rating(float)
+CostGold		=	0			;int
+CostMana		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	20			;number (float)
+DieTime			=	1.3			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\dark_wolf_death.wav
+SelectionSound1		=	Game\select_dark_wolf.wav
+CommandSound1		=	Game\select_dark_wolf.wav
+
+[UnitData]
+Type			=	MONSTER
+Shadow			=	1
+Icon			=   	Portraits\Unit Icons\Dark_Wolf_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	36			;movement points(float)
+WalkDistance		= 	1		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	9.0		; SAI combat rating (float)
+ResupplyRate		=	1		; health / second (float)
+Description 		= STRING_2460_The_hunting_beasts_of_the_Great_Master__dark_wolves_search_out_his_enemies_and_tear_them_to_shreds_
+Group1			= 18
+
+[ElementBonus]
+ATTACK_BONUS_TO_ROUTED		= 6
+DAMAGE_TAKEN_FROM_MAGIC		= .75
+DAMAGE_TAKEN_FROM_HOLY		= 1.25
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.25
+IGNORE_TERRAIN_BONUS		= 1
+
+[SupportBonus]
+
+[CompanyData]
+ShadowMorale		= 1
+Morale			= 35
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 0
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	14		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\dark_wolf_attack.wav

--- a/TGX Files/Data/ObjectData/units/DEFILER.INI
+++ b/TGX Files/Data/ObjectData/units/DEFILER.INI
@@ -1,0 +1,68 @@
+[ObjectData]
+ProperName = STRING_4541_Defiler
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\battle_priest.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	125		;health rating(float)
+CostGold		=	25			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	1			;int
+CostMana		=	0			;int
+UpkeepMana		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\anvil_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\battle_priest_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	11.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_4749_The_Defiler_is_a_horrifying_priest_capable_of_calling_upon_dark_powers_to_weaken_his_enemy_and_protect_his_own_troops__Defilers_are_dedicated_to_spreading_corruption_in_any_form_
+Group1			= 12
+
+[SpellData]
+MaxMana 		= 60 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 4		;the amount of mana that gets regenerated sec.
+Spell0			= Poison Cloud
+Spell1 			= Unholy Armor
+
+[BuildHierarchy]
+OnlyFaction		=	Ceyah
+Component1		=	Temple
+Component2		=	Library
+Technology		= 	Defiler
+
+[ElementBonus]
+
+[SupportBonus]
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)	
+Damage			=	16		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\battle_priest_melee.wav
+Sound2			= 	Game\club2.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/DEVOUT.INI
+++ b/TGX Files/Data/ObjectData/units/DEVOUT.INI
@@ -1,0 +1,70 @@
+[ObjectData]
+ProperName = STRING_0016_Devout
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\priestess.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	125		;health rating(float)
+CostGold		=	25			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	1			;int
+CostMana		=	0			;int
+UpkeepMana		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\Priestess_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Priestess_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2461_These_priestesses_have_been_so_warped_by_their_channeling_of_dark_powers_that_they_have_become_insane_fanatics__capable_of_channeling_terrifying_spells__Their_lust_for_death_is_infectous__bleeding_over_to_the_troops_they_travel_with_
+Group1			= 12
+;AttachedFX0		= orange_sparkle
+
+[SpellData]
+MaxMana 		= 60 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 4		;the amount of mana that gets regenerated sec.
+Spell0			= Unholy Strength
+Spell1 			= Life Leech
+
+[BuildHierarchy]
+OnlyFaction		=	Ceyah
+Component1		=	Nightbringers2
+Technology		= 	Devout
+
+[ElementBonus]
+
+[SupportBonus]
+ATTACK_BONUS_TO_ROUTED		= 4
+ATTACK_BONUS_TO_ANY		= 2
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)	
+Damage			=	10		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\battle_priest_melee.wav
+Sound2			= 	Game\club2.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/ELEMENTAL.INI
+++ b/TGX Files/Data/ObjectData/units/ELEMENTAL.INI
@@ -1,0 +1,71 @@
+[ObjectData]
+ProperName = STRING_2472_Elemental
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\elemental.tgr
+BoundingRadius		=	0.35		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	400			;health rating(float)
+;CostGold		=	4			;int
+;UpkeepGold		=	1			;int
+;UpkeepMana		=	.25			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\elemental_death.wav
+SelectionSound1		=	Game\select_elemental.wav
+CommandSound1		=	Game\select_elemental.wav
+
+[UnitData]
+Type			=	Monster
+Shadow			=	0
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\Elemental_icon.tgr
+IdleTime		=	1		;seconds(float)
+MovementRate		=	14		;movement points(float)
+WalkDistance		=   	1		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	11		; SAI combat rating (float)
+BannerFrame		=	22
+ResupplyRate		=	1		; health / second (float)
+Description 		= STRING_2473_Elementals_are_powerful_creatures_of_pure_magic__born_from_rock_and_fire__They_stun_their_foes_with_shockwaves_sent_through_the_ground_and_the_crush_them_with_their_massive_fists_
+Group1			= 18
+;AttachedFX		= Elemental_HitFX
+
+[SpellData]
+MaxMana =			50 ;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	1  ;the amount of mana that gets regenerated sec.
+Spell0			=	Earthburst
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_MAGIC		= .25
+DAMAGE_TAKEN_FROM_RANGED	= .50
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 100
+VisualRange		= 3
+ControlZone		= 2
+EntrenchmentRate	= 0
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	40		;number (float)
+DamageType		=	MAGIC	
+Sound1			= 	Game\elemental_attack.wav
+
+[Attack2]
+AttackTime		=	1		; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float)
+ReloadTime		=	3		; seconds (float)
+AttackType		=	CAST		; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/ELEMENTALIST.INI
+++ b/TGX Files/Data/ObjectData/units/ELEMENTALIST.INI
@@ -1,0 +1,68 @@
+[ObjectData]
+ProperName = STRING_4599_Elementalist
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\elite_sorceress.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	140			;health rating(float)
+CostGold		=	40			;int
+UpkeepWood		=	1			;int
+UpkeepMana		=	3			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	6			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\Sorceress_death.wav
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\elite_sorceress_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	22			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	12.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description = STRING_4752_The_Elementalist_is_from_an_order_of_mages_that_have_plumbed_the_depths_of_ancient_knowledge_and_come_up_with_what_may_be_the_most_powerful_spell_known_to_man___Capable_of_calling_down_the_stars_of_the_night_sky_to_strike_at_her_enemies__the_Elementalist_serves_as_the_Elite_Mage_for_the_Royalists__Few_can_match_her_raw_destructive_power_
+MeleeFX			= warmage_hitfx
+Group1			= 12
+
+[SpellData]
+MaxMana =			60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	5	;the amount of mana that gets regenerated sec.
+Spell0			=	Ice Armor
+Spell1			=	Meteor
+
+[BuildHierarchy]
+OnlyFaction		=	Royalist
+Component1		=	Temple
+Component2		=	MageCollege
+Component3		=	Barracks
+Technology		= 	Elementalist
+
+[ElementBonus]
+
+[SupportBonus]
+DAMAGE_TAKEN_FROM_MAGIC	= .6
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.75			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	36		;number (float)
+DamageType		=	MAGIC
+Sound1			= 	Spells\magician_attack.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/FOOTMAN.INI
+++ b/TGX Files/Data/ObjectData/units/FOOTMAN.INI
@@ -1,0 +1,77 @@
+[ObjectData]
+ProperName = STRING_1225_Footman
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\footman.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	200			;health rating(float)
+CostGold		=	3			;int
+UpkeepGold		=	0			;int
+UpkeepWood		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\footman_death.wav
+SelectionSound1		=	Game\select_infantry.wav
+SelectionSound2		=	Game\select_infantry2.wav
+CommandSound1		=	Game\command_infantry.wav
+CommandSound2		=	Game\command_infantry2.wav
+
+[UnitData]
+Type			=	FRONT
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\Footman_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	20			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	5.0		; SAI combat rating (float)
+BannerFrame		=	13
+ResupplyRate		=	10			; health / second (float)
+Description 		= STRING_2481_The_basic_Mareten_infantry_element__Footmen_are_inexpensive_to_upkeep_and_flexible_in_deployment_
+Group1			= 1
+Group2			= 5
+Group3			= 7
+Group4			= 10
+
+[BuildHierarchy]
+Race			=	Mareten
+ExceptFaction		= 	Ceyah
+;Component1		=	woodmill
+;Component2		=	blacksmith
+
+[ElementBonus]
+ATTACK_BONUS_TO_MOUNTED	= 5
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 35
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	20		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\spear3.wav
+Sound2			= 	Game\spear1.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/GIANT_WASP.INI
+++ b/TGX Files/Data/ObjectData/units/GIANT_WASP.INI
@@ -1,0 +1,72 @@
+[ObjectData]
+ProperName = STRING_4754_Giant_Wasp
+MonsterCompanyName = STRING_4755_Wasp_Swarm
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\giant_wasp.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	80			;health rating(float)
+CostGold		=	0			;int
+CostMana		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\wasp_death.wav
+SelectionSound1		=	Game\giant_wasp_select.wav
+CommandSound1		=	Game\wasp_attack.wav
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .25
+DAMAGE_TAKEN_FROM_MAGIC		= 1.25
+IGNORE_TERRAIN_BONUS = 1
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 100
+VisualRange		= 5
+ControlZone		= 4
+EntrenchmentRate	= 999
+
+[UnitData]
+Type			=	MONSTER
+Icon			=   Portraits\Unit Icons\Giant_Wasp_icon.tgr
+IdleTime		=	.8			;seconds(float)
+MovementRate		=	36			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	1.0		; SAI combat rating (float)
+ResupplyRate		=	1		; health / second (float)
+Description 		= STRING_4756_Yet_another_small_creature_mutated_by_the_stray_magic_of_Cataclysms__the_Giant_Wasp_is_new_threat_to_all_who_encounter_them__Weak_alone__they_tend_to_swarm_in_large_numbers_and_grow_rapidly_in_their_nests__It_is_best_to_eradicate_their_nests_quickly_when_found_
+DontStopIdling	= 1
+Group1		= 18
+
+[SpellData]
+MaxMana 		= 50 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 1	;the amount of mana that gets regenerated sec.
+Spell0			= Poison Sting
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.1		;seconds(float)
+AttackRange		=	0.25		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	14		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\wasp_attack.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.5			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0
+

--- a/TGX Files/Data/ObjectData/units/GOLEM.INI
+++ b/TGX Files/Data/ObjectData/units/GOLEM.INI
@@ -1,0 +1,74 @@
+[ObjectData]
+ProperName = STRING_2490_Golem
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\elemental.tgr
+BoundingRadius		=	0.35		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	300			;health rating(float)
+UpkeepStone		=	1			;int
+UpkeepMana		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\elemental_death.wav
+SelectionSound1		=	Game\select_elemental.wav
+CommandSound1		=	Game\select_elemental.wav
+
+[UnitData]
+Type			=	FRONT
+Shadow			=	0
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\Elemental_icon.tgr
+IdleTime		=	1		;seconds(float)
+MovementRate		=	14		;movement points(float)
+WalkDistance		=   	1		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10		; SAI combat rating (float)
+BannerFrame		=	22
+ResupplyRate		=	8		; health / second (float)
+Description 		= STRING_2491_Golems_are_weaker_cousins_of_the_Elemental__They_are_produced_enmasse_by_wizardry_guilds_to_create_mindless_warriors_that_feel_no_pain_or_fear_
+Group1			= 18
+
+[SpellData]
+
+[BuildHierarchy]
+Component1		=	Library
+Component2		=	Quarry
+Technology		= 	Golems
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_MAGIC		= .75
+DAMAGE_TAKEN_FROM_RANGED	= .50
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 100
+VisualRange		= 6
+ControlZone		= 5
+EntrenchmentRate	= 1
+Berserk			= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	36		;number (float)
+DamageType		=	MAGIC	
+Sound1			= 	Game\elemental_attack.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/HAROUN_CAPTAIN.INI
+++ b/TGX Files/Data/ObjectData/units/HAROUN_CAPTAIN.INI
@@ -1,0 +1,66 @@
+[ObjectData]
+ProperName = STRING_4066_Haroun_Captain
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\haroun_captain.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	300			;health rating(float)
+CostGold		=	15			;int
+UpkeepGold		=	0			;int
+CostWood		=	1			;int
+CostIron		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\windrider_death.wav
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .5
+DEFENSE_BONUS_VS_ARCHER		= 10
+ATTACK_BONUS_TO_BUILDING 	= -20
+
+[SupportBonus]
+
+[CompanyData]
+
+[UnitData]
+Type			=	CAPTAIN
+Icon			=   Portraits\Unit Icons\haroun_captain_icon.tgr
+Portrait		=	Portraits\Heroes\haroun_captain_portrait.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	34			;movement points(float)
+WalkDistance		= 	1.2		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0		; SAI combat rating (float)
+ResupplyRate		=	15			; health / second (float)
+Description 		= STRING_4067_The_Haroun_Captain_is_the_fighting_Windrider_trained_to_lead_a_company_into_battle_
+Group1			= 6
+Group2			= 10
+Group3			= 17
+
+[Attack1]
+AttackTime		=	1			;seconds(float) seconds per animation cycle
+Projectile		=   horsebow_arrow
+DamagePoint		=	0.8			;seconds(float) at what point (percentage) in attack animation to apply damage/shoot projectile
+ReloadTime		=	2			;seconds(float)
+AttackRange		=	6			;tiles (float)
+AttackType		=	PROJECTILE		;enumeration list(int)
+Damage			=	34		;number (float)
+DamageType		=	NORMAL
+Sound1			=	Game\bow2.wav
+
+[Attack2]
+AttackTime		=	1			;seconds(float) seconds per animation cycle
+DamagePoint		=	0.55			;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5			;seconds(float)
+AttackRange		=	0.75			;tiles (float)
+AttackType		=	MELEE			;enumeration list(int)
+Damage			=	12		;number (float)
+DamageType		=	NORMAL
+Sound1			=	Game\sword4.wav

--- a/TGX Files/Data/ObjectData/units/HIGH_PRIEST.INI
+++ b/TGX Files/Data/ObjectData/units/HIGH_PRIEST.INI
@@ -1,0 +1,70 @@
+[ObjectData]
+ProperName = STRING_4607_High_Priest
+Class			= 	1			;enumeration list(int)
+Sprite			=   	units\battle_priest.tgr
+BoundingRadius		=	0.25			;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	125			;health rating(float)
+CostGold		=	25 			;int
+UpkeepIron		=	1			;int
+UpkeepMana		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\ranger_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\battle_priest_icon.tgr
+IdleTime		=	2		;seconds(float)
+MovementRate		=	16		;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8	; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= 	STRING_4757_Channeling_the_power_of_the_Creator__the_High_Priest_is_a_formidable_foe_to_those_that_serve_the_Nightbringer___The_High_Priests_have_discovered_secret_prayers_to_bind_their_foes_in_rays_of_shimmering_gold_light__Combined_with_prayers_that_keep_their_troops_morale_steady__they_can_be_powerful_allies_of_the_Creator_
+Group1			= 12
+
+[SpellData]
+MaxMana 		=	60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	5	;the amount of mana that gets regenerated sec.
+Spell0			=	Courage
+Spell1			=	Heaven's Cage
+
+[BuildHierarchy]
+ExceptFaction		=	Ceyah
+Component1		=	Library
+Component2		=	Temple
+Technology		= 	High Priest
+
+[ElementBonus]
+
+[SupportBonus]
+ATTACK_BONUS_TO_SHADOW	= 3
+DAMAGE_TAKEN_FROM_UNHOLY	= .5
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)
+Damage			=	10		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\battle_priest_melee.wav
+Sound2			= 	Game\club2.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.25		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+

--- a/TGX Files/Data/ObjectData/units/LICH.INI
+++ b/TGX Files/Data/ObjectData/units/LICH.INI
@@ -1,0 +1,85 @@
+[ObjectData]
+ProperName = STRING_0018_Lich
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\wraith.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	140			;health rating(float)
+CostGold		=	24			;int
+UpkeepMana		=	2			;int
+UpkeepIron		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	16			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\wraith_death.wav
+SelectionSound1		=	Game\undead_select.wav
+
+[UnitData]
+Type			=	SUPPORT
+Shadow			=	1
+Archer			=	1
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\Wraith_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	18 ;16			;movement points(float)
+WalkDistance		=   0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.5		; SAI combat rating (float)
+BannerFrame		=	23
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2500_The_lich_is_a_special_form_of_Wraith__even_more_terrifying_in_power_and_capacity_for_evil__They_have_an_innate_ability_to_see_beyond_normal_reality__increasing_their_awareness_of_their_surroundings_and_enabling_their_company_to_increase_it_s_zone_of_control_
+MeleeFX			= wraith_hitfx
+Group1			= 12
+Group2			= 15
+Group3			= 16
+
+[BuildHierarchy]
+OnlyFaction		= Ceyah
+Component1		= ManaForge
+Component2		= library
+Technology		= Lich
+
+[SpellData]
+MaxMana 		=	60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	5	;the amount of mana that gets regenerated sec.
+Spell0			=		Summon Dead
+Spell1			=		Dreadfire
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .5
+DAMAGE_TAKEN_FROM_MELEE		= .5
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.5
+
+[SupportBonus]
+ZONE_OF_CONTROL_BONUS	= 1.2
+
+[CompanyData]
+Morale			= 30
+VisualRange		= 5
+ControlZone		= 4
+EntrenchmentRate	= 2
+ShadowMorale		= 1
+NoTerrainVisual		= 1
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.2			; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE			;enumeration list (int)
+Damage			=	20			;number (float)
+DamageType		=	MAGIC
+Sound1			=	spells\wizard_attack.wav
+
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST			; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/MAELSTROM_ORB.INI
+++ b/TGX Files/Data/ObjectData/units/MAELSTROM_ORB.INI
@@ -1,0 +1,73 @@
+[ObjectData]
+ProperName = STRING_4770_Maelstrom_Engine
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\siege_engine.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	250			;health rating(float)
+CostGold		=	30 ;25			;int
+UpkeepMana		=	2			;int
+UpkeepWood		=	2			;int
+;UpkeepStone		=	1			;int
+;UpkeepIron		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	2			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\siege_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Siege_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	12 ;10			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	15.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_4771_The_Maelstrom_Engine_is_the_ultimate_mystical_weapon_of_destruction___Surrounded_by_a_field_of_deadly_energy__the_Maelstrom_Engine_is_capable_of_directing_immense_blasts_of_pure_Khaldunite_at_the_enemy__shattering_walls_and_searing_the_ground_with_shadows_of_the_vaporized___Developed_during_the_Third_Age__these_magic_siege_engines_made_it_so_that_castle_walls_were_no_longer_regarded_as_safe_havens_
+MeleeFX			= wizard_hitfx
+
+[BuildHierarchy]
+Component1		=	Woodmill
+Component2		=	Library
+;Component3		=	Quarry
+;Component4		=	Blacksmith
+
+[ElementBonus]
+ATTACK_BONUS_TO_BUILDING	= 150 ;225
+REVERSE_DAMAGE_WHEN_HIT		= 5
+
+[SupportBonus]
+ZONE_OF_CONTROL_BONUS		= 1.25
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			;seconds(float) seconds per animation cycle
+Projectile		=   	maelstrom_blast
+DamagePoint		=	0.6			;seconds(float) at what point (percentage) in attack animation to apply damage/shoot projectile
+ReloadTime		=	3			;seconds(float)
+AttackRange		=	8			;tiles (float)
+AttackType		=	PROJECTILE	;enumeration list(int)
+Damage			=	25		;number (float)
+DamageType		=	KHALDUNITE
+Sound1			=	game\siege_explosion.wav
+Animation		=	0	
+AreaRadius		=	2.5
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.35		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	2			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	25		;number (float)
+DamageType		=	KHALDUNITE
+Sound1			=	game\siege_melee.wav
+Animation		=	0	

--- a/TGX Files/Data/ObjectData/units/NECROMANCER.INI
+++ b/TGX Files/Data/ObjectData/units/NECROMANCER.INI
@@ -1,0 +1,67 @@
+[ObjectData]
+ProperName = STRING_2501_Necromancer
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\warmage.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	130			;health rating(float)
+CostGold		=	16 ;20			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	4			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\anvil_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Warmage_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2502_The_foul_Necromancer_is_capable_of_summoning_up_the_very_corpses_of_the_dead_to_do_battle_for_him__He_is_also_known_for_poisoning_the_air_around_his_enemies__rendering_them_weak_and_helpless_
+MeleeFX			= necromancer_hitfx
+Group1			= 12
+
+[SpellData]
+MaxMana =				60 ;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	4	;the amount of mana that gets regenerated sec.
+Spell0			=		Summon Dead
+Spell1			=		Lethargy
+
+[BuildHierarchy]
+Component1		=	Library
+OnlyFaction		=	Ceyah
+
+[ElementBonus]
+
+[SupportBonus]
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.75			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	30		;number (float)
+DamageType		=	MAGIC
+Sound1			= 	Spells\necro_attack.wav
+Animation		=	1			; warmage animations are backwards in TGS
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0			; warmage animations are backwards in TGS

--- a/TGX Files/Data/ObjectData/units/ORACLE.INI
+++ b/TGX Files/Data/ObjectData/units/ORACLE.INI
@@ -1,0 +1,71 @@
+[ObjectData]
+ProperName = STRING_4581_Oracle
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\elite_priestess.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	125		;health rating(float)
+CostGold		=	35			;int
+UpkeepIron		=	2			;int
+UpkeepMana		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\Priestess_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\elite_priestess_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	22			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	11.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description = STRING_4773_Blessed_with_incredible_powers_of_healing__the_Oracle_serves_as_the_Elite_Priest_for_an_ancient__but_little_known_sect_of_the_Council_priesthood_
+Group1			= 12
+
+[SpellData]
+MaxMana 		= 60 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 4		;the amount of mana that gets regenerated sec.
+Spell0			= Restoration
+Spell1 			= Invigorate
+
+[BuildHierarchy]
+OnlyFaction		=	Council
+Component1		=	TempleOfTheOverseers
+Component2		=	Library
+Component3		=	Blacksmith
+Technology		= 	Oracle
+
+[ElementBonus]
+
+[SupportBonus]
+RESUPPLY_RATE_BONUS		= 1.2 	;1.25
+DAMAGE_TAKEN_FROM_UNHOLY	= .5
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)
+Damage			=	12		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\battle_priest_melee.wav
+Sound2			= 	Game\club2.wav
+Animation		=	1		; warmage animations are backwards in TGS
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0		; warmage animations are backwards in TGS

--- a/TGX Files/Data/ObjectData/units/PIKEMAN.INI
+++ b/TGX Files/Data/ObjectData/units/PIKEMAN.INI
@@ -1,0 +1,78 @@
+[ObjectData]
+ProperName = STRING_4611_Pikeman
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\footman.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	200			;health rating(float)
+CostGold		=	4			;int
+UpkeepGold		=	0			;int
+UpkeepWood		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	14			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\footman_death.wav
+SelectionSound1		=	Game\select_infantry.wav
+SelectionSound2		=	Game\select_infantry2.wav
+CommandSound1		=	Game\command_infantry.wav
+CommandSound2		=	Game\command_infantry2.wav
+
+[UnitData]
+Type			=	FRONT
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\Footman_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	20			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	5.0		; SAI combat rating (float)
+BannerFrame		=	13
+ResupplyRate		=	10			; health / second (float)
+Description 		= STRING_4774_The_Pikeman_wields_an_eight_foot_long_pike_in_combat__wears_heavier_armor_and_is_trained_to_withstand_the_charge_of_any_enemy__They_are_the_masters_of_defense__able_to_entrench_quickly_and_withstand_powerful_attacks_
+Group1			= 1
+Group2			= 5
+Group3			= 7
+Group4			= 10
+
+[BuildHierarchy]
+ExceptFaction		= Ceyah
+Race			= MARETEN
+Component1		= Barracks
+Technology		= Pikeman
+
+[ElementBonus]
+ATTACK_BONUS_TO_MOUNTED	= 5
+
+[SupportBonus]
+ZONE_OF_CONTROL_BONUS	= 1.2
+
+[CompanyData]
+Morale			= 40
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= .8
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)
+Damage			=	22		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\spear3.wav
+Sound2			= 	Game\spear1.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/PROPHET.INI
+++ b/TGX Files/Data/ObjectData/units/PROPHET.INI
@@ -1,0 +1,68 @@
+[ObjectData]
+ProperName = STRING_2506_Prophet
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\battle_priest.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	120		;health rating(float)
+CostGold		=	16 ;32			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	1			;int
+CostMana		=	0			;int
+UpkeepMana		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\ranger_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\battle_priest_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2507_The_virtually_insane_priests_of_the_Great_Master__Prophets_are_known_for_their_spells_that_drain_the_life_of_their_enemies_and_paralyze_them_through_tremendous_assaults_of_pain_and_fear__Their_lust_for_death_is_infectous__bleeding_over_to_the_troops_they_travel_with_
+Group1			= 12
+
+[SpellData]
+MaxMana 		= 60 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 3	;the amount of mana that gets regenerated sec.
+Spell0			= Paralyze
+Spell1 			= Life Leech
+
+[BuildHierarchy]
+OnlyFaction		= Ceyah
+Component1		= Temple
+
+[ElementBonus]
+
+[SupportBonus]
+ATTACK_BONUS_TO_ROUTED		= 2
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)	
+Damage			=	10		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\battle_priest_melee.wav
+Sound2			= 	Game\club2.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+

--- a/TGX Files/Data/ObjectData/units/RHAKSHA.INI
+++ b/TGX Files/Data/ObjectData/units/RHAKSHA.INI
@@ -1,0 +1,64 @@
+[ObjectData]
+ProperName = STRING_0512_Rhaksha
+MonsterCompanyName = STRING_0512_Rhaksha
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\rhaksha.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	150			;health rating(float)
+CostGold		=	0			;int
+CostMana		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	6			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\rhaksha_death.wav
+SelectionSound1		=	Game\select_rhaksha.wav
+CommandSound1		=	Game\select_rhaksha.wav
+
+[UnitData]
+Type			=	MONSTER
+Icon			=   Portraits\Unit Icons\Rhaksha_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	24			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	3.0		; SAI combat rating (float)
+ResupplyRate		=	1		; health / second (float)
+Description 		= STRING_2511_Foul_creatures_of_unknown_origin__Rhaksha_have_swarmed_over_Khaldun_defiling_all_they_touch_
+
+[ElementBonus]
+ATTACK_BONUS_TO_ROUTED	= 4
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 25
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 0
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	24		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\rhaksha_attack.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/RHAKSHA_HIVEMASTER.INI
+++ b/TGX Files/Data/ObjectData/units/RHAKSHA_HIVEMASTER.INI
@@ -1,0 +1,64 @@
+[ObjectData]
+ProperName = STRING_2512_Rhaksha_Hivemaster
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\rhaksha_hivemaster.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	320			;health rating(float)
+CostGold		=	0			;int
+CostMana		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\hivemaster_death.wav
+SelectionSound1		=	Game\select_hivemaster.wav
+CommandSound1		=	Game\select_hivemaster.wav
+
+[UnitData]
+Type			=	MONSTER
+Icon			=   Portraits\Unit Icons\Hivemaster_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	25			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.5		; SAI combat rating (float)
+ResupplyRate		=	1		; health / second (float)
+Description 		= STRING_2513_Twice_as_large_as_a_normal_Rhaksha__Hivemasters_rule_over_the_larger_colonies_that_occasionally_appear_
+
+[ElementBonus]
+ATTACK_BONUS_TO_ROUTED	= 4
+DEFENSE_BONUS_VS_ARCHER	= 8
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 50
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 0
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	36		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\hivemaster_attack.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/RHAKSHA_HUNTER.INI
+++ b/TGX Files/Data/ObjectData/units/RHAKSHA_HUNTER.INI
@@ -1,0 +1,69 @@
+[ObjectData]
+ProperName = STRING_2514_Rhaksha_Hunter
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\rhaksha.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	170			;health rating(float)
+CostGold		=	0			;int
+CostMana		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	6			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\rhaksha_death.wav
+SelectionSound1		=	Game\select_rhaksha.wav
+CommandSound1		=	Game\select_rhaksha.wav
+
+[UnitData]
+Type			=	FRONT
+Captain			=	Rhaksha_Leader
+Icon			=   Portraits\Unit Icons\Rhaksha_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	24			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	4.0		; SAI combat rating (float)
+ResupplyRate		=	10		; health / second (float)
+BannerFrame		=	10
+Description 		= STRING_2515_Stronger_and_more_deadly_than_their_fellow_Rhaksha__the_hunters_are_used_by_Amon_Koth_to_hunt_down_and_slaughter_those_who_oppose_him_
+
+[BuildHierarchy]
+OnlyFaction		= 	None
+Race		=	None
+
+[ElementBonus]
+ATTACK_BONUS_TO_ROUTED	= 4
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 50
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 9999
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	28		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\rhaksha_attack.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/RHAKSHA_LEADER.INI
+++ b/TGX Files/Data/ObjectData/units/RHAKSHA_LEADER.INI
@@ -1,0 +1,68 @@
+[ObjectData]
+ProperName = STRING_2516_Rhaksha_Huntmaster
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\rhaksha_hivemaster.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	340			;health rating(float)
+CostGold		=	0			;int
+CostMana		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\hivemaster_death.wav
+SelectionSound1		=	Game\select_hivemaster.wav
+CommandSound1		=	Game\select_hivemaster.wav
+
+[UnitData]
+Type			=	CAPTAIN
+Icon			=   Portraits\Unit Icons\Hivemaster_icon.tgr
+Portrait		=	Portraits\Heroes\Rhaksha_Portrait.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	25			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	9.0 ; 	; SAI combat rating (float)
+ResupplyRate		=	10		; health / second (float)
+Description 		= STRING_2517_Nearly_as_dangerous_as_Amon_Koth_s_Chosen__Huntmasters_are_powerful_creatures_who_drive_the_Rhaksha_Hunters_forward_in_pursuit_of_prey_
+
+[BuildHierarchy]
+OnlyFaction		=	None
+
+[ElementBonus]
+ATTACK_BONUS_TO_ROUTED	= 4
+DEFENSE_BONUS_VS_ARCHER	= 4
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 75
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 0
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	38		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\hivemaster_attack.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/RHAKSHA_SLAVE.INI
+++ b/TGX Files/Data/ObjectData/units/RHAKSHA_SLAVE.INI
@@ -1,0 +1,69 @@
+[ObjectData]
+ProperName = STRING_1577_Rhaksha_Slave
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\rhaksha.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	150			;health rating(float)
+CostGold		=	6			;int
+CostMana		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	4			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\rhaksha_death.wav
+SelectionSound1		=	Game\select_rhaksha.wav
+CommandSound1		=	Game\select_rhaksha.wav
+
+[UnitData]
+Type			=	FRONT
+Captain			=	Shadow_Captain
+Icon			=   Portraits\Unit Icons\Rhaksha_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	24			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	3.5		; SAI combat rating (float)
+ResupplyRate		=	10		; health / second (float)
+BannerFrame		=	22
+Description 		= STRING_2518_These_violent_creatures_have_been_enslaved_to_be_used_as_fodder_in_mortal_wars_
+
+[BuildHierarchy]
+OnlyFaction		= 	Ceyah
+Technology		=	Rhaksha Slave
+
+[ElementBonus]
+ATTACK_BONUS_TO_ROUTED	= 6
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 25
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 9999
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	22		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\rhaksha_attack.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/SHADELING.INI
+++ b/TGX Files/Data/ObjectData/units/SHADELING.INI
@@ -1,0 +1,72 @@
+[ObjectData]
+ProperName = STRING_2522_Shadeling
+MonsterCompanyName = STRING_2941_Shadelings
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\shadeling.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	120			;health rating(float)
+CostGold		=	0			;int
+CostMana		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	6			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\shadeling_death.wav
+SelectionSound1		=	Game\select_shadeling.wav
+CommandSound1		=	Game\select_shadeling.wav
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .75
+DAMAGE_TAKEN_FROM_HOLY		= 1.5
+DAMAGE_TAKEN_FROM_MAGIC		= 1.25
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.25
+IGNORE_TERRAIN_BONUS = 1
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 30
+VisualRange		= 5
+ControlZone		= 3
+EntrenchmentRate	= 0
+ShadowMorale		= 1
+
+[UnitData]
+Type			=	MONSTER
+Mounted			=	1			;; drp121300 - added mounted/shadow, same as shadeling_scout
+Shadow			=	1
+Icon			=   Portraits\Unit Icons\Shadeling_icon.tgr
+IdleTime		=	.8			;seconds(float)
+MovementRate		=	20			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	1.5		; SAI combat rating (float)
+ResupplyRate		=	1		; health / second (float)
+Description 		= STRING_2523_Small_and_vicious__Shadelings_are_the_embodiment_of_spite_among_the_creatures_of_shadow_
+DontStopIdling	= 1
+Group1			= 18
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.1		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	8		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\shadeling_attack.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/SHADOW_MONSTER.INI
+++ b/TGX Files/Data/ObjectData/units/SHADOW_MONSTER.INI
@@ -1,0 +1,65 @@
+[ObjectData]
+ProperName = STRING_2524_Shadow_Beast
+MonsterCompanyName = STRING_3018_Shadow_Beasts
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\shadow_beast.tgr
+BoundingRadius		=	0.35		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	250			;health rating(float)
+BuildTime		=	5			;seconds(float)
+Defense			=	5			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\shadow_beast_death.wav
+SelectionSound1		=	Game\select_shadow_beast.wav
+CommandSound1		=	Game\select_shadow_beast.wav
+
+[UnitData]
+Type			=	MONSTER
+Shadow			=	1
+Icon			=   Portraits\Unit Icons\Shadow_Beast_icon.tgr
+IdleTime		=	1			;seconds(float)
+MovementRate	=	25			;movement points(float)
+WalkDistance	=   1		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	6.5		; SAI combat rating (float)
+BannerFrame		=	21
+ResupplyRate	=	5			; health / second (float)
+Group1			= 18
+Description = STRING_2533_Shadow_Beasts_are_demonic_creatures__fearsome_in_appearance_and_strength_
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_ANY		= .80
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.5
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 35
+VisualRange		= 7
+ControlZone		= 4
+EntrenchmentRate	= 100
+ShadowMorale		= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	26		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\shadowbeast_attack.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/SHADOW_PRIEST.INI
+++ b/TGX Files/Data/ObjectData/units/SHADOW_PRIEST.INI
@@ -1,0 +1,67 @@
+[ObjectData]
+ProperName = STRING_2534_Shadow_Priest
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\battle_priest.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	120		;health rating(float)
+CostGold		=	24 ;32			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	1			;int
+CostMana		=	0			;int
+UpkeepMana		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\ranger_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\battle_priest_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2535_Shadow_Priests_are_dedicated_to_the_evil_of_the_shadow__capable_of_casting_spells_that_bless_their_troops_with_demonic_fury_and_stun_their_enemy_with_sheer_pain__They_also_have_the_ability_to_deaden_their_troop_s_reaction_of_fear_and_pain__causing_them_to_fight_without_concern_for_their_own_lives_
+Group1			= 12
+
+[SpellData]
+MaxMana 		= 60 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 3		;the amount of mana that gets regenerated per update (30 times/sec)
+Spell0			= Shadow's Blessing
+Spell1 			= Shadowshock
+
+[BuildHierarchy]
+Component1		=	Nightbringers2
+
+[ElementBonus]
+
+[SupportBonus]
+MORALE_CHECK_BONUS	= 2
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)	
+Damage			=	10		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\battle_priest_melee.wav
+Sound2			= 	Game\club2.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.25		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+

--- a/TGX Files/Data/ObjectData/units/SKELETON.INI
+++ b/TGX Files/Data/ObjectData/units/SKELETON.INI
@@ -1,0 +1,76 @@
+[ObjectData]
+ProperName = STRING_2537_Skeleton_Warrior
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\skeleton.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	220			;health rating(float)
+CostGold		=	4			;int
+UpkeepIron		=	1			;int
+UpkeepMana		=	0			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\skeleton_death.wav
+SelectionSound1		=	Game\undead_select.wav
+CommandSound1		=	Game\undead_select.wav
+
+[UnitData]
+Type			=	FRONT
+Shadow			=	1
+Captain			=	undead_captain
+Icon			=   Portraits\Unit Icons\Skeleton_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	20		;movement points(float)
+WalkDistance		=   	.7		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	5.5		; SAI combat rating (float)
+BannerFrame		=	23
+ResupplyRate		=	11		; health / second (float)
+Description 		= STRING_2510_Evil_magicks_have_summoned_forth_skeletal_warriors_to_wreak_havoc_upon_the_enemies_of_the_Dark_Master_
+Group1			= 5
+Group2			= 8
+Group3			= 15
+
+[BuildHierarchy]
+OnlyFaction		= 	Ceyah
+Component1		=	Blacksmith
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .05
+DAMAGE_TAKEN_FROM_HOLY		= 2
+DAMAGE_TAKEN_FROM_MAGIC		= 1.25
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 30
+VisualRange		= 5
+ControlZone		= 3
+EntrenchmentRate	= 1
+ShadowMorale		= 1
+NoTerrainVisual		= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	22		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\sword4.wav
+Sound2			= 	Game\sword2.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/SLAAN.INI
+++ b/TGX Files/Data/ObjectData/units/SLAAN.INI
@@ -1,0 +1,72 @@
+[ObjectData]
+ProperName = STRING_0553_Slaan
+MonsterCompanyName = STRING_0553_Slaan
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\slaan.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	190			;health rating(float)
+CostGold		=	0			;int
+CostMana		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	12			;number (float)
+DieTime			=	1.3			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\slaan_death.wav
+SelectionSound1		=	Game\select_slaan.wav
+CommandSound1		=	Game\select_slaan.wav
+
+[UnitData]
+Type			=	MONSTER
+Icon			=   Portraits\Unit Icons\Slaan_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	6.5		; SAI combat rating (float)
+ResupplyRate		=	20		; health / second (float)
+Description 		= STRING_2538_The_Slaan_are_a_strange_race_of_reptile_men_that_occupy_abandoned_cities_and_ancient_ruins_in_addition_to_their_mud_hut_lairs_
+
+[SpellData]
+MaxMana 		= 50 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 1	;the amount of mana that gets regenerated sec.
+Spell0			= Poison Spit
+
+[ElementBonus]
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 30
+VisualRange		= 5
+ControlZone		= 4
+EntrenchmentRate	= 0
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	18		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\spear2.wav
+Sound2			= 	Game\spear3.wav
+Animation		= 	1
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0
+;AttackRange		=	.75			; tiles (float)
+;DamageType		=	0			; number (float)
+;Sound1			=	Game\settler_attack.wav

--- a/TGX Files/Data/ObjectData/units/SLAANRI_CAPTAIN.INI
+++ b/TGX Files/Data/ObjectData/units/SLAANRI_CAPTAIN.INI
@@ -1,0 +1,63 @@
+[ObjectData]
+ProperName = STRING_4779_Slaanri_Captain
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\slaan_champion.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	300			;health rating(float)
+CostGold		=	15			;int
+UpkeepGold		=	0			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+DieTime			=	1			;seconds(float)
+;OverwriteColor  =	10
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\slaanri_death.wav
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .5
+
+[SupportBonus]
+
+[CompanyData]
+
+[UnitData]
+Type			=	CAPTAIN
+Icon			=   Portraits\Unit Icons\Slaan_Champion_icon.tgr
+Portrait		=	Portraits\Heroes\slaanri_captain_portrait.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	26			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0 		; SAI combat rating (float)
+ResupplyRate		=	15			; health / second (float)
+Description 		= STRING_4780_The_Slaanri_captain_is_the_fighting_warrior_trained_to_lead_a_company_into_battle_
+Group1			= 8
+Group2			= 11
+Group3			= 9
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.3		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)
+Damage			=	28		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\captain_attack.wav
+Sound2			= 	Game\sword3.wav
+Animation		= 	1
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)
+DamageType		=	0		;number (float)
+Animation		= 	0

--- a/TGX Files/Data/ObjectData/units/SLAANRI_CHAMPION.INI
+++ b/TGX Files/Data/ObjectData/units/SLAANRI_CHAMPION.INI
@@ -1,0 +1,82 @@
+[ObjectData]
+ProperName = STRING_4595_Slaanri_Champion
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\slaan_champion.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	275			;health rating(float)
+CostGold		=	10			;int
+CostMana		=	0			;int
+UpkeepStone		=	2 ;1			;int
+UpkeepWood		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	16			;number (float)
+DieTime			=	1.3			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\slaan_death.wav
+SelectionSound1		=	Game\slaanri_warrior_select1.wav
+SelectionSound2		=	Game\slaanri_warrior_select2.wav
+SelectionSound3		=	Game\slaanri_warrior_select3.wav
+CommandSound1		=	Game\slaanri_warrior_command1.wav
+CommandSound2		=	Game\slaanri_warrior_command2.wav
+CommandSound3		=	Game\slaanri_warrior_command3.wav
+
+[UnitData]
+Type			=	Front
+Captain			=	slaanri_captain
+Icon			=   Portraits\Unit Icons\Slaan_Champion_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	18			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	9.0		; SAI combat rating (float)
+ResupplyRate		=	20		; health / second (float)
+BannerFrame		=	28
+Description 		= STRING_4781_Wielding_great_forked_spears_with_wild_abandon__the_Slaanri_Champion_stands_as_the_strongest_and_deadliest_of_all_the_Slaanri_warriors_
+Group1			= 7
+
+[SpellData]
+MaxMana 		= 50 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 3	;the amount of mana that gets regenerated sec.
+Spell0			= Poison Spit
+
+[BuildHierarchy]
+ExceptFaction		=	Ceyah
+Component1		= Quarry
+Component2		= Barracks
+Technology		=	Slaanri Champion
+
+[ElementBonus]
+;RESUPPLY_RATE_BONUS	= 1.25
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 50
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)
+Damage			=	28		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\spear2.wav
+Sound2			= 	Game\spear3.wav
+Animation		= 	1
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0

--- a/TGX Files/Data/ObjectData/units/SLAANRI_MYSTIC.INI
+++ b/TGX Files/Data/ObjectData/units/SLAANRI_MYSTIC.INI
@@ -1,0 +1,76 @@
+[ObjectData]
+ProperName = STRING_4784_Slaanri_Mystic
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\slaan_mystic.tgr
+BoundingRadius		=	0.25			;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	200			;health rating(float)
+CostGold		=	18			;int
+UpkeepStone		=	1			;int
+UpkeepWood		=	1			;int
+UpkeepMana		=	1			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	14			;number (float)
+DieTime			=	1.3			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\mystic_death.wav
+SelectionSound1		=	Game\slaan_select.wav
+CommandSound1		=	Game\slaan_select.wav
+
+[UnitData]
+Type			=	SUPPORT
+Captain			=	slaanri_captain
+Icon			=   Portraits\Unit Icons\Slaan_Mystic_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	9.0		; SAI combat rating (float)
+ResupplyRate		=	20		; health / second (float)
+BannerFrame		=	13
+Description = STRING_4785_The_Slaanri_Mystic_is_a_creature_that_lives_in_close_harmony_with_nature__They_can_call_upon_the_surrounding_flora_and_fauna_to_harry_their_enemies_and_protect_their_homes_
+Group1			= 12
+
+[SpellData]
+MaxMana 		= 60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 4	;the amount of mana that gets regenerated sec.
+Spell0			= Entangle
+Spell1			= Summon Wasps
+
+[BuildHierarchy]
+Race			= Slaan
+Component1		= Temple
+Component2		= Quarry
+
+[ElementBonus]
+;RESUPPLY_RATE_BONUS	= 1.15
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 40
+VisualRange		= 5
+ControlZone		= 4
+EntrenchmentRate	= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)
+Damage			=	18		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\mystic_attack.wav
+Sound2			= 	Game\spear3.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/SLAANRI_SLAVER.INI
+++ b/TGX Files/Data/ObjectData/units/SLAANRI_SLAVER.INI
@@ -1,0 +1,79 @@
+[ObjectData]
+ProperName = STRING_4603_Slaanri_Slaver
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\slaan_mystic.tgr
+BoundingRadius		=	0.25			;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	100			;health rating(float)
+CostGold		=	12			;int
+CostMana		=	0			;int
+UpkeepStone		=	1			;int
+UpkeepWood		=	1			;int
+UpkeepMana		=	2			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	10			;number (float)
+DieTime			=	1.3			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\mystic_death.wav
+SelectionSound1		=	Game\slaan_select.wav
+CommandSound1		=	Game\slaan_select.wav
+
+[UnitData]
+Type			=	SUPPORT
+Captain			=	slaanri_captain
+Icon			=   Portraits\Unit Icons\Slaan_Mystic_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	20			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0		; SAI combat rating (float)
+ResupplyRate		=	20		; health / second (float)
+BannerFrame		=	13
+Description = STRING_4786_Former_Mystics_twisted_by_the_evil_influence_of_Hss_Rak__the_Slaanri_Slavers_live_to_do_their_master_s_bidding___The_Slavers_can_poison_their_foes_with_a_cloud_of_noxious_fumes_while_calling_forth_a_horde_of_enslaved_Slaan_
+Group1			= 12
+
+[SpellData]
+MaxMana 		= 65 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 4	;the amount of mana that gets regenerated sec.
+Spell0			= Poison Cloud
+Spell1			= Summon Slaan Horde
+
+[BuildHierarchy]
+OnlyFaction		= Ceyah
+Component1		= Temple
+Component2		= Barracks
+Technology		= Slaanri Slaver
+
+[ElementBonus]
+
+[SupportBonus]
+ATTACK_BONUS_TO_ROUTED	= 2
+;MORALE_RECOVERY_RATE_BONUS	= .7
+
+[CompanyData]
+Morale			= 50
+VisualRange		= 6
+ControlZone		= 5
+EntrenchmentRate	= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)
+Damage			=	24		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\spear2.wav
+Sound2			= 	Game\spear3.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/SLAAN_CHAMPION.INI
+++ b/TGX Files/Data/ObjectData/units/SLAAN_CHAMPION.INI
@@ -1,0 +1,75 @@
+[ObjectData]
+ProperName = STRING_2539_Champion
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\slaan_champion.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	250			;health rating(float)
+CostGold		=	10			;int
+CostMana		=	0			;int
+UpkeepWood		=	2			;int
+UpkeepMana		=	0			:int
+BuildTime		=	5			;seconds(float)
+Defense			=	14			;number (float)
+DieTime			=	1.3			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\slaan_death.wav
+SelectionSound1		=	Game\slaan_select.wav
+CommandSound1		=	Game\slaan_select.wav
+
+[UnitData]
+Type			=	Front
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\Slaan_Champion_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		= 	0.77		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	9.0		; SAI combat rating (float)
+ResupplyRate		=	20		; health / second (float)
+BannerFrame		=	13
+Description 		= STRING_2540_The_Slaan_Champion_is_strongest_and_most_deadly_of_Slaan_that_fight_for_the_Slaan_Villages_of_Dragonbone_Isle_
+Group1			= 7
+Group2			= 9
+
+[SpellData]
+MaxMana 		= 50 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 3	;the amount of mana that gets regenerated sec.
+Spell0			= Poison Spit
+
+[BuildHierarchy]
+Technology		=	Slaan Champion
+
+[ElementBonus]
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 40
+VisualRange		= 5
+ControlZone		= 4
+EntrenchmentRate	= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	0.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	26		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\spear2.wav
+Sound2			= 	Game\spear3.wav
+Animation		= 	1
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0

--- a/TGX Files/Data/ObjectData/units/SORCERER.INI
+++ b/TGX Files/Data/ObjectData/units/SORCERER.INI
@@ -1,0 +1,69 @@
+[ObjectData]
+ProperName = STRING_4609_Sorcerer
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\warmage.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	125			;health rating(float)
+CostGold		=	22			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	3			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	6			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\anvil_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Warmage_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	18			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	12.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_4789_Able_to_freeze_opponents_and_protect_himself_with_a_shield_of_pure_ice__the_reclusive_Sorcerer_has_mastered_the_elements_of_snow_and_ice_
+MeleeFX			= warmage_hitfx
+Group1			= 12
+
+[SpellData]
+MaxMana =			60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	5	;the amount of mana that gets regenerated sec.
+Spell0			=	Ice Armor
+Spell1			=	Arctic Blast
+
+[BuildHierarchy]
+ExceptFaction		=	Ceyah
+Component1		=	MageCollege
+Technology		= 	Sorcerer
+
+[ElementBonus]
+
+[SupportBonus]
+DAMAGE_TAKEN_FROM_MAGIC	= .6
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.75			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	24		;number (float)
+DamageType		=	MAGIC
+Animation		=	1			; warmage animations are backwards in TGS
+Sound1			= 	Spells\sorceress_attack.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0			; warmage animations are backwards in TGS

--- a/TGX Files/Data/ObjectData/units/STORM_LORD.INI
+++ b/TGX Files/Data/ObjectData/units/STORM_LORD.INI
@@ -1,0 +1,70 @@
+[ObjectData]
+ProperName = STRING_4601_Storm_Lord
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\elite_warmage.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	140			;health rating(float)
+CostGold		=	40			;int
+UpkeepWood		=	1			;int
+UpkeepMana		=	3			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	6			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\ranger_death.wav
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\elite_Warmage_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	22			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	12.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description = STRING_4790_The_Storm_Lords_are_a_small_group_of_elite_mages_that_serve_the_Council_in_their_war_against_the_Ceyah_Kohan___The_Storm_Lords_have_learned_to_harness_the_power_of_the_skies_and_can_control_multiple_strikes_of_lightning_at_once_
+MeleeFX			= warmage_hitfx
+Group1			= 12
+
+[SpellData]
+MaxMana =			60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	5	;the amount of mana that gets regenerated sec.
+Spell0			=	Storm Armor
+Spell1			=	Chain Lightning ;Forked Lightning
+
+[BuildHierarchy]
+OnlyFaction		=	Council
+Component1		=	Temple
+Component2		=	WizardTower
+Component3		=	Barracks
+Technology		= 	Storm Lord
+
+[ElementBonus]
+
+[SupportBonus]
+DEFENSE_BONUS_VS_ARCHER		= 8
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.75			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	36		;number (float)
+DamageType		=	MAGIC
+;Animation		=	1			; warmage animations are backwards in TGS
+Sound1			= 	Spells\wizard_attack.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+;Animation		=	0			; warmage animations are backwards in TGS

--- a/TGX Files/Data/ObjectData/units/SUMMONED_K_ELEMENTAL.INI
+++ b/TGX Files/Data/ObjectData/units/SUMMONED_K_ELEMENTAL.INI
@@ -1,0 +1,70 @@
+[ObjectData]
+ProperName = STRING_4763_Khaldunite_Elemental
+MonsterCompanyName = STRING_4764_Khaldunite_Elementals
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\khaldunite_elemental.tgr
+BoundingRadius		=	0.35		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	350			;health rating(float)
+BuildTime		=	5			;seconds(float)
+Defense			=	12			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\khaldunite_elemental_death.wav
+SelectionSound1		=	Game\khaldunite_elemental_select.wav
+CommandSound1		=	Game\select_elemental.wav
+
+[UnitData]
+Type			=	Monster
+Shadow			=	0
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\khaldunite_elemental_icon.tgr
+IdleTime		=	1		;seconds(float)
+MovementRate		=	16		;movement points(float)
+WalkDistance		=   	1		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	11		; SAI combat rating (float)
+BannerFrame		=	22
+ResupplyRate		=	1		; health / second (float)
+Description 		= STRING_4791_Left_over_from_a_past_age_when_a_fanatical_splinter_sect_worshipped_Khaldunite_as_the_representation_of_the_Creator_s_power_on_Khaldun__the_Khaldunite_Elemental_is_a_physical_manifestation_of_the_immense_destructive_potential_extant_in_all_Khaldunite___These_mindless_creatures_are_extremely_dangerous_and_prove_to_be_formidable_opponents_
+Group1			= 18
+AttachedFX		= wizard_HitFX
+
+[SpellData]
+MaxMana =			100 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
+Spell0			=	Chain Lightning
+
+[ElementBonus]
+IMMUNITY_TO_ENCHANTMENT		= 1
+DAMAGE_TAKEN_FROM_MAGIC		= .50
+DAMAGE_TAKEN_FROM_RANGED	= .50
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 100
+VisualRange		= 8
+ControlZone		= 6
+EntrenchmentRate	= 0
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)
+Damage			=	34		;number (float)
+DamageType		=	MAGIC
+Sound1			= 	Game\elemental_attack.wav
+
+[Attack2]
+AttackTime		=	1		; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float)
+ReloadTime		=	2		; seconds (float)
+AttackType		=	CAST		; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/SUMMONER.INI
+++ b/TGX Files/Data/ObjectData/units/SUMMONER.INI
@@ -1,0 +1,66 @@
+[ObjectData]
+ProperName = STRING_2547_Summoner
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\sorceress.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	130			;health rating(float)
+CostGold		=	14 ;28			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	4			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\Sorceress_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Sorceress_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2548_Summoners_are_the_masters_of_conjuring_up_beings_under_their_control__They_are_able_to_summon_a_huge_elemental_beast_to_battle_their_enemies__Outside_of_combat_they_use_small_nature_spirits_to_aid_in_scouting_their_surroundings__increasing_their_company_s_visual_range_
+MeleeFX			= necromancer_hitfx
+Group1			= 12
+
+[SpellData]
+MaxMana =				60 ;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	3	;the amount of mana that gets regenerated sec.
+Spell0			=		Mystic Shield
+Spell1			=		Summon Elemental
+
+[BuildHierarchy]
+Component1		=	Library
+OnlyFaction		=	Nationalist   	;proper setting
+
+[ElementBonus]
+
+[SupportBonus]
+VISUAL_RANGE_BONUS	= 1.15
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.5			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	26		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Spells\necro_attack.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.75		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/SURTAK_THE_RED.INI
+++ b/TGX Files/Data/ObjectData/units/SURTAK_THE_RED.INI
@@ -1,0 +1,76 @@
+[ObjectData]
+ProperName = STRING_4792_Surtak_the_Red
+MonsterCompanyName = STRING_4792_Surtak_the_Red
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\fire_dragon.tgr
+BoundingRadius		=	.99		;tiles(float)
+RotTime			=	60			;seconds(float)
+MaxHitPoints		=	7500		;health rating(float)
+CostGold		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	0			;int
+CostMana		=	0			;int
+UpkeepMana		=	0			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	14			;number (float)
+DieTime			=	2
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\fire_drake_death.wav
+SelectionSound1		=	Game\select_fire_drake.wav
+
+
+[UnitData]
+Type			=	SOLO
+Portrait		=	Portraits\Heroes\Dragon_Portrait.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	30			;movement points(float)
+WalkDistance		=   	2		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	100.0		; SAI combat rating (float)
+ResupplyRate		=	25		; health / second (float)
+Description	= STRING_4793_One_of_the_last_of_the_dread_Tah_Mahr__Surtak_is_an_ancient_red_dragon_with_a_voracious_appetite_for_destruction___Trained_in_the_ancient_arts_of_war__Surtak_is_a_ferocious_combatant_on_the_field_fo_battle___His_brood_are_the_last_dragons_to_carry_the_Mark_of_the_Tah_Mahr_
+
+[SpellData]
+MaxMana 		= 75 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 5
+Spell0			= Dragon Fire
+
+[BuildHierarchy]
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_MAGIC		= 1.5
+DAMAGE_TAKEN_FROM_RANGED	= .25
+IMMUNITY_TO_ENCHANTMENT		= 1
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 100
+VisualRange		= 8
+ControlZone		= 6
+EntrenchmentRate	= 0
+Berserk			= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	1.5		;seconds(float)
+AttackRange		=	2		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	175		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\shadowbeast_attack.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+;AttackRange		=	.75			; tiles (float)
+;DamageType		=	0			; number (float)
+Sound1			=	Spells\fire_drake_breathe.wav

--- a/TGX Files/Data/ObjectData/units/THIMURGH.INI
+++ b/TGX Files/Data/ObjectData/units/THIMURGH.INI
@@ -1,0 +1,78 @@
+[ObjectData]
+ProperName = STRING_2549_Simurgh
+MonsterCompanyName = STRING_2549_Simurgh
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\Simurgh.tgr
+BoundingRadius		=	1.5		;tiles(float)
+RotTime			=	60			;seconds(float)
+MaxHitPoints		=	9000		;health rating(float)
+CostGold		=	0			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	0			;int
+CostMana		=	0			;int
+UpkeepMana		=	0			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	16			;number (float)
+DieTime			=	3
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\simurgh_death.wav
+SelectionSound1		=	Game\select_simurgh.wav
+CommandSound1		=	Game\select_simurgh.wav
+
+[UnitData]
+Type			=	SOLO
+Shadow			=	1
+Portrait		=	Portraits\Heroes\Simurgh_Portrait.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	30			;movement points(float)
+WalkDistance		=   	1.5		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	125.0		; SAI combat rating (float)
+ResupplyRate		=	15		; health / second (float)
+Description	= STRING_2550_Simurgh_is_one_of_the_most_vile_of_all_the_Ceyah_Kohan__one_of_the_few_that_had_fallen_so_far_as_to_commit_murder_upon_his_fellow_Kohan_during_the_confusion_of_the_first_Cataclysm__He_has_become_so_twisted_that_he_has_forgotten_what_it_was_like_to_be_a_normal_member_of_Kohan_society__All_he_sees_in_himself_anymore_is_a_monster__and_a_monster_he_has_become__Simurgh_has_mutated_into_a_huge_beast_with_the_general_shape_of_a_dragon__but_many_aspects_of_an_insect_or_spider__He_has_legs_and_his_body_is_covered_in_slimy__segmented_armor__Most_frightening_of_all__Simurgh_has_developed_a_taste_for_fresh_blood_
+
+[SpellData]
+MaxMana 		= 50 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 5
+Spell1			= Volley of Shadow
+
+[BuildHierarchy]
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_MAGIC		= 1.2
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.2
+DAMAGE_TAKEN_FROM_RANGED	= .25
+IMMUNITY_TO_ENCHANTMENT		= 1
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 100
+VisualRange		= 8
+ControlZone		= 6
+EntrenchmentRate	= 0
+Berserk			= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	1.5		;seconds(float)
+AttackRange		=	2		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	200		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\simurgh_attack.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+;AttackRange		=	.75			; tiles (float)
+;DamageType		=	0			; number (float)
+Sound1			=	Spells\fire_drake_breathe.wav

--- a/TGX Files/Data/ObjectData/units/UNDEAD.INI
+++ b/TGX Files/Data/ObjectData/units/UNDEAD.INI
@@ -1,0 +1,68 @@
+[ObjectData]
+ProperName = STRING_2551_Undead
+MonsterCompanyName = STRING_2551_Undead
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\skeleton.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	200			;health rating(float)
+BuildTime		=	5			;seconds(float)
+Defense			=	6			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\skeleton_death.wav
+SelectionSound1		=	Game\undead_select.wav
+CommandSound1		=	Game\undead_select.wav
+
+[UnitData]
+Type			=	MONSTER
+Shadow			=	1
+Captain			=	captain
+Icon			=   Portraits\Unit Icons\Skeleton_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	18		;movement points(float)
+WalkDistance		=   	.7		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	4.5		; SAI combat rating (float)
+BannerFrame		=	23
+ResupplyRate		=	1		; health / second (float)
+Description 		= STRING_2552_Evil_magicks_have_reanimated_the_skeletal_remains_of_mortal_beings_to_create_these_twisted_monsters_
+Group1			= 18
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_RANGED	= .05
+DAMAGE_TAKEN_FROM_HOLY		= 2
+DAMAGE_TAKEN_FROM_MAGIC		= 1.25
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 30
+VisualRange		= 5
+ControlZone		= 3
+EntrenchmentRate	= 0
+ShadowMorale		= 1
+NoTerrainVisual		= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.4		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	18		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\sword4.wav
+Sound2			= 	Game\sword2.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/UNDEAD_ARCHER.INI
+++ b/TGX Files/Data/ObjectData/units/UNDEAD_ARCHER.INI
@@ -1,0 +1,82 @@
+[ObjectData]
+ProperName = STRING_2553_Bone_Bow
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\Undead_Archer.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	150			;health rating(float)
+CostGold		=	5			;int
+UpkeepGold		=	0			;int
+UpkeepWood		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	6			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\bone_bow_death.wav
+SelectionSound1		=	Game\undead_select.wav
+CommandSound1		=	Game\undead_select.wav
+
+[UnitData]
+Type			=	FRONT
+Archer			=	1
+Shadow			=	1
+Captain			=	undead_captain
+Icon			=   Portraits\Unit Icons\Bone_Bow_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	5.5		; SAI combat rating (float)
+BannerFrame		=	8
+ResupplyRate		=	5			; health / second (float)
+Description 		= STRING_2554_These_undead_archers_fire_powerful_crossbow_bolts_at_their_targets__They_are_particularly_useful_against_infantry_
+Group1			= 1
+Group2			= 6
+Group3			= 15
+
+[BuildHierarchy]
+;Race			=	Mareten
+OnlyFaction		=	Ceyah
+Component1		=	woodmill
+
+[ElementBonus]
+ATTACK_BONUS_TO_BUILDING 	= -20
+DAMAGE_TAKEN_FROM_RANGED	= .05
+DAMAGE_TAKEN_FROM_HOLY		= 2
+DAMAGE_TAKEN_FROM_MAGIC		= 1.25
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 30
+VisualRange		= 7
+ControlZone		= 5
+EntrenchmentRate	= 1.5
+ShadowMorale		= 1			;; drp121300 - added
+
+[Attack1]
+AttackTime		=	1			;seconds(float) seconds per animation cycle
+Projectile		=   arrow
+DamagePoint		=	0.6			;seconds(float) at what point (percentage) in attack animation to apply damage/shoot projectile
+ReloadTime		=	2			;seconds(float)
+AttackRange		=	6			;tiles (float)
+AttackType		=	PROJECTILE	;enumeration list(int)
+Damage			=	30		;number (float)
+DamageType		=	NORMAL
+Sound1			=	Game\bow1.wav
+
+[Attack2]
+AttackTime		=	1			;seconds(float) seconds per animation cycle
+Projectile		=   	0
+DamagePoint		=	0.5			;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5			;seconds(float)
+AttackRange		=	0.75			;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	14		;number (float)
+DamageType		=	NORMAL
+Sound1			=	Game\bone_bow_melee.wav

--- a/TGX Files/Data/ObjectData/units/VOID_BEAST.INI
+++ b/TGX Files/Data/ObjectData/units/VOID_BEAST.INI
@@ -1,0 +1,78 @@
+[ObjectData]
+ProperName = STRING_2558_Void_Beast
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\elite_shadow_beast.tgr
+BoundingRadius		=	0.35		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	460		;health rating(float)
+CostGold		=	5			;int
+UpkeepStone		=	1			;int
+UpkeepMana		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	10 ;8			;number (float)
+DieTime			=	1			;seconds(float)
+OverwriteColor  =	-1
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\shadow_beast_death.wav
+SelectionSound1		=	Game\select_shadow_beast.wav
+CommandSound1		=	Game\select_shadow_beast.wav
+
+[UnitData]
+Type			=	FRONT
+Shadow			=	1
+Mounted			=	1
+Captain			=	shadow_captain
+Icon			=   Portraits\Unit Icons\Void_Beast_icon.tgr
+IdleTime		=	1			;seconds(float)
+MovementRate		=	32 ;30			;movement points(float)
+WalkDistance		=   	1		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	14.0 ;		; SAI combat rating (float)
+BannerFrame		=	22
+ResupplyRate		=	10		; health / second (float)
+Description 		= STRING_2559_Void_Beasts_are_horrific_creatures_similar_to_the_Shadow_Beasts__They_come_from_deep_within_a_subterranean_realm_in_the_Shadow_dimension__Special_magicks_are_required_to_summon_forth_these_horrors_
+Group1			= 16
+
+[BuildHierarchy]
+OnlyFaction		= 	Ceyah
+Component1		=	barracks
+Component2		=	temple
+Component3		= 	library
+Component4		= 	quarry
+Technology		=	Void Beast
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_ANY		= .75
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.5
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 35
+VisualRange		= 7
+ControlZone		= 4
+EntrenchmentRate	= 5
+ShadowMorale		= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	48 ;46		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\shadowbeast_attack.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)

--- a/TGX Files/Data/ObjectData/units/WARLOCK.INI
+++ b/TGX Files/Data/ObjectData/units/WARLOCK.INI
@@ -1,0 +1,68 @@
+[ObjectData]
+ProperName = STRING_0015_Warlock
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\warmage.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	140			;health rating(float)
+CostGold		=	22 ;44			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	3			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	4			;number (float)
+DieTime			=	1			;seconds(float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\anvil_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Warmage_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	18			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	10.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2560_The_enigmatic_warlock_is_privy_to_strange_and_powerful_magics__They_first_weaken_their_enemies_then_destroy_them_with_great_torrents_of_flame__Their_very_presence_inhibits_the_magic_of_enemy_mages_
+MeleeFX			= necromancer_hitfx
+Group1			= 12
+
+[SpellData]
+MaxMana =			60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	5	;the amount of mana that gets regenerated sec.
+Spell0			=		Magic Vulnerability
+Spell1			=		Conflagration
+
+[BuildHierarchy]
+Component1		=	MageCollege
+Technology		=	Warlock
+
+[ElementBonus]
+
+[SupportBonus]
+DAMAGE_TAKEN_FROM_MAGIC		= .8
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.75			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	18		;number (float)
+DamageType		=	MAGIC
+Animation		=	1			; warmage animations are backwards in TGS
+Sound1			= 	Spells\necro_attack.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0			; warmage animations are backwards in TGS

--- a/TGX Files/Data/ObjectData/units/WARMAGE.INI
+++ b/TGX Files/Data/ObjectData/units/WARMAGE.INI
@@ -1,0 +1,67 @@
+[ObjectData]
+ProperName = STRING_2561_Magician
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\warmage.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	130			;health rating(float)
+CostGold		=	14 ;28			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	2			;int
+BuildTime		=	4			;seconds(float)
+Defense			=	5			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\anvil_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Warmage_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.0 		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2562_Magicians_are_the_masters_of_fire__throwing_churning_blasts_at_their_enemies_and_wrapping_themselves_in_protective_sheaths_of_flame__Their_displays_of_raw_power_also_serve_to_inspire_their_own_troops_
+MeleeFX			= warmage_hitfx
+Group1			= 12
+
+[SpellData]
+MaxMana =			60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	4	;the amount of mana that gets regenerated sec.
+Spell0			=		Fireball
+Spell1			=		Immolation
+
+[BuildHierarchy]
+ExceptFaction		=	Ceyah
+Component1		=	Library
+
+[ElementBonus]
+
+[SupportBonus]
+MORALE_BONUS		= 4
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.75			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	30		;number (float)
+DamageType		=	MAGIC
+Animation		=	1			; warmage animations are backwards in TGS
+Sound1			= 	Spells\magician_attack.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0			; warmage animations are backwards in TGS

--- a/TGX Files/Data/ObjectData/units/WIZARD.INI
+++ b/TGX Files/Data/ObjectData/units/WIZARD.INI
@@ -1,0 +1,67 @@
+[ObjectData]
+ProperName = STRING_2565_Wizard
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\warmage.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	130			;health rating(float)
+CostGold		=	14 ;28			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	2			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	4			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\anvil_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Warmage_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.0 	; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2566_Wizards_are_the_lords_of_the_storm__They_can_smite_their_enemy_from_a_distance_with_demoralizing_bolts_of_lightning__During_combat__they_stir_up_powerful_winds_that_interfere_with_the_arrows_of_attacking_archers_
+MeleeFX			= wizard_hitfx
+Group1			= 12
+
+[SpellData]
+MaxMana 		=	60 	;the max amount that mana can be for the unit
+ManaRegenerationRate 	=	5	;the amount of mana that gets regenerated sec.
+Spell0			=		Storm Shield
+Spell1			=		Lightning
+
+[BuildHierarchy]
+Component1		=	library
+OnlyFaction		=	Council 	;true faction setting
+
+[ElementBonus]
+
+[SupportBonus]
+DEFENSE_BONUS_VS_ARCHER		= 6
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5		; at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	0.75			; seconds (float)
+AttackRange		=	1			; tiles (float)
+AttackType		=	MELEE		; enumeration list (int)
+Damage			=	34		;number (float)
+DamageType		=	MAGIC
+Sound1			= 	Spells\wizard_attack.wav
+Animation		=	1			; warmage animations are backwards in TGS
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)
+Animation		=	0			; warmage animations are backwards in TGS

--- a/TGX Files/Data/ObjectData/units/ZEALOT.INI
+++ b/TGX Files/Data/ObjectData/units/ZEALOT.INI
@@ -1,0 +1,67 @@
+[ObjectData]
+ProperName = STRING_2570_Zealot
+Class			= 	1			;enumeration list(int)
+Sprite			=   units\priestess.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	120		;health rating(float)
+CostGold		=	16 ;32			;int
+UpkeepGold		=	0			;int
+UpkeepIron		=	1			;int
+CostMana		=	0			;int
+UpkeepMana		=	1			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\Priestess_death.wav
+
+[UnitData]
+Type			=	SUPPORT
+Icon			=   Portraits\Unit Icons\Priestess_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	16			;movement points(float)
+WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	8.0		; SAI combat rating (float)
+ResupplyRate		=	4		; health / second (float)
+Description 		= STRING_2571_Nationalist_priests_so_dedicated_to_their_cause_they_are_willing_to_channel_shadow_energy_to_gain_an_advantage__They_encourage_their_troops_to_act_without_mercy__increasing_their_attacks_when_an_enemy_retreats_
+Group1			= 12
+
+[SpellData]
+MaxMana 		= 60 		;the max amount that mana can be for the unit
+ManaRegenerationRate 	= 3	;the amount of mana that gets regenerated sec.
+Spell0 			= Wash of Pain
+Spell1			= Cloud of Fear
+
+[BuildHierarchy]
+Component1		=	Nightbringers
+
+[ElementBonus]
+
+[SupportBonus]
+ATTACK_BONUS_TO_ROUTED		= 2
+ATTACK_BONUS_TO_SHADOW		= 2
+
+[CompanyData]
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE	;enumeration list(int)	
+Damage			=	10		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\battle_priest_melee.wav
+Sound2			= 	Game\club2.wav
+
+[Attack2]
+AttackTime		=	1			; seconds(float) per animation cycle
+DamagePoint		=	0.5			; seconds(float) at what point (percentage) in attack animation to shoot fireball
+ReloadTime		=	3			; seconds (float)
+AttackType		=	CAST		; enumeration list (int)

--- a/TGX Files/Data/ObjectData/units/ZOMBIE.INI
+++ b/TGX Files/Data/ObjectData/units/ZOMBIE.INI
@@ -1,0 +1,71 @@
+[ObjectData]
+ProperName = STRING_2572_Zombie
+Class			= 	0			;enumeration list(int)
+Sprite			=   units\zombie.tgr
+BoundingRadius		=	0.25		;tiles(float)
+RotTime			=	30			;seconds(float)
+MaxHitPoints		=	200			;health rating(float)
+CostGold		=	3			;int
+UpkeepGold		=	0			;int
+UpkeepMana		=	0			;int
+BuildTime		=	5			;seconds(float)
+Defense			=	8			;number (float)
+
+Moveable		=	1			;BOOLEAN
+Selectable		=	1			;BOOLEAN
+Blocking		=	1			;BOOLEAN
+Land			=	1			;BOOLEAN
+Water			=	0			;BOOLEAN
+
+DeathSound1		=	Game\zombie_death.wav
+SelectionSound1		=	Game\undead_select.wav
+CommandSound1		=	Game\undead_select.wav
+
+[UnitData]
+Type			=	FRONT
+Shadow			=	1
+Captain			=	Undead_Captain
+Icon			=   Portraits\Unit Icons\Zombie_icon.tgr
+IdleTime		=	2			;seconds(float)
+MovementRate		=	10		;movement points(float)
+WalkDistance		=   	.4		;tiles (float) how far does unit move in one animation cycle
+CombatValue		=	3.5		; SAI combat rating (float)
+BannerFrame		=	23
+ResupplyRate		=	10		; health / second (float)
+Description 		= STRING_2573_Torn_from_the_grave_to_serve_the_powers_of_evil__Zombies_are_the_undead_infantry_of_the_Dark_Master_
+Group1			= 15
+
+[BuildHierarchy]
+OnlyFaction		= 	Ceyah
+
+[ElementBonus]
+DAMAGE_TAKEN_FROM_HOLY		= 2
+DAMAGE_TAKEN_FROM_MAGIC		= 1.25
+
+[SupportBonus]
+
+[CompanyData]
+Morale			= 25
+VisualRange		= 6
+ControlZone		= 4
+EntrenchmentRate	= 2
+ShadowMorale		= 1
+NoTerrainVisual		= 1
+
+[Attack1]
+AttackTime		=	1		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.5		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0.5		;seconds(float)
+AttackRange		=	.75		;tiles (float)
+AttackType		=	MELEE		;enumeration list(int)	
+Damage			=	18		;number (float)
+DamageType		=	NORMAL
+Sound1			= 	Game\zombie.wav
+
+[Attack2]
+AttackTime		=	0		;seconds(float) seconds per animation cycle
+DamagePoint		=	0.7		;seconds(float) at what point (percentage) in attack animation to apply damage
+ReloadTime		=	0		;seconds(float)
+AttackRange		=	0		;tiles (float)
+AttackType		=	0		;enumeration list(int)	
+DamageType		=	0		;number (float)


### PR DESCRIPTION
Adds the 1.3.7 INI for all units not already present in the mod:

AMON_KOTH'S_CHOSEN.INI
ARCHER.INI
ARCHMAGE.INI
BARBARIAN.INI
BRIGAND.INI
CAPTAIN.INI
CAVALIER.INI
CAVALRY_CAPTAIN.INI
CHANNELER.INI
CONJUROR.INI
DAEVAI.INI
DARK_WOLF.INI
DEFILER.INI
DEVOUT.INI
ELEMENTAL.INI
ELEMENTALIST.INI
FOOTMAN.INI
GIANT_WASP.INI
GOLEM.INI
HAROUN_CAPTAIN.INI
HIGH_PRIEST.INI
LICH.INI
MAELSTROM_ORB.INI
NECROMANCER.INI
ORACLE.INI
PIKEMAN.INI
PROPHET.INI
RHAKSHA.INI
RHAKSHA_HIVEMASTER.INI
RHAKSHA_HUNTER.INI
RHAKSHA_LEADER.INI
RHAKSHA_SLAVE.INI
SHADELING.INI
SHADOW_MONSTER.INI
SHADOW_PRIEST.INI
SKELETON.INI
SLAAN.INI
SLAANRI_CAPTAIN.INI
SLAANRI_CHAMPION.INI
SLAANRI_MYSTIC.INI
SLAANRI_SLAVER.INI
SLAAN_CHAMPION.INI
SORCERER.INI
STORM_LORD.INI
SUMMONED_K_ELEMENTAL.INI
SUMMONER.INI
SURTAK_THE_RED.INI
THIMURGH.INI
UNDEAD.INI
UNDEAD_ARCHER.INI
VOID_BEAST.INI
WARLOCK.INI
WARMAGE.INI
WIZARD.INI
ZEALOT.INI
ZOMBIE.INI