### PR TITLE
Remove Unique Captains from Unit Groups

### DIFF
--- a/TGX Files/Data/ObjectData/units/DHAVRUM_BELRAAG_CAPTAIN.INI
+++ b/TGX Files/Data/ObjectData/units/DHAVRUM_BELRAAG_CAPTAIN.INI
@@ -39,8 +39,6 @@ WalkDistance		=   	0.85		;tiles (float) how far does unit move in one animation 
 CombatValue		=	15.0		; SAI combat rating (float)
 ResupplyRate		=	15			; health / second (float)
 Description = STRING_4690_Lord_Belraag_is_the_High_Noble_of_the_Gauri_nation__He_is_an_implacable_enemy_who_refuses_to_yield_one_foot_of_land_without_making_the_Ceyah_pay_dearly_for_each_gain__Recently__he_has_declared_an_open_alliance_with_the_Drauga_clans_of_the_region__making_him_a_large_thorn_in_Ahriman_s_side_
-Group1			= 11
-Group2			= 9
 
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle


### PR DESCRIPTION
Removed Dhavrum Belraag captain unit from all unit groups so it will no longer show up in the list of units a particular tech applies to