### PR TITLE
Sijansur changes

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
+++ b/TGX Files/Data/ObjectData/Heroes/SIJANSUR.INI
@@ -93,8 +93,7 @@ ATTACK_BONUS_TO_ROUTED          =   6
 DAMAGE_TAKEN_FROM_KHALDUNITE	= .7
 
 [Level3]
-MaxHitPoints		=	1180
-Defense             =   16
+MaxHitPoints		=	1200
 
 [SpellData3]
 MaxMana 		=	50 	;the max amount that mana can be for the unit


### PR DESCRIPTION
- Maximum health at Ascended increased to 1200 (from 1180)
- DV at Ascended remains at 14 (was 16)