### PR TITLE
Garadun Payne attack time

### DIFF
--- a/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
@@ -38,7 +38,7 @@ Description = STRING_2380_Garadun_Payne_is_a_monster_of_a_man__Even_though_he_sp
 [Attack1]
 AttackTime		=	1		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
-ReloadTime		=	1.3		;seconds(float)
+ReloadTime		=	1.4		;seconds(float)
 AttackRange		=	0.75	;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
 Damage			=	62		;number (float)

--- a/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
+++ b/TGX Files/Data/ObjectData/Heroes/GARADUN_PAYNE.INI
@@ -36,9 +36,9 @@ CombatValue		= 15
 Description = STRING_2380_Garadun_Payne_is_a_monster_of_a_man__Even_though_he_spends_his_time_exclusively_in_a_form_somewhere_between_normal_and_war_form__he_is_a_large__strong__and_tough_as_any_warform_Kohan__He_is_fearless_in_battle__willing_to_accept_any_challenge_no_matter_how_powerful_the_opponent_
 
 [Attack1]
-AttackTime		=	1		;seconds(float) seconds per animation cycle
+AttackTime		=	1.2		;seconds(float) seconds per animation cycle
 DamagePoint		=	0.6		;seconds(float) at what point (percentage) in attack animation to apply damage
-ReloadTime		=	1.4		;seconds(float)
+ReloadTime		=	1.2		;seconds(float)
 AttackRange		=	0.75	;tiles (float)
 AttackType		=	MELEE		;enumeration list(int)	
 Damage			=	62		;number (float)


### PR DESCRIPTION
- Adjusted attack time from 1 second to 1.2 seconds (same as Paladins which use the same sprite)
- Reload time lowered from 1.4 to 1.2 (total attack time still remains at 2.4 seconds)