### PR TITLE
Technologies update

### DIFF
--- a/TGX Files/Data/Technology.ini
+++ b/TGX Files/Data/Technology.ini
@@ -157,13 +157,14 @@ DEFENSE_BONUS_VS_ANY		= 1
 
 [Crystal Ring]
 ProperName		= STRING_0055_Crystal_Ring
-Description		= STRING_1543_Special_crytal_rings_that_are_capable_of_amplifying_magical_power__increasing_the_melee_attacks_of_priests_and_mages_
+Description		= Special crystal rings that are capable of amplifying magical power, increasing the melee attacks of casters and harming those that dare strike them in close combat.
 BonusSection	= CrystalRingBonuses
 UnitGroup		= 12
 Sprite			= Art\Interface\Panels\Melee_Bonus.tgr
 
 [CrystalRingBonuses]
-ATTACK_BONUS_TO_ANY		= 4
+ATTACK_BONUS_TO_ANY		= 6
+REVERSE_DAMAGE_WHEN_HIT = 4
 
 [Silken Robe]
 ProperName		= STRING_0123_Silken_Robe

--- a/TGX Files/Data/Technology.ini
+++ b/TGX Files/Data/Technology.ini
@@ -447,10 +447,12 @@ UPGRADE_BONUS_COST_GROUP_2	= .85
 ProperName		= STRING_1587_Academy_of_Magicks
 Description		= STRING_1588_By_instituting_houses_of_learning_for_the_magic_arts_in_all_settlements__those_settlements_are_better_equipped_to_deal_with_a_siege_involving_mystical_attacks_
 BonusSection	= MagicksBonuses
+UnitGroup		= 4
 Sprite			= Art\Interface\Panels\Settlement_Bonus.tgr
 
 [MagicksBonuses]
 UPGRADE_BONUS_VS_MAGIC	= .5
+DAMAGE_TAKEN_FROM_MAGIC = .8
 
 [Economic Advisors]
 ProperName		= STRING_1589_Economic_Advisors

--- a/TGX Files/Data/Technology.ini
+++ b/TGX Files/Data/Technology.ini
@@ -303,7 +303,7 @@ DEFENSE_BONUS_VS_ANY		= 2
 ProperName		= STRING_0054_Counter_Magic
 Description		= STRING_1564_This_new_magic_allows_the_court_mages_to_protect_settlements_from_magical_attacks__reducing_damage_by_75__
 BonusSection	= CounterMagicBonuses
-UnitGroup		= -1
+Boss            = 1
 Sprite			= Art\Interface\Panels\Settlement_Bonus.tgr
 
 [CounterMagicBonuses]

--- a/TGX Files/Data/Technology.ini
+++ b/TGX Files/Data/Technology.ini
@@ -431,7 +431,7 @@ UnitGroup		= 16
 Sprite			= Art\Interface\Panels\Melee_Bonus.tgr
 
 [BoShadowBonuses]
-ATTACK_BONUS_TO_ANY		= 3
+ATTACK_BONUS_TO_ANY		= 2
 
 [Military College]
 ProperName		= STRING_1585_Military_College

--- a/TGX Files/Data/Technology.ini
+++ b/TGX Files/Data/Technology.ini
@@ -55,7 +55,7 @@ UnitGroup		= 15
 Sprite			= Art\Interface\Panels\Melee_Bonus.tgr
 
 [DeadZoneBonuses]
-ATTACK_BONUS_TO_ANY		= 3
+ATTACK_BONUS_TO_ANY		= 2
 
 [Khaldunite Shield]
 ProperName		= STRING_1526_Khaldunite_Shield


### PR DESCRIPTION
# Changelog

- #321 
- #322 
- #323 
- #324 
- #325 

### Dead Zone 
(Group 15 - Undead units)
- Reduced AV from 3 to 2

### Blessing of Shadow 
(Group 16 - Shadow units. Types of demon, as opposed to the broader category)
- Reduced AV from 3 to 2

### Academy of Magicks 
(Settlement tech that now applies to Group 4 - Militia units)
- Now grants all militia a 20% reduction to magic damage taken (80% damage taken)

### Crystal Ring 
(Group 12 - Caster/magic users)
- Increased AV from 4 to 6
- Now grants 4 Reverse Damage in melee

### Counter Magic 
(Settlement tech)
- Redundant tech - has been made scenario only. It will still show up in any campaign or scenario missions as a reward but will not be given as a random tech reward in skirmish.