### PR TITLE
Unholy Damage for Ceyah

### DIFF
--- a/TGX Files/Data/ObjectData/units/DREADLORD.INI
+++ b/TGX Files/Data/ObjectData/units/DREADLORD.INI
@@ -67,5 +67,6 @@ DamageType                          =   0
 MELEE_UNHOLY_DAMAGE                 =   10
 
 [SupportBonus]
-ATTACK_BONUS_TO_ANY                 =   4
+MELEE_UNHOLY_DAMAGE                 =   2
+ATTACK_BONUS_TO_ANY                 =   2
 ATTACK_BONUS_TO_ROUTED              =   4

--- a/TGX Files/Data/ObjectData/units/DREADLORD.INI
+++ b/TGX Files/Data/ObjectData/units/DREADLORD.INI
@@ -64,9 +64,9 @@ AttackType                          =   0
 DamageType                          =   0
 
 [ElementBonus]
+IMMUNITY_TO_ENCHANTMENT             =   1
 MELEE_UNHOLY_DAMAGE                 =   10
 
 [SupportBonus]
-MELEE_UNHOLY_DAMAGE                 =   2
-ATTACK_BONUS_TO_ANY                 =   2
+MELEE_UNHOLY_DAMAGE                 =   5
 ATTACK_BONUS_TO_ROUTED              =   4

--- a/TGX Files/Data/ObjectData/units/MACABRE.INI
+++ b/TGX Files/Data/ObjectData/units/MACABRE.INI
@@ -66,3 +66,4 @@ AttackType              =   CAST
 [ElementBonus]
 
 [SupportBonus]
+MELEE_UNHOLY_DAMAGE     =   4

--- a/TGX Files/Data/ObjectData/units/MACABRE.INI
+++ b/TGX Files/Data/ObjectData/units/MACABRE.INI
@@ -66,4 +66,4 @@ AttackType              =   CAST
 [ElementBonus]
 
 [SupportBonus]
-MELEE_UNHOLY_DAMAGE     =   4
+MELEE_UNHOLY_DAMAGE     =   2

--- a/TGX Files/Data/ObjectData/units/SHADOW_DEMON.INI
+++ b/TGX Files/Data/ObjectData/units/SHADOW_DEMON.INI
@@ -46,6 +46,14 @@ Spell0 			= Summon Shadelings
 OnlyFaction		=	Ceyah
 Component1		=	Library
 
+[ElementBonus]
+MELEE_UNHOLY_DAMAGE		= 6
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.5
+DAMAGE_TAKEN_FROM_RANGED	= .75
+IGNORE_TERRAIN_BONUS = 1		;; drp011501 - added bonus
+
+[SupportBonus]
+
 [CompanyData]
 
 [Attack1]
@@ -66,11 +74,3 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation		= 1
 
-[ElementBonus]
-MELEE_UNHOLY_DAMAGE		= 6
-DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.5
-DAMAGE_TAKEN_FROM_RANGED	= .75
-IGNORE_TERRAIN_BONUS = 1		;; drp011501 - added bonus
-
-[SupportBonus]
-MELEE_UNHOLY_DAMAGE     =   2

--- a/TGX Files/Data/ObjectData/units/SHADOW_DEMON.INI
+++ b/TGX Files/Data/ObjectData/units/SHADOW_DEMON.INI
@@ -46,14 +46,6 @@ Spell0 			= Summon Shadelings
 OnlyFaction		=	Ceyah
 Component1		=	Library
 
-[ElementBonus]
-MELEE_UNHOLY_DAMAGE		= 6
-DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.5
-DAMAGE_TAKEN_FROM_RANGED	= .75
-IGNORE_TERRAIN_BONUS = 1		;; drp011501 - added bonus
-
-[SupportBonus]
-
 [CompanyData]
 
 [Attack1]
@@ -74,3 +66,11 @@ ReloadTime		=	3			; seconds (float)
 AttackType		=	CAST		; enumeration list (int)
 Animation		= 1
 
+[ElementBonus]
+MELEE_UNHOLY_DAMAGE		= 6
+DAMAGE_TAKEN_FROM_KHALDUNITE	= 1.5
+DAMAGE_TAKEN_FROM_RANGED	= .75
+IGNORE_TERRAIN_BONUS = 1		;; drp011501 - added bonus
+
+[SupportBonus]
+MELEE_UNHOLY_DAMAGE     =   2

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -641,8 +641,10 @@ BonusSection = MiasmaBonus
 Sound = spells\foul_miasma.wav
 
 [MiasmaBonus]
-MOVEMENT_BONUS		= .45
+DAMAGE_TAKEN_FROM_UNHOLY = 1.25
+OVEMENT_BONUS		= .45
 ATTACK_BONUS_TO_ANY	= -5
+
 
 [33]
 Name = Shadow's Sleep ;'

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -642,7 +642,7 @@ Sound = spells\foul_miasma.wav
 
 [MiasmaBonus]
 DAMAGE_TAKEN_FROM_UNHOLY = 1.25
-OVEMENT_BONUS		= .45
+MOVEMENT_BONUS		= .45
 ATTACK_BONUS_TO_ANY	= -5
 
 


### PR DESCRIPTION
# Changelog:

- #327
- #328 
- #329 
- #330 

### Foul Miasma

- Added Unholy Vulnerability to the spell, increasing damage from unholy to 125%

### Macabre

- Now provides 4 unholy damage in melee

### Dreadlord

- Provided AV bonus reduced from 4 to 2
- Now provides 2 unholy damage in melee
