### PR TITLE
Building Formation Modifier

### DIFF
--- a/TGX Files/Data/ObjectData/Company.ini
+++ b/TGX Files/Data/ObjectData/Company.ini
@@ -1,0 +1,131 @@
+[CompanyData]
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; combat formula:
+;;
+;; ATT = unit's damage rating
+;; EXP = company experience combat modifier
+;; CATT = company attack bonus (terrain - no longer applies)
+;; AB = unit's attack bonuses
+;; FORM = company formation combat modifier
+;; AV = [(ATT*EXP) + CATT + AB] * FORM
+;;
+;; DEF = object's defensive rating (armor)
+;; EXP = company experience combat modifier
+;; CDEF = company defensive bonus (terrain/formation)
+;; DB = unit's defensive bonuses
+;; DV = DEF * EXP + CDEF + DB
+;;
+;; DAMAGE = AV - DV (other bonuses will be applied to this)
+;;
+;; NOTE:
+;; - minimum_damage is 3
+;; - entrench is +3, fortified is +6
+;; - spells do not use these rules
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; formation combat modifier
+formation_modifier1     =      	 80 ; skirmish
+formation_modifier2     =     	100 ; combat
+formation_modifier3     =     	100 ; entrenched
+formation_modifier4	=	100 ; fortified
+formation_modifier5     =        50 ; column
+formation_modifier6     =      	 25 ; pressed
+formation_modifier7     =      	100 ; broken (monsters, changing formation, rest, regroup)
+formation_modifier8     =     	100 ; engaged
+formation_modifier9	=	 25 ; building
+formation_modifier10	=	100 ; retreat (doesn't affect anything)
+formation_modifier11	=	100 ; rout (doesn't affect anything)
+
+single_unit_fmodifier	=	 50 ; formation modifier for single units
+captainless_modifier	=	100 ; additional attack modifier for when there is no captain or captain is in engage mode
+
+
+;; modifier change rate
+modifier_rate           =         1 ; (1-100) percentage points per second to change formation efficiency
+
+;;dropping_modifier_rate	=		  3 ; (1-100) percentage points per second when formation efficiency is dropping
+dropping_modifier_rate1			=	1 ; skirmish
+dropping_modifier_rate2			=	1 ; combat
+dropping_modifier_rate3			=	1 ; entrenched
+dropping_modifier_rate4			=	1 ; fortified
+dropping_modifier_rate5			=	2 ; column
+dropping_modifier_rate6			=	3 ; pressed
+dropping_modifier_rate7			=	1 ; broken (monsters, changing formation, rest, regroup)
+dropping_modifier_rate8			=	1 ; engaged
+dropping_modifier_rate9			=	2 ; building
+dropping_modifier_rate10		=	1 ; retreat
+dropping_modifier_rate11		=	1 ; rout 
+
+;; formation ZOC modifiers (-1 means leave according to last formation)
+zoc_modifier1			=	120 ; skirmish
+zoc_modifier2			=	120 ; combat
+zoc_modifier3			=	120 ; entrenched
+zoc_modifier4			=	120 ; fortified
+zoc_modifier5			=	100 ; column
+zoc_modifier6			=	 80 ; pressed
+zoc_modifier7			=	 -1 ; broken (monsters, changing formation, rest, regroup)
+zoc_modifier8			=	 -1 ; engaged
+zoc_modifier9			=	 60 ; building
+zoc_modifier10			=	 80 ; retreat
+zoc_modifier11			=	 80 ; rout 
+
+;; formation ZOD modifiers (-1 means leave according to last formation)
+zod_modifier1			=	140 ; skirmish
+zod_modifier2			=	100 ; combat
+zod_modifier3			=	120 ; entrenched
+zod_modifier4			=	120 ; fortified
+zod_modifier5			=	100 ; column
+zod_modifier6			=	 80 ; pressed
+zod_modifier7			=	 -1 ; broken (monsters, changing formation, rest, regroup)
+zod_modifier8			=	 -1 ; engaged
+zod_modifier9			=	 80 ; building
+zod_modifier10			=	100 ; retreat
+zod_modifier11			=	 60 ; rout
+
+;; experience combat modifier (attack/defense)
+experience_modifier1    =	100 ; percentage points, recruit
+experience_modifier2    =	110 ; regular
+experience_modifier3    =	125 ; veteran
+experience_modifier4    =	150 ; elite
+
+single_unit_emodifier	=	90 ; experience modifier for single units
+
+;; move mode aggressiveness (0 passive, 1 defensive, 2 aggressive)
+aggressiveness1			=	2 ; all-out (monsters)
+aggressiveness2			=	1 ; column
+aggressiveness3			=	2 ; combat
+aggressiveness4			=	2 ; skirmish
+aggressiveness5			=	0 ; pressed
+aggressiveness6			=	0 ; retreat
+aggressiveness7			=	0 ; rout
+
+;; move mode speed modifiers
+move_speed1		=	100 ; all-out (monsters)
+move_speed2		=  	100 ; column
+move_speed3		=	70  ; combat
+move_speed4		=	85  ; skirmish
+move_speed5		=	125 ; pressed
+move_speed6		=	100 ; retreat
+move_speed7		=	100 ; rout
+
+;; morale data
+;; - in pressed mode, the company becomes too exhausted at the "morale_check" level
+morale_check		=	10		; make morale checks below this value
+morale_loss_unit	=	2		; lose a unit
+morale_loss_captain	=	5		; lose captain
+morale_loss_engaged	=	0.5		; loss per second when engaged
+morale_loss_pressed	=	0.125	; loss per second when in pressed move, drp050801 - changed to one morale every 8s
+morale_recovery		= 	0.25	; gain per second in supply at rest
+morale_gain_unit	=	1		; kill a unit
+morale_gain_captain	=	2.5		; kill a captain
+morale_gain_rout	=	5		; rout enemy
+	
+;; entrench data
+entrench_time		=	60	; seconds ;;30
+fortify_time		=	180	; seconds ;;60
+
+;; regroup data
+regroup_time		=	10	; seconds
+regroup_contribution 	=	0.1	; fraction, what each front line type contributes to new captain
+regroup_captain_max 	=	0.5	; fraction, max health to bring the captain up to

--- a/TGX Files/Data/ObjectData/Company.ini
+++ b/TGX Files/Data/ObjectData/Company.ini
@@ -28,14 +28,14 @@
 formation_modifier1     =      	 80 ; skirmish
 formation_modifier2     =     	100 ; combat
 formation_modifier3     =     	100 ; entrenched
-formation_modifier4	=	100 ; fortified
+formation_modifier4	    =	    100 ; fortified
 formation_modifier5     =        50 ; column
 formation_modifier6     =      	 25 ; pressed
 formation_modifier7     =      	100 ; broken (monsters, changing formation, rest, regroup)
 formation_modifier8     =     	100 ; engaged
-formation_modifier9	=	 25 ; building
-formation_modifier10	=	100 ; retreat (doesn't affect anything)
-formation_modifier11	=	100 ; rout (doesn't affect anything)
+formation_modifier9	    =	    50 ; building
+formation_modifier10	=	    100 ; retreat (doesn't affect anything)
+formation_modifier11	=	    100 ; rout (doesn't affect anything)
 
 single_unit_fmodifier	=	 50 ; formation modifier for single units
 captainless_modifier	=	100 ; additional attack modifier for when there is no captain or captain is in engage mode

--- a/TGX Files/Data/ObjectData/Company.ini
+++ b/TGX Files/Data/ObjectData/Company.ini
@@ -53,7 +53,7 @@ dropping_modifier_rate5			=	2 ; column
 dropping_modifier_rate6			=	3 ; pressed
 dropping_modifier_rate7			=	1 ; broken (monsters, changing formation, rest, regroup)
 dropping_modifier_rate8			=	1 ; engaged
-dropping_modifier_rate9			=	2 ; building
+dropping_modifier_rate9			=	1 ; building
 dropping_modifier_rate10		=	1 ; retreat
 dropping_modifier_rate11		=	1 ; rout 
 


### PR DESCRIPTION
# Changelog:

- #331 

### Settlers & Engineers

- AV can only drop to 50%, as opposed to 25%.
- Rate that the value drops reduced from 2 per second to 1 per second.