### PR TITLE
Litany of Banishment Damage Increase

### DIFF
--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -1286,7 +1286,7 @@ Duration = 10
 Range = 10
 AreaRadius = 3
 Morale = 0
-Damage = 30
+Damage = 35
 CasterStartEffect0 = Banishcast
 DestinationEffect0 = Banish_shadow
 TargetDoCastEffect0 = banish_shadow_target
@@ -1296,7 +1296,7 @@ Projectile = spell_arrow
 Sound = spells\banish_shadow.wav
 
 [LitanyOfBanishmentBonuses]
-DAMAGE_TAKEN_FROM_HOLY = 1.25
+DAMAGE_TAKEN_FROM_HOLY = 1.5
 
 [69]
 Name = Rallying Call 

--- a/TGX Files/Data/Spells_KE.ini
+++ b/TGX Files/Data/Spells_KE.ini
@@ -1286,7 +1286,7 @@ Duration = 10
 Range = 10
 AreaRadius = 3
 Morale = 0
-Damage = 35
+Damage = 27.7
 CasterStartEffect0 = Banishcast
 DestinationEffect0 = Banish_shadow
 TargetDoCastEffect0 = banish_shadow_target
@@ -1296,7 +1296,7 @@ Projectile = spell_arrow
 Sound = spells\banish_shadow.wav
 
 [LitanyOfBanishmentBonuses]
-DAMAGE_TAKEN_FROM_HOLY = 1.5
+DAMAGE_TAKEN_FROM_HOLY = 1.7
 
 [69]
 Name = Rallying Call 


### PR DESCRIPTION
- #355

WIP, requires further playtesting.

Currently increased both direct holy damage (30 > 35) and holy vulnerability (125% > 150%) but whether or not this compares to the old version of the spell remains to be seen.