### PR TITLE
Maus update

### DIFF
--- a/TGX Files/Data/EFFECTDATA/SPRITES/STORM_SHIELD_PASSIVE.INI
+++ b/TGX Files/Data/EFFECTDATA/SPRITES/STORM_SHIELD_PASSIVE.INI
@@ -1,0 +1,11 @@
+[FXData]
+Class = 3				;shield_front
+Lifetime = 30000
+Front = 1
+
+[FXSpriteData]
+AnimTime =      .8
+Sprite =       storm_shield.tgr
+Looping			=	1				; 1 TRUE, 0 FALSE
+NumTimesToLoop  =	30000				; Number of times for animation to loop (only used if looping is TRUE)
+VisibilityDelay	=   0				; in seconds

--- a/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
@@ -92,6 +92,7 @@ MORALE_BONUS                    =   5
 
 [Level2]
 MaxHitPoints                    =   750
+AttachedFX0		=	STORM_SHIELD_PASSIVE
 
 [SpellData2]
 Spell1                          =   Lightning Vestments

--- a/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
@@ -103,6 +103,9 @@ MaxMana                         =   60
 Damage                          =   38
 
 [ElementBonus2]
+REVERSE_DAMAGE_WHEN_HIT         =   15
+DEFENSE_BONUS_VS_ANY            =   5
+ATTACK_BONUS_TO_ANY             =   5
 DEFENSE_BONUS_VS_ARCHER         =   6
 
 [SupportBonus2]

--- a/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
@@ -77,7 +77,8 @@ MaxHitPoints                    =   610
 Defense                         =   10
 
 [SpellData1]
-MaxMana                         =   60
+ManaRegenerationRate            =   3
+MaxMana                         =   55
 
 [Attack0Data1]
 Damage                          =   32

--- a/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
@@ -95,8 +95,9 @@ MaxHitPoints                    =   750
 AttachedFX0		=	STORM_SHIELD_PASSIVE
 
 [SpellData2]
-Spell1                          =   Lightning Vestments
-ManaRegenerationRate            =   3
+Spell0                          =   Lightning Vestments
+Spell1                          =   Lightning
+MaxMana                         =   60
 
 [Attack0Data2]
 Damage                          =   38

--- a/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
@@ -116,7 +116,7 @@ MORALE_BONUS                    =   6
 MaxHitPoints                    =   870
 
 [SpellData3]
-MaxMana                         =   75
+Spell1                          =   Forked Lightning
 
 [Attack0Data3]
 Damage                          =   44

--- a/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
+++ b/TGX Files/Data/ObjectData/Heroes/MISTRESS_ROXANNA.INI
@@ -4,7 +4,7 @@ Class                           =   2
 Sprite                          =   units\sorceress.tgr
 BoundingRadius                  =   0.25
 RotTime                         =   30
-MaxHitPoints                    =   490
+MaxHitPoints                    =   510
 CostGold                        =   0
 BuildTime                       =   0
 Defense                         =   8
@@ -38,7 +38,7 @@ Description                     =   STRING_6040_Mausallas_Bahram_possesses_an_un
 
 [SpellData]
 MaxMana                         =   50
-ManaRegenerationRate            =   3
+ManaRegenerationRate            =   2
 Spell0                          =   Storm Shield
 Spell1                          =   Cantrip
 
@@ -49,7 +49,7 @@ DamagePoint                     =   0.5
 ReloadTime                      =   0.5
 AttackRange                     =   1
 AttackType                      =   Melee
-Damage                          =   24
+Damage                          =   27
 DamageType                      =   Vorpal
 Animation                       =   0
 MoraleDamage                    =   0


### PR DESCRIPTION
# Changelog:

## Mausallas Bahram
Resolves #400 

### Awakened
HP increased to 510 (from 490)
AV increased to 27 (from 24)
Mana regen lowered to 2 (from 3)

### Enlightened
Max mana lowered to 55 (from 60)
Mana regen raised to 3 (from 2 at Awakened)

### Restored
Lightning Vestments now replaces Storm Shield
Lightning replaces Cantrip
Storm Shield effects (5 AV 5 DV 15 reverse damage) are now a permanent personal bonus. Storm shield effect is permanently active
Max mana raised to 60 (from 55 at Enlightened)

### Ascended
Forked Lightning replaces Lightning

