### PR TITLE
Revert Cloud of Fear targeting change

### DIFF
--- a/TGX_FILES/DATA/SPELLS.INI
+++ b/TGX_FILES/DATA/SPELLS.INI
@@ -351,7 +351,6 @@ ProperName = STRING_1444_Cloud_Of_Fear
 Description = STRING_1445_Creates_a_bubbling_cloud_of_darkness_that_lowers_the_morale_of_enemies_caught_within_
 Mana_Cost = 35
 Type = Group
-Special     =   Unholy
 Offensive =	1	;DEFENSIVE or OFFENSIVE
 Duration = 50
 Range = 10


### PR DESCRIPTION
Removed 'Special = Unholy' from Cloud of Fear, returning it to its vanilla behavior of being cast vs Ceyah companies. Zealots naturally prefer to cast Wash of Pain, so they should still achieve good saturation against Ceyah armies before they start casting Clod of Fear, and they will now present a better answer to companies that have lost their frontline