### PR TITLE
Evil Terrain change

### DIFF
--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD01.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD01.INI
@@ -1,0 +1,8 @@
+[ObjectData]
+ProperName = STRING_2294_Evil_doodad_1
+Class		= 	0	;enumeration list(int)
+Sprite		=   features\Evil_doodad1.tgr
+BoundingRadius	=	.9	;tiles(float) 
+Evil = 1
+Dimension = -1
+frequency = common

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD01.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD01.INI
@@ -5,4 +5,4 @@ Sprite		=   features\Evil_doodad1.tgr
 BoundingRadius	=	.9	;tiles(float) 
 Evil = 1
 Dimension = -1
-frequency = common
+frequency = rare

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD02.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD02.INI
@@ -5,5 +5,5 @@ Sprite		=   features\Evil_doodad2.tgr
 BoundingRadius	=	.9	;tiles(float) 
 Evil = 1
 Dimension = -1
-frequency =common
+frequency =rare
 

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD02.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD02.INI
@@ -1,0 +1,9 @@
+[ObjectData]
+ProperName = STRING_2295_Evil_doodad_2
+Class		= 	0	;enumeration list(int)
+Sprite		=   features\Evil_doodad2.tgr
+BoundingRadius	=	.9	;tiles(float) 
+Evil = 1
+Dimension = -1
+frequency =common
+

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD03.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD03.INI
@@ -5,5 +5,5 @@ Sprite		=   features\Evil_doodad3.tgr
 BoundingRadius	=	.9	;tiles(float) 
 Evil = 1
 Dimension = -1
-frequency = common
+frequency = rare
 

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD03.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD03.INI
@@ -1,0 +1,9 @@
+[ObjectData]
+ProperName = STRING_2296_Evil_doodad_3
+Class		= 	0	;enumeration list(int)
+Sprite		=   features\Evil_doodad3.tgr
+BoundingRadius	=	.9	;tiles(float) 
+Evil = 1
+Dimension = -1
+frequency = common
+

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD04.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD04.INI
@@ -1,0 +1,8 @@
+[ObjectData]
+Class		= 3		;enumeration list(int)
+ProperName	= STRING_2297_Evil_Doodad_4
+Sprite		= features\Evil_Doodad4.tgr
+BoundingRadius	= .1		;tiles(float) 
+dimension	= -1	;; drp122200 - dimension was erroneously set to 5
+Evil = 1
+frequency	= rare

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD05.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/EVIL_DOODAD05.INI
@@ -1,0 +1,8 @@
+[ObjectData]
+Class		= 3		;enumeration list(int)
+ProperName	= STRING_2298_Evil_Doodad_5
+Sprite		= features\Evil_Doodad5.tgr
+BoundingRadius	= .1		;tiles(float) 
+dimension	= -1
+Evil = 1
+frequency	= rare

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/FLAME_BURST.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/FLAME_BURST.INI
@@ -1,0 +1,15 @@
+[ObjectData]
+ProperName =STRING_2299_Flame_burst
+Class		= 	0	;enumeration list(int)
+Sprite		=   features\Flame_burst.tgr
+BoundingRadius	=	.9	;tiles(float) 
+Evil = 1
+frequency = common
+Dimension = 1
+
+[Animation]
+FrameRate = 75		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 11
+MinStillTime = 5000
+MaxStillTime = 10000

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/FLAME_BURST.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/FLAME_BURST.INI
@@ -4,8 +4,8 @@ Class		= 	0	;enumeration list(int)
 Sprite		=   features\Flame_burst.tgr
 BoundingRadius	=	.9	;tiles(float) 
 Evil = 1
-frequency = common
-Dimension = 1
+frequency = uncommon
+Dimension = 0
 
 [Animation]
 FrameRate = 75		;ms

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/LAVA_DOODAD01.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/LAVA_DOODAD01.INI
@@ -1,0 +1,17 @@
+[ObjectData]
+ProperName = STRING_2332_Lava_doodad_1
+Class		= 	0	;enumeration list(int)
+Sprite		=   features\lava_doodad1.tgr
+BoundingRadius	=	.9	;tiles(float) 
+Evil = 1
+Ground = 1
+frequency = common
+Dimension = 0
+Tilebased = 1
+
+[Animation]
+FrameRate = 200		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 14
+MinStillTime = 5000
+MaxStillTime = 10000

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/LAVA_DOODAD02.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/LAVA_DOODAD02.INI
@@ -1,0 +1,17 @@
+[ObjectData]
+ProperName = STRING_2333_Lava_doodad_2
+Class		= 	0	;enumeration list(int)
+Sprite		=   features\lava_doodad2.tgr
+BoundingRadius	=	.9	;tiles(float) 
+Evil = 1
+Ground = 1
+frequency = common
+Dimension = 0
+Tilebased = 1
+
+[Animation]
+FrameRate = 200		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 14
+MinStillTime = 5000
+MaxStillTime = 10000

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/LAVA_DOODAD03.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/LAVA_DOODAD03.INI
@@ -1,0 +1,17 @@
+[ObjectData]
+ProperName = STRING_2334_Lava_doodad_3
+Class		= 	0	;enumeration list(int)
+Sprite		=   features\lava_doodad3.tgr
+BoundingRadius	=	.9	;tiles(float) 
+Evil = 1
+Ground = 1
+frequency = common
+Dimension = 0
+Tilebased = 1
+
+[Animation]
+FrameRate = 200		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 14
+MinStillTime = 5000
+MaxStillTime = 10000

--- a/TGX_FILES/DATA/OBJECTDATA/FEATURES/LAVA_DOODAD04.INI
+++ b/TGX_FILES/DATA/OBJECTDATA/FEATURES/LAVA_DOODAD04.INI
@@ -1,0 +1,17 @@
+[ObjectData]
+ProperName = STRING_2335_Lava_doodad_4
+Class		= 	0	;enumeration list(int)
+Sprite		=   features\lava_doodad4.tgr
+BoundingRadius	=	.9	;tiles(float) 
+Evil = 1
+Ground = 1
+frequency = common
+Dimension = 0
+Tilebased = 1
+
+[Animation]
+FrameRate = 200		;ms
+Random = 1			;should the animation cycle be randomly started
+Frames = 13
+MinStillTime = 5000
+MaxStillTime = 10000


### PR DESCRIPTION
Reduces frequency of black spiky rocks in evil terrain generation. Might look a little strange but makes it a much more suitable terrain for gameplay.